### PR TITLE
Remove pkg license info from THIRD_PARTY_NOTICES

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update \
         libelf1 \
         google-perftools \
  && dpkg -r --force-all e2fslibs e2fsprogs apt debconf dpkg \
- && ( for pkg in /usr/share/doc/*; do cp $pkg/copyright /THIRD_PARTY_NOTICES/$(basename $pkg); done ) \
  && rm -rf /var/lib/apt \
  ;
 

--- a/collector/container/rhel/Dockerfile
+++ b/collector/container/rhel/Dockerfile
@@ -31,7 +31,6 @@ RUN mv collector-wrapper.sh /usr/local/bin/ && \
     tar -zxf bundle.tar.gz ./usr/local/lib/libsinsp-wrapper.so && \
     tar -zxf bundle.tar.gz ./usr/local/bin/collector && \
     rm -f bundle.tar.gz && \
-    rpm -qa --qf "%{name}: %{license}\n" > /THIRD_PARTY_NOTICES/NOTICE-redhat-packages.txt && \
     dnf upgrade -y && \
     dnf install -y kmod && \
     dnf clean all && \


### PR DESCRIPTION
THIRD_PARTY_NOTICE directory contains license info for statically linked libraries

```
ls /THIRD_PARTY_NOTICES/
LuaJIT-2.0.3   googletest-release-1.10.0  jq-1.6          libb64-1.2.1          prometheus-v0.9.0  sysdig
c-ares-1.16.0  grpc-v1.28.1               jsoncpp-0.10.7  ncurses-6_0_20150725  protobuf-3.11.4    tbb-2018_U5
```