### PR TITLE
Fix collector dockerfile arg

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -1,7 +1,7 @@
+FROM debian:stretch-slim
+
 ARG collector_version=xxx
 ARG module_version=xxx
-
-FROM debian:stretch-slim
 
 LABEL maintainer="StackRox <support@stackrox.com>"
 LABEL io.stackrox.collector.module-version="${module_version}"


### PR DESCRIPTION
Incorrect order of args caused kernel-modules/MODULE_VERSION.txt to be empty.

Dockerfile args must be declared within the build stage that the argument is used. Global args at the top of the Dockerfile can be used but only if the arg is redeclared in within each build stage.