### PR TITLE
Use newer apollo-ci image to avoid apt-get repository issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
 
 defaultImage: &defaultImage
   docker:
-  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.7"
+  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.13"
     auth:
       username: $QUAY_CGORMAN1_RO_USER
       password: $QUAY_CGORMAN1_RO_PASSWORD


### PR DESCRIPTION
Mid-August 2021 a new debian version has been released. This triggered a change in repository metadata which would conflict with the cached value in `apt-cache`. Newer image version does not have this problem because it was _likely_ built after that debian release. 

See https://github.com/stackrox/collector/pull/455 and https://github.com/stackrox/rox/pull/9125 for more info.