### PR TITLE
Fix CI issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 8
+    parallelism: 32
     environment:
     - BUILD_CONTAINER_TAG: stackrox/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: stackrox/collector-builder:kobuilder-cache


### PR DESCRIPTION
Issues:
- Debian kernels failing due to regression in bundle creation
  - Address by using fixed bundles from this PR: https://github.com/stackrox/kernel-packer/pull/131
- RHEL 8.3 kernel probe compilation failing due to gcc version in the redhat builder image
  - Fix by using modern builder for rhel kernels >= 8.3
- `kernels` job failing on `Install and configure gcloud`
  - Use pip3 instead of pip2

Testing

- [ ] sanity check: rebuild all probes