### PR TITLE
Remove dev packages from collector image

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -43,11 +43,9 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends -t stretch-backports \
-        libc-ares-dev \
-        libprotobuf-dev \
-        protobuf-compiler \
-        libgrpc++-dev \
-        protobuf-compiler-grpc \
+        libc-ares2 \
+        libprotobuf17 \
+        libgrpc++1 \
  && dpkg -r --force-all e2fslibs e2fsprogs apt debconf dpkg \
  && rm -rf /var/lib/apt \
         ;

--- a/collector/container/Dockerfile_slim
+++ b/collector/container/Dockerfile_slim
@@ -22,6 +22,8 @@ ENV SYSDIG_HOST_ROOT=/host
 # HTTP API port (8080)
 EXPOSE 8080 9090
 
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list
+
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
@@ -38,9 +40,17 @@ RUN apt-get update \
         libtbb2 \
         libelf1 \
         libjsoncpp1 \
+ ;
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends -t stretch-backports \
+        libc-ares2 \
+        libprotobuf17 \
+        libgrpc++1 \
  && dpkg -r --force-all e2fslibs e2fsprogs apt debconf dpkg \
  && rm -rf /var/lib/apt \
- ;
+        ;
+
 
 COPY libs/libsinsp-wrapper.so \
      /usr/local/lib/


### PR DESCRIPTION
- Remove *-dev debian packages from the main collector image that introduced new CVEs -- these packages were only needed for compilation, not at runtime