### PR TITLE
Set the connect max timeout to 2s and increase overall budget

### DIFF
--- a/collector/container/scripts/bootstrap.sh
+++ b/collector/container/scripts/bootstrap.sh
@@ -60,7 +60,7 @@ function download_kernel_object() {
 
     local filename_gz="${OBJECT_PATH}.gz"
     local curl_opts=(
-        -sS -4 --retry 20 --retry-connrefused --retry-delay 1 --retry-max-time 30
+        -sS -4 --retry 30 --retry-connrefused --retry-delay 1 --retry-max-time 60
         --connect-timeout 2
         -f -L -w "HTTP Status Code %{http_code}"
         -o "${filename_gz}"


### PR DESCRIPTION
This prevents the entire retry-max-time budget from being exhausted during a single connect attempt that is stuck.