### PR TITLE
Fix 5.15.0-1 compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,7 +570,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 32
+    parallelism: 8
     environment:
     - BUILD_CONTAINER_TAG: stackrox/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: stackrox/collector-builder:kobuilder-cache


### PR DESCRIPTION
This PR adds gcc-11 to the hirsute builder image in order for it to handle newer kernels built with this tool.