### PR TITLE
Add 4.14.131-linuxkit to blacklist

### DIFF
--- a/kernel-modules/BLACKLIST
+++ b/kernel-modules/BLACKLIST
@@ -6,3 +6,4 @@
 # If <module-version> or <object type> is omitted, "*" is assumed
 ~3\.10\.0-1062(?:\.\d+)*\.el7.x86_64 * bpf
 *.el6.*
+4.14.131-linuxkit


### PR DESCRIPTION
This kernel was added to support docker desktop edge, blacklisting for now because it is not a customer priority.