### PR TITLE
Update UBI image versions to the latest 8.4 for RHSA-2021:2717

### DIFF
--- a/collector/container/Dockerfile.ubi
+++ b/collector/container/Dockerfile.ubi
@@ -1,6 +1,6 @@
 # This builds a collector container based on UBI with a reliance on Red Hat
 # subscription entitlements.
-FROM registry.access.redhat.com/ubi8/ubi:8.4-203 AS builder
+FROM registry.access.redhat.com/ubi8/ubi:8.4-206.1626828523 AS builder
 
 ARG REDHAT_USERNAME
 ARG REDHAT_PASSWORD
@@ -49,7 +49,7 @@ ARG NPROCS=2
 RUN NPROCS=${NPROCS} ./builder/build/build-ubi.sh
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-200
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
 
 WORKDIR /
 

--- a/collector/container/rhel/Dockerfile
+++ b/collector/container/rhel/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8/ubi
-ARG BASE_TAG=8.3
+ARG BASE_TAG=8.4
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 


### PR DESCRIPTION
Note that `podman pull` says that `8.4` and `8.4-206.1626828523` have the same sha `0ced1c7c9b23d0e107c7b15d5a0017abbbcf7e64e49a4c9f9efa1b9589ca8b68` so should be the same image.

We could use either `8.4` style or `8.4-206.1626828523` consistently but I did not want to change that now.

## Testing done.

None. Only checked that images are pullable.
Crossing fingers and hoping all works.