### PR TITLE
Update dockerfile due to missing gcc packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,10 +152,10 @@ jobs:
         command: |
           [[ -d "/tmp/cache/kernel-modules/${MODULE_VERSION}/" ]] || exit 0
           mkdir -p "${WORKSPACE_ROOT}/ko-build/build-output/${MODULE_VERSION}"
-          #mv -v \
-          #    "/tmp/cache/kernel-modules/${MODULE_VERSION}"/* \
-          #    "${WORKSPACE_ROOT}/ko-build/build-output/${MODULE_VERSION}/" \
-          #  || true
+          mv -v \
+              "/tmp/cache/kernel-modules/${MODULE_VERSION}"/* \
+              "${WORKSPACE_ROOT}/ko-build/build-output/${MODULE_VERSION}/" \
+            || true
 
     - run:
         name: Compile list of cached modules


### PR DESCRIPTION
This dockerfile needed to be updated because debian unstable no longer has packages for `gcc-5` or `gcc-6`, resulting in a build error. The base image has been changed to `stretch`, changed default `/usr/bin/gcc` to `gcc-4.9` instead of `gcc-5`, and I disabled special handling of binutils because it is version 2.28-5 in `stretch` which shouldn't cause any issue with older kernels.