### PR TITLE
Fix failure in reload images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,7 +1172,7 @@ jobs:
           for mod_dir in "${mod_build_dir}"/*/ ; do
             mod_ver="$(basename "$mod_dir")"
             mkdir -p "/tmp/released-kernel-object-cache/${mod_ver}"
-            cp "${mod_dir}/"*.gz "/tmp/released-kernel-object-cache/${mod_ver}"
+            cp "${mod_dir}/"*.gz "/tmp/released-kernel-object-cache/${mod_ver}" || true
           done
 
     - run:


### PR DESCRIPTION
Reload image job only checks for object files built in *any* shard, but `cp` command would fail if there isn't at least one object in *each* shard.