### PR TITLE
ROX-7576 Remove images after reload step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1501,7 +1501,7 @@ jobs:
             fi
             # clean-up to reduce disk usage
             docker image rm -f "${image_list[@]}"
-            docker prune --force
+            docker image prune --force
             docker images
           done
 


### PR DESCRIPTION
Description:

Prune unneeded images after reload step to prevent disk space exhaustion.
Example of error: https://app.circleci.com/pipelines/github/stackrox/collector/5355/workflows/1f4b9032-5b47-4bd3-873f-4f4d1f91139b/jobs/92298?invite=true#step-111-2813

Testing: 

Successfully ran `reload-released-images` job. Pruning images saves ~44 GB.

VM creation error in `test-module-rhel-7` can be ignored.