### PR TITLE
Silence log that alerts when a process directory

### DIFF
--- a/collector/lib/ConnScraper.cpp
+++ b/collector/lib/ConnScraper.cpp
@@ -396,7 +396,7 @@ bool ReadContainerConnections(const char* proc_path, std::vector<Connection>* co
 
     FDHandle dirfd = procdir.openat(curr->d_name, O_RDONLY);
     if (!dirfd.valid()) {
-      CLOG(ERROR) << "Could not open process directory " << curr->d_name << ": " << StrError();
+      CLOG(DEBUG) << "Could not open process directory " << curr->d_name << ": " << StrError();
       continue;
     }
 


### PR DESCRIPTION
cannot be read by ConnScraper. This can create
noisy logs for shortlived processes. And may
lead to interpretation that collector is missing data,
which shouldn't be true, connection data for short
lived processes is observed via system calls.