### PR TITLE
Ignore scripts directory created through 'make image'

### DIFF
--- a/collector/container/rhel/.gitignore
+++ b/collector/container/rhel/.gitignore
@@ -1,4 +1,4 @@
 bundle.tar.gz
 bundle.tar.gz.sha512
 prebuild.sh
-scripts/
+/scripts/


### PR DESCRIPTION
This a simple PR that adds `scripts/` to the rhel container `.gitignore` file. The directory gets created automatically when running `make image` and 2 scripts are copied into it, which remain there and pollute the local repo.