### PR TITLE
Workflow for building kernel probes locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 .rox/
-integration-tests/*.logs
+.ccls-cache
+integration-tests/*.log
+integration-tests/container-logs/*.log
 integration-tests/perf.json
 sysdig/cmake-build
 sysdig/cmake-build-rhel
@@ -14,3 +16,10 @@ kernel-modules/kobuild-tmp
 
 # Development SSH Server keys
 .collector_dev_ssh_host_ed25519_key*
+
+# Patches and local probe build
+kobuild
+sources
+patches
+probes
+source-archives

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,11 @@ MOD_VER_FILE=$(CURDIR)/kernel-modules/kobuild-tmp/MODULE_VERSION.txt
 LOCAL_SSH_PORT ?= 2222
 DEV_SSH_SERVER_KEY ?= $(CURDIR)/.collector_dev_ssh_host_ed25519_key
 
-dev-build: image integration-tests-process-network
-
-dev-build-rhel: image-rhel integration-tests-process-network-rhel
-
 .PHONY: tag
 tag:
 	@echo "$(COLLECTOR_TAG)"
 
+# create or pull the builder image used to build collector
 .PHONY: builder
 builder:
 ifdef BUILD_BUILDER_IMAGE
@@ -26,6 +23,7 @@ else
 	docker pull stackrox/collector-builder:$(COLLECTOR_BUILDER_TAG)
 endif
 
+# create or pull the rhel builder image used to build collector
 .PHONY: builder-rhel
 builder-rhel:
 ifdef BUILD_BUILDER_IMAGE
@@ -39,11 +37,30 @@ else
 	docker pull stackrox/collector-builder:rhel-$(COLLECTOR_BUILDER_TAG)
 endif
 
+# build collector binaries using Docker
 collector: builder
 	make -C collector container/bin/collector
 
+# build collector rhel binaries using Docker
 collector-rhel: builder-rhel
 	make -C collector container/bin/collector-rhel
+
+# copy collector binaries built using CLion
+collector-dev:
+	mkdir -p collector/container/bin collector/container/libs
+	docker cp collector_remote_dev:/tmp/cmake-build/collector collector/container/bin/
+	docker cp collector_remote_dev:/tmp/cmake-build/EXCLUDE_FROM_DEFAULT_BUILD/userspace/libsinsp/libsinsp-wrapper.so collector/container/libs/libsinsp-wrapper.so
+	docker cp collector_remote_dev:/THIRD_PARTY_NOTICES - | tar -x --strip-components 1 -C collector/container/THIRD_PARTY_NOTICES
+
+# copy rhel collector binaries built using CLion
+collector-rhel-dev:
+	mkdir -p collector/container/bin collector/container/libs
+	docker cp collector_remote_dev:/tmp/cmake-build-rhel/collector collector/container/bin/collector.rhel
+	docker cp collector_remote_dev:/tmp/cmake-build-rhel/EXCLUDE_FROM_DEFAULT_BUILD/userspace/libsinsp/libsinsp-wrapper.so collector/container/libs/libsinsp-wrapper.so.rhel
+	docker cp collector_remote_dev:/THIRD_PARTY_NOTICES - | tar -x --strip-components 1 -C collector/container/THIRD_PARTY_NOTICES.rhel
+
+txt-files:
+	make -C collector txt-files
 
 .PHONY: unittest
 unittest:
@@ -58,37 +75,33 @@ build-kernel-modules:
 	make -C kernel-modules build-container
 
 $(MOD_VER_FILE): build-kernel-modules
-	rm -rf kernel-modules/kobuild-tmp/
-	mkdir -p kernel-modules/kobuild-tmp/versions-src
-	docker run --rm -i \
-	  -v "$(CURDIR)/sysdig:/sysdig:ro" \
-	  --tmpfs /scratch:exec --tmpfs /output:exec \
-	  --env SYSDIG_DIR=/sysdig/src --env SCRATCH_DIR=/scratch --env OUTPUT_DIR=/output \
-	  build-kernel-modules prepare-src 2> /dev/null | tail -n 1 > "$(MOD_VER_FILE)"
+	./scripts/prepare-module-srcs
 
-image: collector unittest $(MOD_VER_FILE)
-	make -C collector txt-files
+collector-image: $(MOD_VER_FILE)
 	docker build --build-arg collector_version="$(COLLECTOR_TAG)" \
 		--build-arg module_version="$(shell cat $(MOD_VER_FILE))" \
 		-f collector/container/Dockerfile \
 		-t stackrox/collector:$(COLLECTOR_TAG) \
+		-t stackrox/collector:$(COLLECTOR_TAG)-base \
 		collector/container
 
-.PHONY: $(CURDIR)/collector/container/rhel/bundle.tar.gz
-$(CURDIR)/collector/container/rhel/bundle.tar.gz:
-	$(CURDIR)/collector/container/rhel/create-bundle.sh $(CURDIR)/collector/container - $(CURDIR)/collector/container/rhel/
-
-.PHONY: $(CURDIR)/collector/container/rhel/prebuild.sh
-$(CURDIR)/collector/container/rhel/prebuild.sh:
-	$(CURDIR)/collector/container/rhel/create-prebuild.sh $@
-
-image-rhel: collector-rhel unittest-rhel $(MOD_VER_FILE) $(CURDIR)/collector/container/rhel/bundle.tar.gz
-	make -C collector txt-files
+collector-image-rhel: $(MOD_VER_FILE)
+	$(CURDIR)/collector/container/rhel/create-bundle.sh \
+		"$(CURDIR)/collector/container" - "$(CURDIR)/collector/container/rhel"
 	docker build --build-arg collector_version="rhel-$(COLLECTOR_TAG)" \
 		--build-arg module_version="$(shell cat $(MOD_VER_FILE))" \
 		-f collector/container/rhel/Dockerfile \
 		-t stackrox/collector-rhel:$(COLLECTOR_TAG) \
 		collector/container/rhel
+
+image: collector unittest txt-files collector-image
+	docker build \
+		--build-arg module_version="$(shell cat $(MOD_VER_FILE))" \
+		--build-arg collector_version="$(COLLECTOR_TAG)" \
+		-t "stackrox/collector:$(COLLECTOR_TAG)" \
+		"$(CURDIR)/kernel-modules/container"
+
+image-rhel: collector-rhel unittest-rhel txt-files collector-image-rhel
 
 .PHONY: integration-tests
 integration-tests:
@@ -139,15 +152,18 @@ ifeq (,$(wildcard $(DEV_SSH_SERVER_KEY)))
 	ssh-keygen -t ed25519 -N '' -f $(DEV_SSH_SERVER_KEY) < /dev/null
 endif
 
+# Start container for remote docker development in CLion
 .PHONY: start-dev
 start-dev: builder teardown-dev $(DEV_SSH_SERVER_KEY)
 	make -C collector generated-srcs
+	mkdir -p collector/cmake-build collector/cmake-build-rhel
 	docker run -d \
 		--name collector_remote_dev \
 		--cap-add sys_ptrace -p127.0.0.1:$(LOCAL_SSH_PORT):22 \
 		-v $(DEV_SSH_SERVER_KEY):/etc/sshkeys/ssh_host_ed25519_key:ro \
 		stackrox/collector-builder:$(COLLECTOR_BUILDER_TAG)
 
+# Start container, using rhel builder image, for remote docker development in CLion
 .PHONY: start-dev-rhel $(DEV_SSH_SERVER_KEY)
 start-dev-rhel: builder-rhel teardown-dev
 	make -C collector generated-srcs
@@ -157,10 +173,48 @@ start-dev-rhel: builder-rhel teardown-dev
 		-v $(DEV_SSH_SERVER_KEY):/etc/sshkeys/ssh_host_ed25519_key:ro \
 		stackrox/collector-builder:rhel-$(COLLECTOR_BUILDER_TAG)
 
+# build collector image with binaries from remote docker dev and locally built probes
+image-dev: txt-files collector-dev collector-image probe-archive-dev
+	docker build \
+		--build-arg module_version="$(shell cat $(MOD_VER_FILE))" \
+		--build-arg collector_version="$(COLLECTOR_TAG)" \
+		--build-arg max_layer_depth=7 \
+		--build-arg max_layer_size=300 \
+		-t "stackrox/collector:$(COLLECTOR_TAG)" \
+		"$(CURDIR)/kernel-modules/container"
+
+# build rhel collector image with binaries from remote docker dev and locally built probes
+image-rhel-dev: txt-files collector-rhel-dev probe-archive-dev
+	$(CURDIR)/collector/container/rhel/create-bundle.sh \
+		"$(CURDIR)/collector/container" \
+		"$(CURDIR)/kernel-modules/container/$(shell cat $(MOD_VER_FILE)).tar.gz" \
+		"$(CURDIR)/collector/container/rhel"
+	docker build \
+		--build-arg collector_version="$(COLLECTOR_TAG)" \
+		--build-arg module_version="$(shell cat $(MOD_VER_FILE))" \
+		-f collector/container/rhel/Dockerfile \
+		-t stackrox/collector-rhel:$(COLLECTOR_TAG) \
+		collector/container/rhel
+
 .PHONY: teardown-dev
 teardown-dev:
 	-docker rm -fv collector_remote_dev
 
+# Copy kernel bundles from ../kernel-packer and build all builder containers
+.PHONY: probe-dev
+probe-dev: $(MOD_VER_FILE)
+	./scripts/copy-kernel-packer-repo-bundles
+	./legacy-modules/download.sh
+	make -C "${CURDIR}/kernel-modules" all-build-containers
+
+# create an archive of all probes built locally
+.PHONY: probe-archive-dev
+probe-archive-dev: $(MOD_VER_FILE)
+	mkdir -p "$(CURDIR)/kernel-modules/container/kernel-modules"
+	cp "$(CURDIR)/probes/$(shell cat $(MOD_VER_FILE))/"* "$(CURDIR)/kernel-modules/container/kernel-modules/" || true
+
 .PHONY: clean
 clean: teardown-dev
 	make -C collector clean
+	rm -rf sources patches probes source-archives
+	rm -rf "$(CURDIR)/kernel-modules/container/kernel-modules"

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ These instructions are for using the *JetBrains* C/C++ IDE **CLion**, but should
     - (Optional) Local builder images can used by setting the environment variable before execution using `BUILD_BUILDER_IMAGE=true make start-dev`.
 Or, builder images from a PR by with `COLLECTOR_BUILDER_TAG=<circle-build-id> make start-dev`.
 
-Instructions for Mac OS 
+Instructions for Mac OS
 - In the **CLion->Preferences** window, add a new **Toolchain** entry in settings under **Build, Execution, Deployment** as a **Remote Host** type.
 - Then, click in the **Credentials** section and fill out the SSH credentials used in the builder Dockerfile.
   - Host: `localhost`, Port: `2222`, User name: `remoteuser`, Password: `c0llectah`
 - Next, select **Deployment** under **Build, Execution, Deployment**, and then **Mappings**. Set **Deployment path** to `/tmp`.
 - Finally, add a CMake profile that uses the **Remote Host** toolchain and change **Build directory**/**Generation Path** to `cmake-build`.
 
-Instructions for Linux 
+Instructions for Linux
 - In the **File->Settings->Build, Execution, Deployment->Toolchains** window, add a new **Toolchain** entry as a **Remote Host** type.
 - Then, click in the **Credentials** section and fill out the SSH credentials used in the builder Dockerfile.
   - Host: `localhost`, Port: `2222`, User name: `remoteuser`, Password: `c0llectah`
@@ -60,7 +60,7 @@ The development workflow can also be used with the rhel based builder image.
   - Clone the [stackrox/kernel-packer](https://github.com/stackrox/kernel-packer) repository.
   - From the kernel-packer repository, run `./scripts/local-bundle 5.4.0-1028-gcp`, to download and build the kernel bundle.
   - Prepare the probe build environment in the collector repostitory with `make probe-dev`
-  - Build the probe with `./scripts/build-probe 5.4.0-1028-gcp`
+  - Build the probe with `./scripts/build-probe 5.4.0-1028-gcp [mod|bpf]`
   - Build a collector binaries within CLion
   - Build a the collector image with the CLion binaries and locally built probes with `make image-dev`
   - Push the image: `docker push stackrox/collector:$(make tag)`

--- a/README.md
+++ b/README.md
@@ -52,5 +52,16 @@ The development workflow can also be used with the rhel based builder image.
 ### Building collector image(s) from the command-line
 - `make image` or `make image-rhel` will create the default (Ubuntu) and Red Hat based collector images respectively.
 
+### Building collector image(s) from the command-line with CLion binaries
+- `make image-dev` or `make image-dev-rhel` will copy the collector binaries built by CLion in the `collector_remote_dev` container.
 
-
+### Example workflow to building a kernel probes locally from the command-line and run integration tests on a remote VM
+- To build a collector image locally containing probes for the kernel `5.4.0-1028-gcp`
+  - Clone the [stackrox/kernel-packer](https://github.com/stackrox/kernel-packer) repository.
+  - From the kernel-packer repository, run `./scripts/local-bundle 5.4.0-1028-gcp`, to download and build the kernel bundle.
+  - Prepare the probe build environment in the collector repostitory with `make probe-dev`
+  - Build the probe with `./scripts/build-probe 5.4.0-1028-gcp`
+  - Build a collector binaries within CLion
+  - Build a the collector image with the CLion binaries and locally built probes with `make image-dev`
+  - Push the image: `docker push stackrox/collector:$(make tag)`
+  - Execute the integration tests on a remote gcp VM with `COLLECTION_METHOD=ebpf REMOTE_HOST_TYPE=gcloud GCLOUD_INSTANCE=robby-test GCLOUD_OPTIONS="--zone us-central1-a --project stackrox-dev" make integration-tests-process-network`

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -19,22 +19,19 @@ generated-srcs-rhel:
 		-v $(CURDIR)/../rox-proto:/collector/rox-proto:ro \
 		stackrox/collector-builder:rhel-$(COLLECTOR_BUILDER_TAG) make -f protogen.mk generated-proto-srcs
 
-container/bin/collector: $(HDRS) $(SRCS) txt-files generated-srcs $(shell find sysdig/src/ -name '*.h' -o -name '*.cpp' -o -name '*.c')
-	mkdir -p container/bin
-	mkdir -p container/libs
+container/bin/collector: $(HDRS) $(SRCS) generated-srcs txt-files $(shell find sysdig/src/ -name '*.h' -o -name '*.cpp' -o -name '*.c')
 	docker rm -fv build_collector || true
 	docker run --rm --name build_collector \
 		-v "$(CURDIR):/src:ro" \
 		-v "$(CURDIR)/../sysdig/:/sysdig:ro" \
 		-v "$(CURDIR)/cmake-build:/tmp/cmake-build" \
 		stackrox/collector-builder:$(COLLECTOR_BUILDER_TAG) /build-collector.sh
-	cp cmake-build/collector container/bin/
+	mkdir -p container/bin container/libs
 	cp -r cmake-build/THIRD_PARTY_NOTICES/* container/THIRD_PARTY_NOTICES/
+	cp cmake-build/collector container/bin/collector
 	cp cmake-build/EXCLUDE_FROM_DEFAULT_BUILD/userspace/libsinsp/libsinsp-wrapper.so container/libs/libsinsp-wrapper.so
 
-container/bin/collector-rhel: $(HDRS) $(SRCS) txt-files generated-srcs-rhel $(shell find sysdig/src/ -name '*.h' -o -name '*.cpp' -o -name '*.c')
-	mkdir -p container/bin
-	mkdir -p container/libs
+container/bin/collector-rhel: $(HDRS) $(SRCS) generated-srcs-rhel txt-files $(shell find sysdig/src/ -name '*.h' -o -name '*.cpp' -o -name '*.c')
 	docker rm -fv build_collector_rhel || true
 	docker run --rm --name build_collector_rhel \
 		-v "$(CURDIR):/src:ro" \
@@ -42,6 +39,7 @@ container/bin/collector-rhel: $(HDRS) $(SRCS) txt-files generated-srcs-rhel $(sh
 		-v "$(CURDIR)/cmake-build-rhel:/tmp/cmake-build" \
 		-e DISABLE_PROFILING="true" \
 		stackrox/collector-builder:rhel-$(COLLECTOR_BUILDER_TAG) /build-collector.sh
+	mkdir -p container/bin container/libs
 	cp cmake-build-rhel/collector container/bin/collector.rhel
 	cp -r cmake-build-rhel/THIRD_PARTY_NOTICES/* container/THIRD_PARTY_NOTICES.rhel/
 	cp cmake-build-rhel/EXCLUDE_FROM_DEFAULT_BUILD/userspace/libsinsp/libsinsp-wrapper.so container/libs/libsinsp-wrapper.so.rhel
@@ -114,6 +112,9 @@ clean: clean-generated-srcs
 	rm -rf container/libs
 	rm -rf container/THIRD_PARTY_NOTICES
 	rm -rf container/THIRD_PARTY_NOTICES.rhel
+	rm -rf container/probes
+	rm -f container/COPYING*.txt
+	rm -f container/NOTICE.txt
 
 .PHONY: clean-generated-srcs
 clean-generated-srcs:

--- a/kernel-modules/.gitignore
+++ b/kernel-modules/.gitignore
@@ -1,2 +1,3 @@
 *.ko
 sysdig/
+container/MODULE_VERSION.txt

--- a/kernel-modules/Makefile
+++ b/kernel-modules/Makefile
@@ -10,6 +10,7 @@ all: build-container
 .PHONY: build-container
 build-container:
 	docker build $(BUILD_CONTAINER_CACHE_IMAGES:%=--cache-from=%) -t $(BUILD_CONTAINER_TAG) ./build
+	docker tag "$(BUILD_CONTAINER_TAG)" "$(BUILD_CONTAINER_TAG)-default"
 
 build-container-%: build/Dockerfile.%
 	docker build $(BUILD_CONTAINER_CACHE_IMAGES:%=--cache-from=%-$@) -t $(BUILD_CONTAINER_TAG)-$* ./build -f $<

--- a/kernel-modules/container/Dockerfile
+++ b/kernel-modules/container/Dockerfile
@@ -5,6 +5,7 @@ ARG base_image=${collector_repo}:${collector_version}-base
 FROM python:3 as kernel-modules
 ARG max_layer_size=xxx
 ARG max_layer_depth=xxx
+SHELL ["bash", "-c"]
 
 # Increase the value in this check if additional hardcoded layers are added below.
 RUN test "${max_layer_depth}" -le 8
@@ -13,10 +14,12 @@ COPY kernel-modules/ /kernel-modules
 COPY partition-probes.py /
 
 WORKDIR /kernel-modules
+RUN for i in $(seq 0 ${max_layer_depth}); do mkdir -p /kernel-modules/"$i"; done
 
 # Split probes into directories containing at most max_layer_size bytes.
 RUN /partition-probes.py "${max_layer_depth}" "${max_layer_size}" "." "/layers" && \
-  for i in "/layers"/*; do mkdir -p "$(basename "$i")"; xargs -a "$i" mv -t "$(basename "$i")" ; done
+  shopt -s nullglob && \
+  for i in "/layers"/*; do xargs -a "$i" mv -t "$(basename "$i")" ; done
 
 # Probes are split across multiple layers to limit blob size
 FROM ${base_image} AS probe-layer-1

--- a/scripts/build-probe
+++ b/scripts/build-probe
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_ROOT="${SOURCE_ROOT:-${DIR}/..}"
+BUILD_CONTAINER_TAG="${BUILD_CONTAINER_TAG:-stackrox/collector-builder:kobuilder-cache}"
+KOBUILD_DIR="${KOBUILD_DIR:-${SOURCE_ROOT}/kobuild}"
+PROBE_DIR="${PROBE_DIR:-${SOURCE_ROOT}/probes}"
+
+kernel="$1"
+probe_type="$2"
+module_version=$(cat "${SOURCE_ROOT}/kernel-modules/kobuild-tmp/MODULE_VERSION.txt")
+
+bundle_file="${KOBUILD_DIR}/bundles/bundle-${kernel}.tgz"
+
+inspect_dir=$(mktemp -d)
+tar -xzf "${bundle_file}" -C "${inspect_dir}" ./BUNDLE_DISTRO ./BUNDLE_VERSION
+distro="$(< "${inspect_dir}/BUNDLE_DISTRO")"
+kernel_version="$(< "${inspect_dir}/BUNDLE_VERSION")"
+rm -rf "${inspect_dir}"
+
+# Select builder flavor
+flavor="modern"
+if basename "${SOURCE_ROOT}/kernel-modules/build/Dockerfile".* | sed 's/Dockerfile.//' | grep -q "${distro}"; then
+    flavor="${distro}"
+elif (( kernel_version >= 5 )); then
+    flavor="modern"
+fi
+
+echo "Using ${flavor} builder"
+echo "Building ${probe_type} probe for ${distro}:${kernel} and collector version ${module_version}"
+
+task_file=/tmp/kernel-build-task-file
+echo "${kernel} ${module_version} ${probe_type}" > "${task_file}"
+
+mkdir -p "${PROBE_DIR}"
+docker run --rm -i \
+  -v "${KOBUILD_DIR}/bundles:/bundles:ro" \
+  -v "${SOURCE_ROOT}/sources:/sources:ro" \
+  -v "${PROBE_DIR}:/output" \
+  --tmpfs /scratch:exec \
+  "build-kernel-modules-${flavor}" build-kos <"${task_file}"

--- a/scripts/copy-kernel-packer-repo-bundles
+++ b/scripts/copy-kernel-packer-repo-bundles
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_ROOT="${SOURCE_ROOT:-${DIR}/..}"
+KOBUILD_DIR="${KOBUILD_DIR:-${SOURCE_ROOT}/kobuild}"
+
+KERNEL_PACKER_DIR="${KERNEL_PACKER_DIR:-${SOURCE_ROOT}/../kernel-packer}"
+BUNDLE_SRC_DIR="${KERNEL_PACKER_DIR}/.build-data/bundles"
+BUNDLE_DST_DIR="${KOBUILD_DIR}/bundles"
+
+mkdir -p "${BUNDLE_DST_DIR}"
+for bundle_path in "${BUNDLE_SRC_DIR}"/[0-9a-z]*/bundle-*.tgz ; do
+    bundle=$(basename "$bundle_path")
+    rm "${BUNDLE_DST_DIR}/${bundle}"
+    ln "$bundle_path" "${BUNDLE_DST_DIR}/${bundle}"
+done

--- a/scripts/prepare-module-srcs
+++ b/scripts/prepare-module-srcs
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+TOPLEVEL="$(cd ${SOURCE_ROOT:-${DIR}/..}; pwd)"
+SOURCES_DIR="${SOURCES_DIR:-${TOPLEVEL}/sources}"
+MOD_VER_FILE="${TOPLEVEL}/kernel-modules/kobuild-tmp/MODULE_VERSION.txt"
+
+mkdir -p "${TOPLEVEL}/sources"
+
+docker run --rm -i \
+  -v "${TOPLEVEL}/sysdig:/sysdig:ro" \
+  -v "${SOURCES_DIR}:/output" \
+  --tmpfs /scratch:exec \
+  --env SYSDIG_DIR=/sysdig/src --env SCRATCH_DIR=/scratch --env OUTPUT_DIR=/output \
+  build-kernel-modules prepare-src 2> /dev/null | tail -n 1 > "${MOD_VER_FILE}"
+
+version="$(cat ${MOD_VER_FILE})"
+mkdir -p "${SOURCES_DIR}/${version}"
+tar xzf "${SOURCES_DIR}/${version}.tgz" -C "${SOURCES_DIR}/${version}"
+rm "${SOURCES_DIR}/${version}.tgz"
+
+if [[ -f "${TOPLEVEL}/kernel-modules/patches/${version}.patch" ]] ; then
+    echo "Applying patch for module version ${version} ..."
+    patch -f -p1 -d "${SOURCES_DIR}/${version}" <"${TOPLEVEL}/kernel-modules/patches/${version}.patch" || true
+fi

--- a/scripts/prepare-module-srcs
+++ b/scripts/prepare-module-srcs
@@ -8,6 +8,7 @@ SOURCES_DIR="${SOURCES_DIR:-${TOPLEVEL}/sources}"
 MOD_VER_FILE="${TOPLEVEL}/kernel-modules/kobuild-tmp/MODULE_VERSION.txt"
 
 mkdir -p "${TOPLEVEL}/sources"
+mkdir -p "${TOPLEVEL}/kernel-modules/kobuild-tmp"
 
 docker run --rm -i \
   -v "${TOPLEVEL}/sysdig:/sysdig:ro" \


### PR DESCRIPTION
- Add makefile targets to copy binary from remote build container when building local image
- Add a script to copy kernel-packer-repo bundles 
- Add a script to prepare probe sources