### PR TITLE
ROX-794: Push collector modules to gcloud bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,33 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
           make integration-tests integration-test-report
 
+  upload-modules:
+    docker:
+    - image: docker.io/stackrox/apollo-ci:collector-0.1.11-18-g3ecb0861c9
+      auth:
+        username: $DOCKER_USER
+        password: $DOCKER_PASS
+    environment:
+      ROX_CI_IMAGE: "true"
+
+    working_directory: ~/workspace
+
+    steps:
+      - init
+      - gcloud-init
+
+      - run:
+          name: Uploading Kernel modules
+          command: |
+            gsutil -m rsync -r \
+              "${WORKSPACE_ROOT}/ko-build/build-output/${MODULE_VERSION}/" \
+              "${COLLECTOR_MODULES_BUCKET}/${MODULE_VERSION}/"
+
+      - run:
+          name: Sanity check
+          command:
+            gsutil ls "${COLLECTOR_MODULES_BUCKET}/${MODULE_VERSION}/"
+
 workflows:
   version: 2
   build:
@@ -573,3 +600,10 @@ workflows:
         filters:
           tags:
             only: /.*/
+    - upload-modules:
+        requires:
+          - kernels
+        filters:
+          tags:
+            only: /.*/
+


### PR DESCRIPTION
I wanted to do something more sophisticated here to make sure this is only done for releases (and retroactively for old kernels), but this should be good enough to make sure we can upload new modules with little friction (modules are being pushed in a PR since the versioning effectively eliminates the risk of overwriting good modules with bad ones). Before we make any changes to the kernel module, however, we should probably do something smarter here to avoid uploading unstable modules to a public bucket (even though people would have to guess the version SHA).