### PR TITLE
Use consistent docker + CLI versions, and retry installing docker.io

### DIFF
--- a/.circleci/envbuilder.sh
+++ b/.circleci/envbuilder.sh
@@ -46,7 +46,15 @@ installDockerOnUbuntuViaGCPSSH() {
   shift
   local GCP_SSH_KEY_FILE="$1"
   shift
-  gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_NAME" --command "(which docker || export DEBIAN_FRONTEND=noninteractive ; sudo apt update -y && sudo apt install -y docker.io && sudo usermod -aG docker $(whoami) )"
+  for _ in {1..3}; do
+    if gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_NAME" --command "(which docker || export DEBIAN_FRONTEND=noninteractive ; sudo apt update -y && sudo apt install -y docker.io && sudo usermod -aG docker $(whoami) )"; then
+      return 0
+    fi
+    echo "Retrying in 5s ..."
+    sleep 5
+  done
+  echo "Failed to install Docker after 3 retries"
+  return 1
 }
 
 installDockerOnRHELViaGCPSSH() {


### PR DESCRIPTION
This fixes an issue on RHEL where the docker CLI and daemon versions were incompatible. Also attempts to reinstall `docker.io` on Ubuntu multiple times, as we're seeing spurious "has no installation candidate" errors.