### PR TITLE
Bump CI cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,8 +431,8 @@ jobs:
     - restore_cache:
         name: Restore Kernel module build cache
         keys:
-          - kernel-module-cache-v17-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
-          - kernel-module-cache-v17-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-master-
+          - kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
+          - kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-master-
 
     - run:
         name: Unpack module sources
@@ -805,7 +805,7 @@ jobs:
 
     - save_cache:
         name: Saving Kernel module build cache
-        key: kernel-module-cache-v17-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
+        key: kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
         paths:
           - /tmp/cache/
 


### PR DESCRIPTION
This PR bumps the CI cache version, in order to force a rebuild of broken eBPF probes