### PR TITLE
Fix segfault in read callback for network control message

### DIFF
--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<grpc::ClientContext> NetworkStatusNotifier::CreateClientContext(
 }
 
 void NetworkStatusNotifier::OnRecvControlMessage(const sensor::NetworkFlowsControlMessage* msg) {
-  if (!msg->has_public_ip_addresses()) {
+  if (!msg || !msg->has_public_ip_addresses()) {
     return;
   }
 


### PR DESCRIPTION
C++ proto API isn't nicely null-safe like Go :f