### PR TITLE
Tag collector images as slim and push them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,6 +784,7 @@ jobs:
 
           docker build \
             -t "stackrox/collector:${COLLECTOR_VERSION}-base" \
+            -t "stackrox/collector:${COLLECTOR_VERSION}-slim" \
             "${build_args[@]}" \
             container
 
@@ -845,6 +846,8 @@ jobs:
           docker push "stackrox/collector:${COLLECTOR_VERSION}"
           echo "Pushing collector latest image"
           docker push "stackrox/collector:${COLLECTOR_VERSION}-latest"
+          echo "Pushing collector slim image"
+          docker push "stackrox/collector:${COLLECTOR_VERSION}-slim"
 
           echo "Pushing collector rhel base image"
           docker push "stackrox/collector-rhel:${COLLECTOR_VERSION}-base"


### PR DESCRIPTION
This is part of the story [Distribute slimmer version of Collector](https://stack-rox.atlassian.net/browse/ROX-4986).

I was not entirely sure if/why we would need two image tags for essentially the same thing: `collector-base` (which exists already) and `collector-slim` (which is referenced in the story).

**Note:** Of course there is no strong technical reason for this, but after having discussed this somewhat with Malte today, I would describe a reasonable perspective as follows:

`collector-base` can be regarded as our _internal_ base image while `collector-slim` is targeted for _deployment in customer clusters_. Right now these two coincide, but that does not necessarily have to be the case in the future.

Question: Do we also need to adjust the tagging in the run step _Build collector rhel images_? I don't know yet what kind of RHEL specific magic is going on there, but I did not expect this:

```
          docker build \
            -t "stackrox/collector-rhel:${COLLECTOR_VERSION}-base" \
            -t "stackrox/collector-rhel:${COLLECTOR_VERSION}" \
            -t "stackrox/collector-rhel:${COLLECTOR_VERSION}-latest" \
            "${build_args[@]}" \
            -f container/rhel/Dockerfile \
            container/rhel
```

i.e., the same collector-rhel image is tagged as base, non-base and latest at the same time?
