### PR TITLE
Fix gcloud rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,6 @@ jobs:
         name: Download missing modules for current version from gcloud bucket
         command: |
           mkdir -p "${WORKSPACE_ROOT}/ko-build/cached-probes/${MODULE_VERSION}"
-          [[ -d "/tmp/cache/kernel-modules/${MODULE_VERSION}/" ]] || exit 0
           gsutil -m rsync -r \
             "${COLLECTOR_MODULES_BUCKET}/${MODULE_VERSION}/" \
             "${WORKSPACE_ROOT}/ko-build/cached-probes/${MODULE_VERSION}/" \


### PR DESCRIPTION
If we increment the circle ci version, this removed check will fail and we skip gcloud sync which causes a rebuild of all probes which is not what we want.