### PR TITLE
Remove .PHONY deps because the target creates the file

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -1,4 +1,3 @@
-.PHONY: deps
 deps: Gopkg.toml Gopkg.lock
 	@echo "+ $@"
 	@# `dep check` exits with a nonzero code if there is a toml->lock mismatch.


### PR DESCRIPTION

4.6 Phony Targets
A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request. There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.

from https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html