### PR TITLE
Trim process arguments used for rate limiter key to 256 bytes

### DIFF
--- a/collector/lib/ProcessSignalHandler.cpp
+++ b/collector/lib/ProcessSignalHandler.cpp
@@ -31,11 +31,13 @@ namespace collector {
 
 std::string compute_process_key(const ::storage::ProcessSignal& s) {
   std::stringstream ss;
-  auto args = s.args();
-  if (s.args().length() > 256) {
-    args = args.substr(0, 256);
+  ss << s.container_id() << " " << s.name() << " ";
+  if (s.args().length() <= 256) {
+    ss << s.args();
+  } else {
+    ss.write(s.args().c_str(), 256);
   }
-  ss << s.container_id() << " " << s.name() << " " << args << " " << s.exec_file_path();
+  ss << " " << s.exec_file_path();
   return ss.str();
 }
 


### PR DESCRIPTION
Based on my read of the rate limiter, the max size is 4096, which comes out to keys of 256 kb, if for some reason someone has a huge key, then we should be way under now