### PR TITLE
Remove support for old collector versions

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -1,108 +1,12 @@
 # This file contains the collector versions that are used in Rox releases.
 # Lines starting with a # character are ignored. In general, only the first token in each line is taken into account.
 # Still, it is good practice to prefix any comments with a # character.
+# Note: this file does not contain a comprehensive history of all collector versions referenced in Rox
+# releases; it is occasionally cleaned up to reflect our 6 months support policy.
+# See the RELEASED_VERSIONS.unsupported file in the same directory for entries corresponding to
+# now-unsupported releases.
 # IMPORTANT: THIS FILE ALWAYS NEEDS TO END WITH A NEWLINE CHARACTER
 
-1.6.0-61-g3470d501f8  # Manual entry created for release 2.3.16.1 (Feb 20, 2019)
-1.6.0-83-g645f7ffc15  # Manual entry created for release 2.4.16.3 (Feb 20, 2019)
-1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.1 by kwajdowicz at Fri Mar  8 00:36:31 UTC 2019
-1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.2 by kwajdowicz at Mon Mar 11 23:57:01 UTC 2019
-1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.3 by kwajdowicz at Wed Mar 13 04:56:31 UTC 2019
-1.6.0-113-g27efc40d58  # Rox release testing-rc.4 by joshdk at Wed Mar 13 18:13:03 UTC 2019
-1.6.0-113-g27efc40d58  # Rox release testing-rc.4 by joshdk at Wed Mar 13 18:33:27 UTC 2019
-1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.4 by kwajdowicz at Wed Mar 13 19:13:46 UTC 2019
-1.6.0-129-g330fb808a7  # Rox release 2.4.17.0 by kwajdowicz at Thu Mar 14 04:44:53 UTC 2019
-1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.1 by kwajdowicz at Fri Mar 22 03:02:11 UTC 2019
-1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.2 by kwajdowicz at Wed Mar 27 01:54:54 UTC 2019
-1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.3 by kwajdowicz at Wed Mar 27 23:33:10 UTC 2019
-1.6.0-157-g0a7860a444  # Rox release 2.4.18.0 by kwajdowicz at Thu Mar 28 18:55:00 UTC 2019
-1.6.0-157-g0a7860a444  # Rox release 2.4.18.1-rc.1 by kwajdowicz at Fri Mar 29 04:40:25 UTC 2019
-1.6.0-157-g0a7860a444  # Rox release 2.4.18.1 by kwajdowicz at Fri Mar 29 18:36:33 UTC 2019
-1.6.0-172-g8a5248aadb  # Rox release 2.4.19.0 by kwajdowicz at Wed Apr 10 20:47:48 UTC 2019
-1.6.0-172-g8a5248aadb  # Rox release 2.4.19.1 by misberner at Thu Apr 11 18:31:35 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.0 by kwajdowicz at Fri Apr 26 22:01:14 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.1 by viswajithiii at Mon Apr 29 22:38:42 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.2 by kwajdowicz at Thu May  2 17:36:20 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.3 by josephaltmaier at Tue May  7 02:23:14 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.4 by viswajithiii at Fri May 10 20:49:17 UTC 2019
-1.6.0-190-g17e626b942  # Rox release 2.4.20.5 by kwajdowicz at Fri May 17 15:33:12 UTC 2019
-1.6.0-233-g40304f2b83  # Rox release 2.4.21.0 by kwajdowicz at Wed May 29 23:58:11 UTC 2019
-1.6.0-233-g40304f2b83  # Rox release 2.4.21.1 by kwajdowicz at Fri May 31 23:02:41 UTC 2019
-1.6.0-233-g40304f2b83  # Rox release 2.4.21.2 by kwajdowicz at Mon Jun  3 21:38:05 UTC 2019
-1.6.0-247-g37ed2fb66d  # Rox release 2.4.22.0 by kwajdowicz at Thu Jun  6 04:02:15 UTC 2019
-1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.0 by kwajdowicz at Fri Jun 21 20:37:33 UTC 2019
-1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.1 by ikornienko at Fri Jun 28 06:45:27 UTC 2019
-1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.2 by ikornienko at Wed Jul  3 15:53:09 UTC 2019
-1.6.0-284-g688ac08005  # Rox release 2.4.24.0 by kwajdowicz at Fri Jul 12 04:15:10 UTC 2019
-1.6.0-284-g688ac08005  # Rox release 2.4.24.1 by kwajdowicz at Tue Jul 16 19:43:49 UTC 2019
-1.6.0-284-g688ac08005  # Rox release 2.4.24.2 by kwajdowicz at Wed Jul 17 23:39:15 UTC 2019
-1.6.0-292-g900ffefe20  # Rox release 2.5.25.0 by kwajdowicz at Mon Jul 22 18:58:37 UTC 2019
-1.6.0-292-g900ffefe20  # Rox release 2.5.25.1 by kwajdowicz at Thu Jul 25 21:56:10 UTC 2019
-1.6.0-300-g74b9187cab  # Rox release 2.5.26.0 by kwajdowicz at Tue Jul 30 17:23:41 UTC 2019
-1.6.0-300-g74b9187cab  # Rox release 2.5.26.1 by kwajdowicz at Fri Aug  9 17:13:39 UTC 2019
-1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by robbycochran at Tue Aug 20 23:23:11 UTC 2019
-1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by robbycochran at Wed Aug 21 00:10:21 UTC 2019
-1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by connorgorman at Wed Aug 21 04:06:40 UTC 2019
-1.6.0-317-g903fb094c8  # Rox release 2.5.27.1 by kwajdowicz at Thu Sep  5 20:55:30 UTC 2019
-1.6.0-317-g903fb094c8  # Rox release 2.5.27.2 by kwajdowicz at Mon Sep  9 19:58:01 UTC 2019
-2.5.2  # Rox release 2.5.29.0 by robbycochran at Thu Sep 19 23:10:10 UTC 2019
-2.5.2  # Rox release 2.5.29.0 by robbycochran at Fri Sep 20 00:21:37 UTC 2019
-1.6.0-284-g688ac08005  # Rox release 2.4.24.3 by kwajdowicz at Wed Sep 25 05:37:55 UTC 2019
-2.5.3  # Rox release 2.5.29.1 by robbycochran at Fri Sep 27 23:35:16 UTC 2019
-2.5.3  # Rox release 2.5.30.0 by kwajdowicz at Fri Oct  4 06:29:38 UTC 2019
-2.5.6  # Rox release 2.5.31.0 by kwajdowicz at Fri Oct 18 16:24:37 UTC 2019
-2.5.6  # Rox release 2.5.32.0 by ikornienko at Mon Nov  4 06:11:13 UTC 2019
-2.5.6  # Rox release 2.5.32.1 by ikornienko at Wed Nov  6 20:25:14 UTC 2019
-2.5.7  # Rox release 3.0.33.0 by ikornienko at Wed Nov 13 19:36:32 UTC 2019
-2.5.7  # Rox release 3.0.34.0 by kwajdowicz at Thu Nov 21 19:59:36 UTC 2019
-2.5.7 3.0.34.0  # Rox release 3.0.34.0 by kwajdowicz at Thu Nov 21 20:16:17 UTC 2019
-2.5.8 3.0.34.1  # Rox release 3.0.34.1 by kwajdowicz at Fri Nov 22 04:13:35 UTC 2019
-2.5.9 3.0.34.2  # Rox release 3.0.34.2 by kwajdowicz at Thu Nov 28 02:57:01 UTC 2019
-2.5.9 3.0.35.0  # Rox release 3.0.35.0 by kwajdowicz at Wed Dec 11 05:56:27 UTC 2019
-2.5.9 3.0.36.0  # Rox release 3.0.36.0 by kwajdowicz at Thu Dec 19 06:58:52 UTC 2019
-2.5.9 3.0.36.1  # Rox release 3.0.36.1 by kwajdowicz at Fri Jan 10 05:41:31 UTC 2020
-3.0.1 3.0.37.0  # Rox release 3.0.37.0 by kwajdowicz at Wed Jan 22 16:47:51 UTC 2020
-3.0.2 3.0.38.0  # Rox release 3.0.38.0 by kwajdowicz at Fri Jan 31 01:05:49 UTC 2020
-3.0.2 3.0.38.1  # Rox release 3.0.38.1 by misberner at Mon Feb  3 19:01:19 UTC 2020
-3.0.3 3.0.38.2  # Rox release 3.0.38.2 by kwajdowicz at Wed Feb 12 02:16:47 UTC 2020
-3.0.6 3.0.39.0  # Rox release 3.0.39.0 by kwajdowicz at Thu Feb 20 04:51:13 UTC 2020
-3.0.3 3.0.38.3  # Rox release 3.0.38.3 by kwajdowicz at Fri Feb 21 00:12:13 UTC 2020
-3.0.7 3.0.39.2  # Rox release 3.0.39.2 by kwajdowicz at Tue Feb 25 06:02:51 UTC 2020
-3.0.7 3.0.39.3  # Rox release 3.0.39.3 by kwajdowicz at Wed Mar  4 01:34:49 UTC 2020
-3.0.8 3.0.38.4  # Rox release 3.0.38.4 by kwajdowicz at Wed Mar  4 06:35:17 UTC 2020
-3.0.9 3.0.40.0  # Rox release 3.0.40.0 by kwajdowicz at Thu Mar 12 00:31:47 UTC 2020
-3.0.9 3.0.40.1  # Rox release 3.0.40.1 by misberner at Wed Mar 25 20:30:19 UTC 2020
-3.0.11 3.0.41.0  # Rox release 3.0.41.0 by kwajdowicz at Thu Apr  2 03:45:00 UTC 2020
-3.0.11 3.0.41.1  # Rox release 3.0.41.1 by kwajdowicz at Fri Apr  3 04:14:18 UTC 2020
-3.0.11 3.0.41.2  # Rox release 3.0.41.2 by kwajdowicz at Fri Apr  3 23:15:51 UTC 2020
-3.0.11 3.0.41.3  # Rox release 3.0.41.3 by misberner at Tue Apr  7 22:16:19 UTC 2020
-3.0.11 3.0.41.4  # Rox release 3.0.41.4 by kwajdowicz at Fri Apr 10 22:14:33 UTC 2020
-3.0.11 3.0.42.0  # Rox release 3.0.42.0 by kwajdowicz at Wed Apr 22 23:40:56 UTC 2020
-3.0.13 3.0.43.0  # Rox release 3.0.43.0 by kwajdowicz at Fri May 15 23:55:24 UTC 2020
-3.0.13 3.0.43.90  # Rox release 3.0.43.90 by viswajithiii at Tue May 19 19:03:06 UTC 2020
-3.0.13 3.0.43.1  # Rox release 3.0.43.1 by viswajithiii at Wed May 20 05:47:09 UTC 2020
-3.0.13-22-g13b9285325 3.0.44.0  # Rox release 3.0.44.0 by kwajdowicz at Thu Jun  4 05:14:09 UTC 2020
-3.0.15 3.0.44.1  # Rox release 3.0.44.1 by kwajdowicz at Fri Jun 12 05:05:47 UTC 2020
-3.0.16 3.0.45.0  # Rox release 3.0.45.0 by kwajdowicz at Wed Jun 24 23:31:00 UTC 2020
-3.0.16 3.0.45.1  # Rox release 3.0.45.1 by viswajithiii at Thu Jul  2 02:58:20 UTC 2020
-3.0.17 3.0.46.0  # Rox release 3.0.46.0 by gavin-stackrox at Thu Jul 16 00:57:54 UTC 2020
-3.0.18 3.0.47.0  # Rox release 3.0.47.0 by kwajdowicz at Thu Aug  6 05:42:47 UTC 2020
-3.0.18 3.0.47.1  # Rox release 3.0.47.1 by viswajithiii at Fri Aug  7 23:57:09 UTC 2020
-3.0.18 3.0.47.2  # Rox release 3.0.47.2 by viswajithiii at Thu Aug 13 02:03:03 UTC 2020
-3.1.0 3.0.48.0  # Rox release 3.0.48.0 by kwajdowicz at Thu Aug 27 06:39:54 UTC 2020
-3.1.0 3.0.48.1  # Rox release 3.0.48.1 by kwajdowicz at Fri Sep  4 18:41:15 UTC 2020
-3.1.1 3.0.49.0  # Rox release 3.0.49.0 by kwajdowicz at Wed Sep 16 22:18:41 UTC 2020
-3.1.1 3.0.49.1  # Rox release 3.0.49.1 by viswajithiii at Fri Sep 18 19:00:38 UTC 2020
-3.1.1 3.0.49.2  # Rox release 3.0.49.2 by kwajdowicz at Sat Sep 26 01:33:14 UTC 2020
-3.1.3 3.0.50.0  # Rox release 3.0.50.0 by kwajdowicz at Thu Oct  8 16:49:47 UTC 2020
-3.1.3 3.0.51.0  # Rox release 3.0.51.0 (manual update by misberner)
-3.1.4 3.0.51.1  # Rox release 3.0.51.1 by kwajdowicz at Thu Nov  5 03:25:19 UTC 2020
-3.1.7 3.0.52.0  # Rox release 3.0.52.0 by kwajdowicz at Thu Nov 19 06:26:26 UTC 2020
-3.1.8 3.0.52.1  # Rox release 3.0.52.1 by kwajdowicz at Tue Dec  8 06:24:50 UTC 2020
-3.1.9 3.0.53.0  # Rox release 3.0.53.0 by kwajdowicz at Thu Dec 17 04:20:52 UTC 2020
-3.1.12 3.0.55.0  # Rox release 3.0.55.0 by kwajdowicz at Thu Feb  4 05:56:08 UTC 2021
-3.1.14 3.0.56.0  # Rox release 3.0.56.0 by kwajdowicz at Thu Feb 25 05:06:30 UTC 2021
-3.1.15 3.0.56.1  # Rox release 3.0.56.1 by connorgorman at Mon Mar  8 20:19:40 UTC 2021
 3.1.16 3.0.57.0  # Rox release 3.0.57.0 by connorgorman at Thu Mar 18 23:31:59 UTC 2021
 3.1.16 3.0.57.1  # Rox release 3.0.57.1 by connorgorman at Thu Mar 25 00:53:37 UTC 2021
 3.1.16 3.0.57.2  # Rox release 3.0.57.2 by misberner at Thu Mar 25 23:19:07 UTC 2021

--- a/RELEASED_VERSIONS.unsupported
+++ b/RELEASED_VERSIONS.unsupported
@@ -1,0 +1,104 @@
+# This file contains entries from the RELEASED_VERSIONS file in the same directory that are no longer
+# supported.
+# It is preserved for documentation/history preservation purposes only, and serves no practical purpose.
+
+1.6.0-61-g3470d501f8  # Manual entry created for release 2.3.16.1 (Feb 20, 2019)
+1.6.0-83-g645f7ffc15  # Manual entry created for release 2.4.16.3 (Feb 20, 2019)
+1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.1 by kwajdowicz at Fri Mar  8 00:36:31 UTC 2019
+1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.2 by kwajdowicz at Mon Mar 11 23:57:01 UTC 2019
+1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.3 by kwajdowicz at Wed Mar 13 04:56:31 UTC 2019
+1.6.0-113-g27efc40d58  # Rox release testing-rc.4 by joshdk at Wed Mar 13 18:13:03 UTC 2019
+1.6.0-113-g27efc40d58  # Rox release testing-rc.4 by joshdk at Wed Mar 13 18:33:27 UTC 2019
+1.6.0-113-g27efc40d58  # Rox release 2.4.17.0-rc.4 by kwajdowicz at Wed Mar 13 19:13:46 UTC 2019
+1.6.0-129-g330fb808a7  # Rox release 2.4.17.0 by kwajdowicz at Thu Mar 14 04:44:53 UTC 2019
+1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.1 by kwajdowicz at Fri Mar 22 03:02:11 UTC 2019
+1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.2 by kwajdowicz at Wed Mar 27 01:54:54 UTC 2019
+1.6.0-144-g77e5690bf9  # Rox release 2.4.18.0-rc.3 by kwajdowicz at Wed Mar 27 23:33:10 UTC 2019
+1.6.0-157-g0a7860a444  # Rox release 2.4.18.0 by kwajdowicz at Thu Mar 28 18:55:00 UTC 2019
+1.6.0-157-g0a7860a444  # Rox release 2.4.18.1-rc.1 by kwajdowicz at Fri Mar 29 04:40:25 UTC 2019
+1.6.0-157-g0a7860a444  # Rox release 2.4.18.1 by kwajdowicz at Fri Mar 29 18:36:33 UTC 2019
+1.6.0-172-g8a5248aadb  # Rox release 2.4.19.0 by kwajdowicz at Wed Apr 10 20:47:48 UTC 2019
+1.6.0-172-g8a5248aadb  # Rox release 2.4.19.1 by misberner at Thu Apr 11 18:31:35 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.0 by kwajdowicz at Fri Apr 26 22:01:14 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.1 by viswajithiii at Mon Apr 29 22:38:42 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.2 by kwajdowicz at Thu May  2 17:36:20 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.3 by josephaltmaier at Tue May  7 02:23:14 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.4 by viswajithiii at Fri May 10 20:49:17 UTC 2019
+1.6.0-190-g17e626b942  # Rox release 2.4.20.5 by kwajdowicz at Fri May 17 15:33:12 UTC 2019
+1.6.0-233-g40304f2b83  # Rox release 2.4.21.0 by kwajdowicz at Wed May 29 23:58:11 UTC 2019
+1.6.0-233-g40304f2b83  # Rox release 2.4.21.1 by kwajdowicz at Fri May 31 23:02:41 UTC 2019
+1.6.0-233-g40304f2b83  # Rox release 2.4.21.2 by kwajdowicz at Mon Jun  3 21:38:05 UTC 2019
+1.6.0-247-g37ed2fb66d  # Rox release 2.4.22.0 by kwajdowicz at Thu Jun  6 04:02:15 UTC 2019
+1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.0 by kwajdowicz at Fri Jun 21 20:37:33 UTC 2019
+1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.1 by ikornienko at Fri Jun 28 06:45:27 UTC 2019
+1.6.0-251-gf5fe03f0a4  # Rox release 2.4.23.2 by ikornienko at Wed Jul  3 15:53:09 UTC 2019
+1.6.0-284-g688ac08005  # Rox release 2.4.24.0 by kwajdowicz at Fri Jul 12 04:15:10 UTC 2019
+1.6.0-284-g688ac08005  # Rox release 2.4.24.1 by kwajdowicz at Tue Jul 16 19:43:49 UTC 2019
+1.6.0-284-g688ac08005  # Rox release 2.4.24.2 by kwajdowicz at Wed Jul 17 23:39:15 UTC 2019
+1.6.0-292-g900ffefe20  # Rox release 2.5.25.0 by kwajdowicz at Mon Jul 22 18:58:37 UTC 2019
+1.6.0-292-g900ffefe20  # Rox release 2.5.25.1 by kwajdowicz at Thu Jul 25 21:56:10 UTC 2019
+1.6.0-300-g74b9187cab  # Rox release 2.5.26.0 by kwajdowicz at Tue Jul 30 17:23:41 UTC 2019
+1.6.0-300-g74b9187cab  # Rox release 2.5.26.1 by kwajdowicz at Fri Aug  9 17:13:39 UTC 2019
+1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by robbycochran at Tue Aug 20 23:23:11 UTC 2019
+1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by robbycochran at Wed Aug 21 00:10:21 UTC 2019
+1.6.0-317-g903fb094c8  # Rox release 2.5.27.0 by connorgorman at Wed Aug 21 04:06:40 UTC 2019
+1.6.0-317-g903fb094c8  # Rox release 2.5.27.1 by kwajdowicz at Thu Sep  5 20:55:30 UTC 2019
+1.6.0-317-g903fb094c8  # Rox release 2.5.27.2 by kwajdowicz at Mon Sep  9 19:58:01 UTC 2019
+2.5.2  # Rox release 2.5.29.0 by robbycochran at Thu Sep 19 23:10:10 UTC 2019
+2.5.2  # Rox release 2.5.29.0 by robbycochran at Fri Sep 20 00:21:37 UTC 2019
+1.6.0-284-g688ac08005  # Rox release 2.4.24.3 by kwajdowicz at Wed Sep 25 05:37:55 UTC 2019
+2.5.3  # Rox release 2.5.29.1 by robbycochran at Fri Sep 27 23:35:16 UTC 2019
+2.5.3  # Rox release 2.5.30.0 by kwajdowicz at Fri Oct  4 06:29:38 UTC 2019
+2.5.6  # Rox release 2.5.31.0 by kwajdowicz at Fri Oct 18 16:24:37 UTC 2019
+2.5.6  # Rox release 2.5.32.0 by ikornienko at Mon Nov  4 06:11:13 UTC 2019
+2.5.6  # Rox release 2.5.32.1 by ikornienko at Wed Nov  6 20:25:14 UTC 2019
+2.5.7  # Rox release 3.0.33.0 by ikornienko at Wed Nov 13 19:36:32 UTC 2019
+2.5.7  # Rox release 3.0.34.0 by kwajdowicz at Thu Nov 21 19:59:36 UTC 2019
+2.5.7 3.0.34.0  # Rox release 3.0.34.0 by kwajdowicz at Thu Nov 21 20:16:17 UTC 2019
+2.5.8 3.0.34.1  # Rox release 3.0.34.1 by kwajdowicz at Fri Nov 22 04:13:35 UTC 2019
+2.5.9 3.0.34.2  # Rox release 3.0.34.2 by kwajdowicz at Thu Nov 28 02:57:01 UTC 2019
+2.5.9 3.0.35.0  # Rox release 3.0.35.0 by kwajdowicz at Wed Dec 11 05:56:27 UTC 2019
+2.5.9 3.0.36.0  # Rox release 3.0.36.0 by kwajdowicz at Thu Dec 19 06:58:52 UTC 2019
+2.5.9 3.0.36.1  # Rox release 3.0.36.1 by kwajdowicz at Fri Jan 10 05:41:31 UTC 2020
+3.0.1 3.0.37.0  # Rox release 3.0.37.0 by kwajdowicz at Wed Jan 22 16:47:51 UTC 2020
+3.0.2 3.0.38.0  # Rox release 3.0.38.0 by kwajdowicz at Fri Jan 31 01:05:49 UTC 2020
+3.0.2 3.0.38.1  # Rox release 3.0.38.1 by misberner at Mon Feb  3 19:01:19 UTC 2020
+3.0.3 3.0.38.2  # Rox release 3.0.38.2 by kwajdowicz at Wed Feb 12 02:16:47 UTC 2020
+3.0.6 3.0.39.0  # Rox release 3.0.39.0 by kwajdowicz at Thu Feb 20 04:51:13 UTC 2020
+3.0.3 3.0.38.3  # Rox release 3.0.38.3 by kwajdowicz at Fri Feb 21 00:12:13 UTC 2020
+3.0.7 3.0.39.2  # Rox release 3.0.39.2 by kwajdowicz at Tue Feb 25 06:02:51 UTC 2020
+3.0.7 3.0.39.3  # Rox release 3.0.39.3 by kwajdowicz at Wed Mar  4 01:34:49 UTC 2020
+3.0.8 3.0.38.4  # Rox release 3.0.38.4 by kwajdowicz at Wed Mar  4 06:35:17 UTC 2020
+3.0.9 3.0.40.0  # Rox release 3.0.40.0 by kwajdowicz at Thu Mar 12 00:31:47 UTC 2020
+3.0.9 3.0.40.1  # Rox release 3.0.40.1 by misberner at Wed Mar 25 20:30:19 UTC 2020
+3.0.11 3.0.41.0  # Rox release 3.0.41.0 by kwajdowicz at Thu Apr  2 03:45:00 UTC 2020
+3.0.11 3.0.41.1  # Rox release 3.0.41.1 by kwajdowicz at Fri Apr  3 04:14:18 UTC 2020
+3.0.11 3.0.41.2  # Rox release 3.0.41.2 by kwajdowicz at Fri Apr  3 23:15:51 UTC 2020
+3.0.11 3.0.41.3  # Rox release 3.0.41.3 by misberner at Tue Apr  7 22:16:19 UTC 2020
+3.0.11 3.0.41.4  # Rox release 3.0.41.4 by kwajdowicz at Fri Apr 10 22:14:33 UTC 2020
+3.0.11 3.0.42.0  # Rox release 3.0.42.0 by kwajdowicz at Wed Apr 22 23:40:56 UTC 2020
+3.0.13 3.0.43.0  # Rox release 3.0.43.0 by kwajdowicz at Fri May 15 23:55:24 UTC 2020
+3.0.13 3.0.43.90  # Rox release 3.0.43.90 by viswajithiii at Tue May 19 19:03:06 UTC 2020
+3.0.13 3.0.43.1  # Rox release 3.0.43.1 by viswajithiii at Wed May 20 05:47:09 UTC 2020
+3.0.13-22-g13b9285325 3.0.44.0  # Rox release 3.0.44.0 by kwajdowicz at Thu Jun  4 05:14:09 UTC 2020
+3.0.15 3.0.44.1  # Rox release 3.0.44.1 by kwajdowicz at Fri Jun 12 05:05:47 UTC 2020
+3.0.16 3.0.45.0  # Rox release 3.0.45.0 by kwajdowicz at Wed Jun 24 23:31:00 UTC 2020
+3.0.16 3.0.45.1  # Rox release 3.0.45.1 by viswajithiii at Thu Jul  2 02:58:20 UTC 2020
+3.0.17 3.0.46.0  # Rox release 3.0.46.0 by gavin-stackrox at Thu Jul 16 00:57:54 UTC 2020
+3.0.18 3.0.47.0  # Rox release 3.0.47.0 by kwajdowicz at Thu Aug  6 05:42:47 UTC 2020
+3.0.18 3.0.47.1  # Rox release 3.0.47.1 by viswajithiii at Fri Aug  7 23:57:09 UTC 2020
+3.0.18 3.0.47.2  # Rox release 3.0.47.2 by viswajithiii at Thu Aug 13 02:03:03 UTC 2020
+3.1.0 3.0.48.0  # Rox release 3.0.48.0 by kwajdowicz at Thu Aug 27 06:39:54 UTC 2020
+3.1.0 3.0.48.1  # Rox release 3.0.48.1 by kwajdowicz at Fri Sep  4 18:41:15 UTC 2020
+3.1.1 3.0.49.0  # Rox release 3.0.49.0 by kwajdowicz at Wed Sep 16 22:18:41 UTC 2020
+3.1.1 3.0.49.1  # Rox release 3.0.49.1 by viswajithiii at Fri Sep 18 19:00:38 UTC 2020
+3.1.1 3.0.49.2  # Rox release 3.0.49.2 by kwajdowicz at Sat Sep 26 01:33:14 UTC 2020
+3.1.3 3.0.50.0  # Rox release 3.0.50.0 by kwajdowicz at Thu Oct  8 16:49:47 UTC 2020
+3.1.3 3.0.51.0  # Rox release 3.0.51.0 (manual update by misberner)
+3.1.4 3.0.51.1  # Rox release 3.0.51.1 by kwajdowicz at Thu Nov  5 03:25:19 UTC 2020
+3.1.7 3.0.52.0  # Rox release 3.0.52.0 by kwajdowicz at Thu Nov 19 06:26:26 UTC 2020
+3.1.8 3.0.52.1  # Rox release 3.0.52.1 by kwajdowicz at Tue Dec  8 06:24:50 UTC 2020
+3.1.9 3.0.53.0  # Rox release 3.0.53.0 by kwajdowicz at Thu Dec 17 04:20:52 UTC 2020
+3.1.12 3.0.55.0  # Rox release 3.0.55.0 by kwajdowicz at Thu Feb  4 05:56:08 UTC 2021
+3.1.14 3.0.56.0  # Rox release 3.0.56.0 by kwajdowicz at Thu Feb 25 05:06:30 UTC 2021
+3.1.15 3.0.56.1  # Rox release 3.0.56.1 by connorgorman at Mon Mar  8 20:19:40 UTC 2021


### PR DESCRIPTION
We have a ~6 month support policy (which used to correspond to 9 releases, now less due to the changed release cadence).

Remove all versions from the `RELEASED_VERSIONS` file that were released more than 6 months ago; this will reduce the amount of effort required for building collector modules.