### PR TITLE
Update docker version to fix the update support packages job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1419,7 +1419,7 @@ jobs:
               circleci step halt
             fi
 
-      - setup_remote_docker
+      - setup_remote_docker:
           version: 20.10.11
       - stackrox-io-login
       - gcloud-init


### PR DESCRIPTION
**Description**

The `update-support-packages` job is [failing](https://app.circleci.com/pipelines/github/stackrox/collector/6787/workflows/33040080-2c47-48b8-88bb-d79ce2c3aa33/jobs/142569) on master, specifically on the `collector:3.5.0` image. 

After investigation, it was determined that collector version 3.5.0 is the first collector version to be based on ubi:8.5 and the newer ubi image's root filesystem cannot be read by a non-privileged execution of a container with the image.

I'm not sure what particular setting (seccomp?) that changed between ubi versions 8.4 and 8.5 is the root cause. Updating the remote docker version setting fixes the issue.

Sshing into Circle job, running image `apollo-ci:collector-0.3.13` using Circle's remote docker ('setup_remote_docker') with the default remote docker version.
```
  circleci@230ade7ade6b:$ docker version
  Client: Docker Engine - Community
   Version:           19.03.12
   API version:       1.32
   Go version:        go1.13.10
   Git commit:        48a66213fe
   Built:             Mon Jun 22 15:42:53 2020
   OS/Arch:           linux/amd64
   Experimental:      false

  Server:
   Engine:
    Version:          17.09.0-ce
    API version:      1.32 (minimum version 1.12)
    Go version:       go1.8.3
    Git commit:       afdb6d4
    Built:            Tue Sep 26 22:40:56 2017
    OS/Arch:          linux/amd64
    Experimental:     false

  circleci@230ade7ade6b:$ docker run --rm -it registry.access.redhat.com/ubi8/ubi:8.4 ls /
  bin   dev  home  lib64       media  opt   root  sbin  sys  usr
  boot  etc  lib   lost+found  mnt    proc  run   srv   tmp  var

  circleci@230ade7ade6b:$ docker run --rm -it registry.access.redhat.com/ubi8/ubi:8.5 ls /
  ls: cannot access '/': Operation not permitted
```

**Testing** 

- [x] The `update-support-packages` job passes with `test-support-packages` label enabled.