### PR TITLE
Build CoreOS 4.14.96 kernel module

### DIFF
--- a/kernel-modules/coreos-repackage/README.md
+++ b/kernel-modules/coreos-repackage/README.md
@@ -97,9 +97,9 @@ To find the path, run `make print-package-cache-path` in the parent directory
 (`kernel-modules`).
 
 Then, construct your output path by taking the input URL, changing the
-filename to `bundle.tgz`, and removing repeated slashes. For instance,
+filename to `bundle.tgz`, and URL-encoding the URL. For instance,
 `http://stable.release.core-os.net/amd64-usr/1688.5.3/coreos_developer_container.bin.bz2`
 becomes
-`gs://kernel-headers-cache/http:/stable.release.core-os.net/amd64-usr/1688.5.3/bundle.tgz`
+`gs://stackrox-kernel-headers-mirror/packages/http:%2F%2Fstable.release.core-os.net%2Famd64-usr%2F1688.5.3%2Fbundle.tgz`
 
 Then, upload: `gsutil cp output/bundle.tgz FINAL_FILENAME`.

--- a/kernel-modules/supported-kernels/kernel-manifest.yml
+++ b/kernel-modules/supported-kernels/kernel-manifest.yml
@@ -480,6 +480,8 @@ coreos:
       - http://stable.release.core-os.net/amd64-usr/1911.4.0/bundle.tgz
       4.14.88:
       - http://stable.release.core-os.net/amd64-usr/1967.3.0/bundle.tgz
+      4.14.96:
+      - http://stable.release.core-os.net/amd64-usr/1967.4.0/bundle.tgz
     coreos-r1:
       4.11.12:
       - http://stable.release.core-os.net/amd64-usr/1409.9.0/bundle.tgz


### PR DESCRIPTION
offline: 
 * repackage 1967.4.0 (4.14.96) and upload to GCS

in repo:
 * add 4.14.96 to manifest
 * remove use of gcc-5 because Debian has removed it from their repos: https://tracker.debian.org/pkg/gcc-5. I do not know if this has effects on anything else.