### PR TITLE
Prevent CI VMs from locking on password prompt

### DIFF
--- a/.circleci/envbuilder.sh
+++ b/.circleci/envbuilder.sh
@@ -111,7 +111,7 @@ gcpSSHReady() {
 
   local retryCount=6
   for _ in $(seq 1 $retryCount ); do
-    gcloud compute ssh --strict-host-key-checking=no --ssh-key-file="${GCP_SSH_KEY_FILE}" "${GCP_VM_USER}@${GCP_VM_NAME}" --command "whoami" \
+    gcloud compute ssh --strict-host-key-checking=no --ssh-flag="-o PasswordAuthentication=no" --ssh-key-file="${GCP_SSH_KEY_FILE}" "${GCP_VM_USER}@${GCP_VM_NAME}" --command "whoami" \
       && exitCode=0 && break || exitCode=$? && sleep 15
   done
 


### PR DESCRIPTION
Flatcar integration tests have been failing systematically due to them locking ssh connections on a password prompt, this PR works around that problem by explicitly asking for no password prompt the first time VMs are ssh'd into. This is not a fix to the underlying problem but I believe it to be enough to get integration tests to work on a more consistent manner.

At the time of writing I've ran ITs 3 times and have not encountered any issues on the flatcar VMs that fail pretty consistently on the master branch.