### PR TITLE
Build 5.[7-9] kernels

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -6,7 +6,5 @@
 # If <module-version> or <object type> is omitted, "*" is assumed
 ~3\.10\.0-1062(?:\.\d+)*\.el7.x86_64 * bpf
 *.el6.*
-# TODO(ROX-5396) - Fix collector probe compilation for 5.7.* and 5.8.* kernels
-~5\.[7,8,9]\..*
 # TOOD(ROX-5809) - Fix collector probe compilation for 4.19. cloud Debian kernels
 ~4\.19.*cloud.*


### PR DESCRIPTION
Revert block of 5.[7-9] to determine if any kernels are fixed with gcc-10 in the modern builder