### PR TITLE
ROX-7316 Add connection scraper and tracker metrics

### DIFF
--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -27,6 +27,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <vector>
 
 #include "CollectorConfig.h"
+#include "CollectorStats.h"
 
 namespace collector {
 
@@ -54,6 +55,7 @@ class CollectorService {
 
   std::atomic<ControlValue>* control_;
   const std::atomic<int>& signum_;
+  CollectorStats collector_stats_;
 };
 
 }  // namespace collector

--- a/collector/lib/CollectorStats.cpp
+++ b/collector/lib/CollectorStats.cpp
@@ -1,0 +1,17 @@
+#include "CollectorStats.h"
+
+namespace collector {
+
+#define X(n) #n,
+std::array<std::string, CollectorStats::timer_type_max> CollectorStats::timer_type_to_name = {
+  TIMER_NAMES
+};
+#undef X
+
+#define X(n) #n,
+std::array<std::string, CollectorStats::counter_type_max> CollectorStats::counter_type_to_name = {
+  COUNTER_NAMES
+};
+#undef X
+
+} // namespace collector

--- a/collector/lib/CollectorStats.h
+++ b/collector/lib/CollectorStats.h
@@ -1,0 +1,107 @@
+#ifndef COLLECTOR_COLLECTORSTATS_H
+#define COLLECTOR_COLLECTORSTATS_H
+
+#include <array>
+#include <atomic>
+#include <unordered_map>
+#include <vector>
+
+#include "TimeUtil.h"
+
+#define TIMER_NAMES   \
+X(net_scrape_read)    \
+X(net_scrape_update)  \
+X(net_fetch_state)    \
+X(net_create_message) \
+X(net_write_message)
+
+#define COUNTER_NAMES \
+X(net_conn_updates) \
+X(net_conn_deltas) \
+X(net_conn_inactive) \
+X(net_cep_updates) \
+X(net_cep_deltas) \
+X(net_cep_inactive) \
+X(net_known_ip_networks) \
+X(net_known_public_ips)
+
+namespace collector {
+
+class CollectorStats {
+public:
+# define X(n) n,
+  enum TimerType {
+    TIMER_NAMES
+    X(timer_type_max)
+  };
+# undef X
+  static std::array<std::string, timer_type_max> timer_type_to_name;
+
+  inline int64_t GetTimerCount(size_t index) const { return timer_count_[index]; }
+  inline int64_t GetTimerDurationMicros(size_t index) const { return timer_total_us_[index]; }
+  inline void EndTimerAt(size_t index, int64_t duration_us) {
+    ++timer_count_[index];
+    timer_total_us_[index] += duration_us;
+  }
+
+# define X(n) n,
+  enum CounterType {
+    COUNTER_NAMES
+    X(counter_type_max)
+  };
+# undef X
+  static std::array<std::string, counter_type_max> counter_type_to_name;
+
+  inline int64_t GetCounter(size_t index) const { return counter_[index]; }
+  inline void CounterSet(size_t index, int64_t val) {
+    counter_[index] = val;
+  }
+  inline void CounterAdd(size_t index, int64_t val) {
+    counter_[index] += val;
+  }
+
+private:
+  std::array<std::atomic<int64_t>, timer_type_max> timer_count_ = {{}};
+  std::array<std::atomic<int64_t>, timer_type_max> timer_total_us_ = {{}};
+
+  std::array<std::atomic<int64_t>, counter_type_max> counter_ = {{}};
+};
+
+namespace internal {
+
+template<typename T>
+class ScopedTimer {
+public:
+  ScopedTimer(T* timer_array, size_t index)
+    : timer_array_(timer_array), index_(index), start_time_(NowMicros()) {}
+  ~ScopedTimer() {
+    if (timer_array_) {
+      timer_array_->EndTimerAt(index_, NowMicros() - start_time_);
+    }
+  }
+  constexpr operator bool() const { return true; }
+
+private:
+  T* timer_array_;
+  size_t index_;
+  int64_t start_time_;
+};
+
+template<typename T>
+ScopedTimer<T> scoped_timer(T* timer_array, size_t index) {
+  return ScopedTimer<T>(timer_array, index);
+}
+
+} // namespace internal
+
+#define SCOPED_TIMER(s,i) auto __scoped_timer_ ## __LINE__ = internal::scoped_timer(s,i)
+#define WITH_TIMER(s,i) if (SCOPED_TIMER(s,i))
+
+#define COUNTER_SET(s,i,v) do { if (s != nullptr) { s->CounterSet(i, static_cast<int64_t>(v)); } } while(0)
+#define COUNTER_ADD(s,i,v) do { if (s != nullptr) { s->CounterAdd(i, static_cast<int64_t>(v)); } } while(0)
+#define COUNTER_INC(s,i) COUNTER_ADD(s,i,1)
+#define COUNTER_ZERO(s,i) COUNTER_SET(s,i,0)
+
+} // namespace collector
+
+#endif //COLLECTOR_COLLECTORSTATS_H

--- a/collector/lib/CollectorStatsExporter.h
+++ b/collector/lib/CollectorStatsExporter.h
@@ -27,6 +27,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <memory>
 
 #include "CollectorConfig.h"
+#include "CollectorStats.h"
 #include "StoppableThread.h"
 #include "SysdigService.h"
 
@@ -36,7 +37,7 @@ namespace collector {
 
 class CollectorStatsExporter {
   public:
-    CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, SysdigService* sysdig);
+    CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, SysdigService* sysdig, CollectorStats* collector_stats);
 
     bool start();
     void run();
@@ -47,6 +48,7 @@ class CollectorStatsExporter {
     const CollectorConfig* config_;
     SysdigService *sysdig_;
     StoppableThread thread_;
+    CollectorStats* collector_stats_;
 };
 
 }  // namespace collector

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -80,6 +80,8 @@ class ConnStatus {
 using ConnMap = UnorderedMap<Connection, ConnStatus>;
 using ContainerEndpointMap = UnorderedMap<ContainerEndpoint, ConnStatus>;
 
+class CollectorStats;
+
 class ConnectionTracker {
  public:
   void UpdateConnection(const Connection& conn, int64_t timestamp, bool added);
@@ -103,6 +105,8 @@ class ConnectionTracker {
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
+
+  void SetCollectorStats(CollectorStats* stats) { stats_ = stats;}
 
  private:
   // NormalizeConnection transforms a connection into a normalized form.
@@ -153,6 +157,7 @@ class ConnectionTracker {
   NRadixTree known_ip_networks_;
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
+  CollectorStats* stats_ = nullptr;
 };
 
 /* static */

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -49,13 +49,17 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   NetworkStatusNotifier(std::string hostname, std::string proc_dir, int scrape_interval, bool scrape_listen_endpoints,
                         bool turn_off_scrape,
                         std::shared_ptr<ConnectionTracker> conn_tracker,
-                        std::shared_ptr<grpc::Channel> channel)
+                        std::shared_ptr<grpc::Channel> channel,
+                        CollectorStats* collector_stats)
       : hostname_(std::move(hostname)), conn_scraper_(std::move(proc_dir)), scrape_interval_(scrape_interval),
         turn_off_scraping_(turn_off_scrape),
         scrape_listen_endpoints_(scrape_listen_endpoints),
         conn_tracker_(std::move(conn_tracker)), channel_(std::move(channel)),
-        stub_(sensor::NetworkConnectionInfoService::NewStub(channel_))
-  {}
+        stub_(sensor::NetworkConnectionInfoService::NewStub(channel_)),
+        stats_(collector_stats)
+  {
+    conn_tracker_->SetCollectorStats(stats_);
+  }
 
   void Start();
   void Stop();
@@ -99,6 +103,7 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
 
   std::shared_ptr<grpc::Channel> channel_;
   std::unique_ptr<Stub> stub_;
+  CollectorStats* stats_;
 };
 
 }  // namespace collector


### PR DESCRIPTION
Add the following timer statistics to Prometheus
```
  rox_collector_timers{type="net_write_message_times_us_avg"} 461.000000
  rox_collector_timers{type="net_write_message_times_us_total"} 46121.000000
  rox_collector_timers{type="net_scrape_read_events"} 100.000000
  rox_collector_timers{type="net_scrape_update_events"} 100.000000
  rox_collector_timers{type="net_scrape_read_times_us_total"} 10782852.000000
  rox_collector_timers{type="net_scrape_read_times_us_avg"} 107828.000000
  rox_collector_timers{type="net_fetch_state_events"} 100.000000
  rox_collector_timers{type="net_scrape_update_times_us_total"} 6103.000000
  rox_collector_timers{type="net_scrape_update_times_us_avg"} 61.000000
  rox_collector_timers{type="net_fetch_state_times_us_avg"} 103.000000
  rox_collector_timers{type="net_fetch_state_times_us_total"} 10367.000000
  rox_collector_timers{type="net_create_message_events"} 100.000000
  rox_collector_timers{type="net_create_message_times_us_total"} 6706.000000
  rox_collector_timers{type="net_create_message_times_us_avg"} 67.000000
  rox_collector_timers{type="net_write_message_events"} 100.000000
  rox_collector_counters{type="net_known_public_ips"} 0.000000
  rox_collector_counters{type="net_cep_inactive"} 3610.000000
  rox_collector_counters{type="net_known_ip_networks"} 28389.000000
  rox_collector_counters{type="net_cep_deltas"} 28.000000
  rox_collector_counters{type="net_cep_updates"} 2798.000000
  rox_collector_counters{type="net_conn_inactive"} 15340.000000
  rox_collector_counters{type="net_conn_deltas"} 1471.000000
  rox_collector_counters{type="net_conn_updates"} 30934.000000
```