### PR TITLE
Increase timeout for fetching kernel support

### DIFF
--- a/collector/container/scripts/bootstrap.sh
+++ b/collector/container/scripts/bootstrap.sh
@@ -60,7 +60,7 @@ function download_kernel_object() {
 
     local filename_gz="${OBJECT_PATH}.gz"
     local curl_opts=(
-        -sS -4 --retry 5 --retry-connrefused --retry-delay 1 --retry-max-time 30
+        -sS -4 --retry 20 --retry-connrefused --retry-delay 1 --retry-max-time 30
         -f -L -w "HTTP Status Code %{http_code}"
         -o "${filename_gz}"
     )


### PR DESCRIPTION
Previous timeout was 10s, not it is set to 30s in order to give sensor enough time for startup.