### PR TITLE
ROX-5193: Prevent logspam caused by missing net/tcp6 file

### DIFF
--- a/collector/lib/ConnScraper.cpp
+++ b/collector/lib/ConnScraper.cpp
@@ -319,7 +319,7 @@ bool GetConnections(int dirfd, UnorderedMap<ino_t, ConnInfo>* connections) {
     FDHandle net_tcp_fd = openat(dirfd, "net/tcp", O_RDONLY);
     if (net_tcp_fd.valid()) {
       FileHandle net_tcp(std::move(net_tcp_fd), "r");
-      success = ReadConnectionsFromFile(Address::Family::IPV4, L4Proto::TCP, net_tcp, connections)) && success;
+      success = ReadConnectionsFromFile(Address::Family::IPV4, L4Proto::TCP, net_tcp, connections) && success;
     } else {
       success = false;  // there should always be a net/tcp file
     }


### PR DESCRIPTION
1. Try to read as much data as possible from the process directory, continuing even if we encounter an error reading one of the files.
2. Determine whether any error encountered is persistent by trying to re-read the network namespace inode (we know that this should work for a still-live process as we have read it before).