### PR TITLE
Fix bundle path for kernel-modules

### DIFF
--- a/collector/container/rhel/create-bundle.sh
+++ b/collector/container/rhel/create-bundle.sh
@@ -64,7 +64,7 @@ cp -p "${INPUT_ROOT}/scripts/bootstrap.sh" "${bundle_root}/bootstrap.sh"
 cp -p "${INPUT_ROOT}/scripts/collector-wrapper.sh" "${bundle_root}/usr/local/bin/"
 cp -p "${INPUT_ROOT}/NOTICE-collector.txt" "${bundle_root}/COPYING.txt"
 cp -p "${INPUT_ROOT}/bin/collector.rhel" "${bundle_root}/usr/local/bin/collector"
-cp -pr "${MODULE_DIR}" "${bundle_root}/kernel-modules"
+cp -pr "${MODULE_DIR}"/* "${bundle_root}/kernel-modules/"
 
 # Files needed from the collector-builder image and associated
 # destination in collector-rhel image.


### PR DESCRIPTION
Fix for kernel-modules path in rhel image bundle; modules were copied into `/kernel-modules/kernel-modules`.

Testing:
Verified kernel modules are in correct location:
```
$ docker run -it  --rm --entrypoint /bin/sh stackrox/collector-rhel:3.0.5-2-ge58cec0f33
sh-4.2# ls /kernel-modules/*.gz | wc -l
2241
```