### PR TITLE
Disable dockerhub usage until migration to gcr or quay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1302,8 +1302,7 @@ jobs:
               circleci step halt
             fi
 
-      # Not supported on machine instances
-      #- setup_remote_docker
+      - setup_remote_docker
       - stackrox-io-login
       - gcloud-init
 


### PR DESCRIPTION
Use CI image from quay with temporary creds.

Still enabled:
- rhel/ubi/ubuntu image builds
- Kernel probe builds and support packages

Disables:
- pulling and pushing from DockerHub
- local and remote VM integration tests which require image push
- pushing built collector images
- reloading of `-latest` images

Once we can push to quay, I can re-enable the above.