### PR TITLE
Allow newer builds of RHEL 7 to use eBPF

### DIFF
--- a/collector/container/scripts/bootstrap.sh
+++ b/collector/container/scripts/bootstrap.sh
@@ -202,7 +202,7 @@ function rhel76_host() {
             # Extract build id: 3.10.0-957.10.1.el7.x86_64 -> 957
             local kernel_build_id
             kernel_build_id=$(echo "$KERNEL_VERSION" | cut -d. -f3 | cut -d- -f2)
-            if [[ ${kernel_build_id} -ge 957 ]] && [[ ${kernel_build_id} -lt 1062 ]] ; then
+            if [[ ${kernel_build_id} -ge 957 ]]; then
                 return 0
             fi
         fi

--- a/integration-tests/executor.go
+++ b/integration-tests/executor.go
@@ -100,6 +100,12 @@ func isSelinuxPermissiveNeeded() bool {
 	if strings.Contains(vmType, "coreos") {
 		return true
 	}
+	if strings.Contains(vmType, "rhel-7") {
+		collectionMethod := ReadEnvVarWithDefault("COLLECTION_METHOD", "kernel_module")
+		if collectionMethod == "ebpf" {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Small PR to enable newer builds of RHEL 7 to use eBPF as the collection method