### PR TITLE
Update the default kernel probe builder image

### DIFF
--- a/kernel-modules/build/Dockerfile
+++ b/kernel-modules/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:stretch
 
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -8,7 +8,6 @@ RUN apt-get update \
       make \
       curl \
       gcc \
-      gcc-7 \
       clang-7 \
       llvm-7 \
       g++ \
@@ -19,16 +18,14 @@ RUN apt-get update \
       pkg-config \
  ;
 
-RUN sed s_stable_jessie_g < /etc/apt/sources.list > /etc/apt/sources.list.d/jessie.list && \
+RUN sed s_stretch_jessie_g < /etc/apt/sources.list > /etc/apt/sources.list.d/jessie.list && \
     apt-get update && apt-get install --no-install-recommends -y \
       gcc-4.9 \
 ;
 
-# Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
+# Since our base Debian image ships with GCC 6 which breaks older kernels, revert the
 # default to gcc-4.9
 RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc
-RUN ln -s /usr/bin/gcc-7 /usr/bin/gcc-6
-
 RUN rm -rf /usr/bin/clang \
  && rm -rf /usr/bin/llc \
  && ln -s /usr/bin/clang-7 /usr/bin/clang \
@@ -36,14 +33,8 @@ RUN rm -rf /usr/bin/clang \
 
 RUN apt-get autoremove -y
 
-# debian:unstable head contains binutils 2.31, which generates
-# binaries that are incompatible with kernels < 4.16. So manually
-# forcibly install binutils 2.30-22 instead.
-RUN curl -s -o binutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils_2.30-22_amd64.deb \
- && curl -s -o libbinutils_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/libbinutils_2.30-22_amd64.deb \
- && curl -s -o binutils-x86-64-linux-gnu_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.30-22_amd64.deb \
- && curl -s -o binutils-common_2.30-22_amd64.deb http://snapshot.debian.org/archive/debian/20180622T211149Z/pool/main/b/binutils/binutils-common_2.30-22_amd64.deb \
- && dpkg -i *binutils*.deb
+# Ensure binutils is less than 2.31, which is incompatiable with kernels < 4.16
+RUN dpkg --compare-versions $(dpkg-query -f='${Version}' --show binutils) lt 2.31
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/


### PR DESCRIPTION
Debian stable has been moved to buster and this image needs to stay on debian jessie to support building older kernel versions

Testing:
- [x] `kernels` job passes