### PR TITLE
Re-populate time field for NetworkInfo message

### DIFF
--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -206,6 +206,8 @@ sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(c
   AddConnections(info->mutable_updated_connections(), conn_delta);
   AddContainerEndpoints(info->mutable_updated_endpoints(), endpoint_delta);
 
+  *info->mutable_time() = CurrentTimeProto();
+
   return msg;
 }
 


### PR DESCRIPTION
This is at fault for the timestamp-based failures we are seeing in Rox.