### PR TITLE
Add CircleCI configuration validation to pre-commit

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -5,3 +5,9 @@ if ! make -C collector check-staged; then
 	echo "Use the '--no-verify' flag in order to bypass the pre-commit check altogether."
 	exit 1
 fi
+
+# Validate CircleCI configuration if it was modified and the CLI is available
+if command -v circleci >/dev/null && git diff --name-only --cached | grep -qE '^\.circleci/config\.yml$'; then
+	echo "Validating CircleCI configuration..."
+	circleci config validate
+fi


### PR DESCRIPTION
This PR adds an additional step to the `pre-commit` git hook. If the `circleci` CLI is available locally and the `.circleci/config.yml` file has staged changes, the configuration will be validated before it is committed, stopping the commit from happening if the configuration is invalid. If the `circleci` CLI is unavailable in the system, no action is taken.