### PR TITLE
Fix collector-rhel kernel modules double add

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,15 +736,11 @@ jobs:
 
           docker build \
             -t "stackrox/collector-rhel:${COLLECTOR_VERSION}-base" \
-            "${build_args[@]}" \
-            -f container/rhel/Dockerfile \
-            container/rhel
-
-          docker build \
             -t "stackrox/collector-rhel:${COLLECTOR_VERSION}" \
             -t "stackrox/collector-rhel:${COLLECTOR_VERSION}-latest" \
             "${build_args[@]}" \
-            container-combined
+            -f container/rhel/Dockerfile \
+            container/rhel
 
     - run:
         name: Sanity check images


### PR DESCRIPTION
`collector-rhel:{tag}-base` already contains all kernel objects, and we were re-adding them making the `collector-rhel:{tag}-latest` image almost twice as big. This issue does not affect the non-rhel collector image.

```
Before:
stackrox/collector-rhel  3.0.4                       530d6ae31d8b        1 second ago             1.26GB
stackrox/collector-rhel  3.0.4-latest                530d6ae31d8b        1 second ago             1.26GB
stackrox/collector-rhel  3.0.4-base                  0f3b4d43c9be        About a minute ago       759MB

After:
stackrox/collector-rhel  3.0.4-1-g7adc571d14         99bc83c26c43        Less than a second ago   759MB
stackrox/collector-rhel  3.0.4-1-g7adc571d14-base    99bc83c26c43        Less than a second ago   759MB
stackrox/collector-rhel  3.0.4-1-g7adc571d14-latest  99bc83c26c43        Less than a second ago   759MB

```
