### PR TITLE
ROX-7824 fix circleci clang format install issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,9 +220,9 @@ jobs:
         name: Install clang-format
         command: |
           sudo bash -c 'printf "deb http://deb.debian.org/debian/ buster-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list'
-          sudo apt-get update
+          sudo apt-get --allow-releaseinfo-change update
           sudo apt-get install -y clang-format-11
-          sudo update-alternatives --allow-releaseinfo-change --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
     - run:
         name: Lint via clang-format
         command: |


### PR DESCRIPTION
This PR fixed a similar issue with a similar solution https://github.com/stackrox/rox/pull/9125