### PR TITLE
silence oncall alerts for debian cloud and 5.9.* kernels

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -7,4 +7,6 @@
 ~3\.10\.0-1062(?:\.\d+)*\.el7.x86_64 * bpf
 *.el6.*
 # TODO(ROX-5396) - Fix collector probe compilation for 5.7.* and 5.8.* kernels
-~5\.[7,8]\..*
+~5\.[7,8,9]\..*
+# TOOD(ROX-5809) - Fix collector probe compilation for 4.19. cloud Debian kernels
+~4\.19.*cloud.*


### PR DESCRIPTION
Silenced alerts are tracked in ROX-5396 ROX-5809