### PR TITLE
Use newer apollo-ci image to avoid apt-get repository issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
 
 defaultImage: &defaultImage
   docker:
-  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.7"
+  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.13"
     auth:
       username: $QUAY_CGORMAN1_RO_USER
       password: $QUAY_CGORMAN1_RO_PASSWORD
@@ -212,7 +212,7 @@ jobs:
         name: Install clang-format
         command: |
           sudo bash -c 'printf "deb http://deb.debian.org/debian/ buster-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list'
-          sudo apt-get --allow-releaseinfo-change update
+          sudo apt-get update
           sudo apt-get install -y clang-format-11
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
     - run:


### PR DESCRIPTION
Mid-August 2021 a new debian version has been released. This triggered a change in repository metadata which would conflict with the cached value in `apt-cache`. Newer image version does not have this problem because it was _likely_ built after that debian release. 

See https://github.com/stackrox/rox/pull/9125 for more info.