### PR TITLE
[2.3.11.7 Base] Add RedHat kernel 3.10.0-862.14.4.el7.x86_64 for Swisscard

### DIFF
--- a/kernel-modules/supported-kernels/kernel-manifest.yml
+++ b/kernel-modules/supported-kernels/kernel-manifest.yml
@@ -134,6 +134,8 @@ centos:
       - https:/mirrors.kernel.org/centos/7.5.1804/updates/x86_64/Packages/kernel-devel-3.10.0-862.6.3.el7.x86_64.rpm
       3.10.0-862.9.1:
       - https:/mirrors.kernel.org/centos/7.5.1804/updates/x86_64/Packages/kernel-devel-3.10.0-862.9.1.el7.x86_64.rpm
+      3.10.0-862.14.4:
+      - https:/mirrors.kernel.org/centos/7.5.1804/updates/x86_64/Packages/kernel-devel-3.10.0-862.14.4.el7.x86_64.rpm
 
 centos-uncrawled:
   description: CentOS uncrawled kernels


### PR DESCRIPTION
This commit is directly on top of the collector ref used in the `2.3.11.7` release (`1.6.0-46-ge45881d9
`).