### PR TITLE
Build latest images incrementally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,6 +759,7 @@ jobs:
             docker build \
               -t "stackrox/collector:${COLLECTOR_VERSION}" \
               -t "stackrox/collector:${COLLECTOR_VERSION}-latest" \
+              -t "stackrox/collector:${COLLECTOR_VERSION}-latest-base" \
               "${build_args[@]}" \
               container-combined
           fi
@@ -812,6 +813,10 @@ jobs:
           docker push "stackrox/collector:${COLLECTOR_VERSION}"
           echo "Pushing collector latest image"
           docker push "stackrox/collector:${COLLECTOR_VERSION}-latest"
+
+          if [[ "$CIRCLE_BRANCH" == "master" || -n "$CIRCLE_TAG" ]]; then
+            docker push "stackrox/collector:${COLLECTOR_VERSION}-latest-base"
+          fi
 
           echo "Pushing collector rhel base image"
           docker push "stackrox/collector-rhel:${COLLECTOR_VERSION}-base"
@@ -1285,7 +1290,7 @@ jobs:
             echo "Checking ${collector_ver} with module version ${mod_ver}"
 
             released_latest_image="stackrox/collector:${collector_ver}-latest"
-            released_base_image="stackrox/collector:${collector_ver}"
+            released_base_image="stackrox/collector:${collector_ver}-latest-base"
             docker pull "${released_latest_image}"
 
             missing_objs_file="/tmp/missing-objs-${collector_ver}"
@@ -1300,7 +1305,11 @@ jobs:
             echo "Kernel objects missing in image ${released_latest_image}:"
             cat "${missing_objs_file}"
 
-            docker pull "${released_base_image}"
+            if ! docker pull "${released_base_image}" ; then
+              docker tag "${released_latest_image}" "${released_base_image}"
+              docker push "${released_base_image}"
+            fi
+
             "./reload/build-latest.sh" "${collector_ver}" "${mod_ver}" "/tmp/released-kernel-object-cache/" "${COLLECTOR_MODULES_BUCKET}"
 
             docker push "stackrox/collector:${collector_ver}-latest"

--- a/collector/container-combined/Dockerfile
+++ b/collector/container-combined/Dockerfile
@@ -1,6 +1,6 @@
 ARG collector_version=xxx
 ARG collector_repo=stackrox/collector
-ARG base_image=$collector_repo:${collector_version}
+ARG base_image=$collector_repo:${collector_version}-latest-base
 
 ARG module_version=xxx
 ARG base_modules_image=stackrox-kernel-modules:${module_version}
@@ -17,13 +17,20 @@ SHELL ["/bin/bash", "-c"]
 COPY --from=all_modules /kernel-modules/*.gz /modules/all/
 COPY --from=base_modules /kernel-modules/*.gz /modules/base/
 
-RUN sort <(cd /modules/all && sha256sum *.gz) <(/modules/base && sha256sum *.gz) \
+RUN sort <(cd /modules/all && sha256sum *.gz) <(cd /modules/base && sha256sum *.gz) \
         | uniq -u | awk '{print$2}' | sort -u >/modules/diff-manifest \
     && cat /modules/diff-manifest \
     && mkdir /modules/diff \
     && ( cd /modules/all && xargs -i </modules/diff-manifest cp {} /modules/diff/ ) \
     && ls -l /modules/diff/
 
+# We need some file in the directory, otherwise the COPY below will fail. Thanks Docker for
+# not supporting a copy that allows an empty source list. It's only been an FR since 2015.
+
+RUN touch /modules/diff/MARKER.gz
+
 FROM ${base_image}
 
 COPY --from=diff_modules /modules/diff/*.gz /kernel-modules/
+RUN rm -f /kernel-modules/MARKER.gz
+


### PR DESCRIPTION
Use a `latest-base` image that for new images will be equal to the first `-latest` image ever to be pushed, and for existing images will be on-demand derived from the `-latest` image currently pushed. There are two reasons for this:
- Customers will start downloading incremental changes right away.
- We replaced all eBPF probes recently due to the soft-lockup bug, hence if we used the collector image WITHOUT a `-latest` suffix as the base for latest image, there would be a lot of duplication in the layers.