### PR TITLE
Benchmark network lookup optimizations

### DIFF
--- a/collector/lib/NRadix.cpp
+++ b/collector/lib/NRadix.cpp
@@ -155,7 +155,7 @@ IPNet NRadixTree::Find(const IPNet& network) const {
     if (bit == 0) {
       // We have walked 128 bits, stop.
       if (++i >= Address::kU64MaxLen) {
-        if (node->value_) {
+        if (node && node->value_) {
           ret = *node->value_;
         }
         break;

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -240,7 +240,8 @@ class IPNet {
   }
 
   size_t Hash() const {
-    return HashAll(address_.array(), mask_, bits_);
+    if (is_addr_) return HashAll(address_.array(), mask_, bits_);
+    return HashAll(mask_, bits_);
   }
 
   bool IsNull() const {


### PR DESCRIPTION
```
Time to create tree with 30000 networks: 48.4057ms
Time to sort 20000 ipv4 networks: 8.7366ms
Time to sort 10000 ipv6 networks: 4.9669ms
Avg time to lookup 30000 addresses with network radix tree (#networks:30000): 0.0263089ms
Avg time to lookup 30000 addresses without network radix tree (#networks:30000): 0.17033ms
```