### PR TITLE
Fix join modules when no new probes are built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -983,6 +983,7 @@ jobs:
           command: |
             shopt -s nullglob
             shopt -s dotglob
+            mkdir -p "${WORKSPACE_ROOT}/ko-build/built-probes"
             shard_dirs=("${WORKSPACE_ROOT}/ko-build/build-output/shard-"*)
             if [[ "{#shard_dirs[@]}" == 0 ]]; then
               exit 0


### PR DESCRIPTION
A recent [change](https://github.com/stackrox/collector/pull/385) to the `join-modules` job causes a failure in the `persist_workspace` step. We just need to create the directory to prevent failure that occurs when no new probes are built.

https://app.circleci.com/pipelines/github/stackrox/collector/4734/workflows/b5fbdfe8-6a3c-440b-8607-cedf9501d1a3/jobs/73935