### PR TITLE
Fix clang and llvm version mismatch on impish builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,7 +570,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 32
+    parallelism: 8
     environment:
     - BUILD_CONTAINER_TAG: stackrox/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: stackrox/collector-builder:kobuilder-cache


### PR DESCRIPTION
eBPF integration tests on Fedora 35 are failing when trying to load programs into a map, I suspect a mismatch on the impish builder might be the culprit.