### PR TITLE
Resize arena adaptively and reduce logspam

### DIFF
--- a/collector/lib/ProtoAllocator.h
+++ b/collector/lib/ProtoAllocator.h
@@ -53,7 +53,7 @@ inline google::protobuf::ArenaOptions ArenaOptionsForInitialBlock(char* storage,
 template <typename Message>
 class ArenaProtoAllocator {
  public:
-  static constexpr size_t kDefaultPoolSize = 1024; // used to be 32768
+  static constexpr size_t kDefaultPoolSize = 524288;
 
   ArenaProtoAllocator() : ArenaProtoAllocator(kDefaultPoolSize) {}
 


### PR DESCRIPTION
If the pre-allocated arena size is exceeded, resize the arena to a multiple of the initial block size that is large enough to hold the data, this should ensure that we eventually stop seeing the warning logs. Also throttle the "allocating block on the heap" logs.