### PR TITLE
Use UBI image floating tags

### DIFF
--- a/collector/container/Dockerfile.ubi
+++ b/collector/container/Dockerfile.ubi
@@ -1,6 +1,6 @@
 # This builds a collector container based on UBI with a reliance on Red Hat
 # subscription entitlements.
-FROM registry.access.redhat.com/ubi8/ubi:8.4-206.1626828523 AS builder
+FROM registry.access.redhat.com/ubi8/ubi:8.4 AS builder
 
 ARG REDHAT_USERNAME
 ARG REDHAT_PASSWORD
@@ -49,7 +49,7 @@ ARG NPROCS=2
 RUN NPROCS=${NPROCS} ./builder/build/build-ubi.sh
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 WORKDIR /
 


### PR DESCRIPTION
Floating tags are like `latest`, they follow the most recent releases of the image. Therefore using floating tag would give us up-to-date base image every time we build.
We already do the same in other places in `rox` and `scanner`. This is one spot that I came across in Collector that probably needs to be adjusted.
With specific release tags, how it was before, we'd have to manually refresh them if/when the base image becomes vulnerable.

That's how floating tags look like :)
https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?container-tabs=overview
![image](https://user-images.githubusercontent.com/537715/131104644-ccbcf1c9-245e-434c-86b1-7c56c50f1c71.png)


Note that we cannot and probably should not do the same in Red Hat CPaaS because there are jobs that automatically follow floating tags and update Dockerfiles in `git` for us. I mean syntax like this "magically" works in CPaaS but not in GitHub+CircleCI:
```Dockerfile
#@follow_tag(registry.access.redhat.com/ubi8/ubi-minimal:latest)
FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-208
```

## Testing done

None, relying on CI.