### PR TITLE
ROX-4751 track cwd state changes with chdir/fchdir

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -40,7 +40,7 @@ class CollectorConfig {
   static constexpr bool        kTurnOffScrape = false;
   static constexpr int         kScrapeInterval = 30;
   static constexpr char        kCollectionMethod[] = "kernel-module";
-  static constexpr const char* kSyscalls[] = {"accept","connect","execve","fork","clone","close","shutdown","socket","procexit","procinfo"};
+  static constexpr const char* kSyscalls[] = {"accept","connect","execve","fork","clone","close","shutdown","socket","procexit","procinfo", "chdir", "fchdir"};
   static constexpr char        kChisel[] = R"(
 args = {}
 function on_event()


### PR DESCRIPTION
## Description
Handle current working directory state changes that occur before an `execve` syscall with relative path:
- runc sets the current working directory (WORKDIR) for entry point using `chdir`, 
https://github.com/opencontainers/runc/blob/master/libcontainer/init_linux.go#L132
- If a subsequent `execve` is on a relative path then sysdig will concatenate incorrect execpath here:
https://github.com/stackrox/sysdig/blob/stackrox-changes-tag-0.26.4/userspace/libsinsp/parsers.cpp#L1741
- If container uses `runsv` (seen in gitlab-ce image in roxsim), the same error (`chdir` -> `execve`) can occur

## Performance
The impact of monitoring `chdir`/`fchdir` should be minimal since this is a not a frequent syscall

## Testing
- Added regression to rox qa tests (https://github.com/stackrox/rox/pull/6150)
- Verified fix on roxsim deployments spark-app (relpath entrypoint with workdir) and gitlab-ce(runsv)


