### PR TITLE
Use circle tag env var instead of git describe

### DIFF
--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -4,5 +4,9 @@ COLLECTOR_BUILDER_TAG=cache
 endif
 
 ifeq ($(COLLECTOR_TAG),)
+ifeq ($(CIRCLE_TAG),)
 COLLECTOR_TAG=$(shell git describe --tags --abbrev=10 --dirty)
+else
+COLLECTOR_TAG := $(CIRCLE_TAG)
+endif
 endif


### PR DESCRIPTION
Currently, if we have two tags pointing to the same commit, COLLECTOR_TAG is set to the older git tag when tagging the image build version. When adding a new tag to a commit with an existing tag, to rebuilt to fix a CVE for example, the old git tag is used as the image version. 

I will cherry pick this onto https://github.com/stackrox/collector/tree/release/3.1.x and then tag and push 3.1.32.