### PR TITLE
Keep going when building kernel objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,6 +464,7 @@ jobs:
         name: Build modules
         command: |
           docker run --rm -i \
+            -e FAILURE_LOG_FILE="/output/FAILURES-${CIRCLE_NODE_INDEX}" \
             -v "${HOME}/kobuild-tmp/bundles:/bundles:ro" \
             -v "${WORKSPACE_ROOT}/ko-build/module-versions:/sources:ro" \
             -v "${WORKSPACE_ROOT}/ko-build/build-output:/output" \
@@ -605,6 +606,15 @@ jobs:
     - initcommand
     - docker-login
     - gcloud-init
+
+    - run:
+        name: Test for build failures
+        command: |
+          if ls "${WORKSPACE_ROOT}/ko-build/build-output/FAILURES-"* 2>/dev/null; then
+            echo >&2 "Compilation failed for some kernel/module version combinations!"
+            cat >&2 2>/dev/null "${WORKSPACE_ROOT}/ko-build/build-output/FAILURES-"*
+            exit 1
+          fi
 
     - run:
         name: Copying Kernel modules build output

--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-build_ko() {
+build_ko() (
     local kernel_version="$1"
     local module_version="$2"
 
@@ -106,14 +106,19 @@ build_ko() {
     collector_probe="bpf/probe.o"
     gzip -c "$collector_probe" >"/output/${module_version}/collector-ebpf-${kernel_version}.o.gz"
     rm "$collector_probe"
-}
+)
 
 build_kos() {
     while read -a line || [[ "${#line[@]}" -gt 0 ]]; do
         local kernel_version="${line[0]}"
         local module_version="${line[1]}"
 
-        build_ko "$kernel_version" "$module_version"
+        if ! build_ko "$kernel_version" "$module_version"; then
+            echo >&2 "Failed to build module version ${module_version} for kernel ${kernel_version}"
+            if [[ -n "${FAILURE_LOG_FILE:-}" ]]; then
+                echo >>"${FAILURE_LOG_FILE}" "${kernel_version} ${module_version}"
+            fi
+        fi
     done
 }
 


### PR DESCRIPTION
If some builds break, we shouldn't stop uploading modules altogether