### PR TITLE
Update rox-ci-image to 0.3.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
 
 defaultImage: &defaultImage
   docker:
-  - image: "quay.io/rhacs-eng/apollo-ci:collector-0.3.21"
+  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.21"
     auth:
       username: $QUAY_RHACS_ENG_RO_USERNAME
       password: $QUAY_RHACS_ENG_RO_PASSWORD


### PR DESCRIPTION
This PR exists to ensure that changes introduced in https://github.com/stackrox/rox-ci-image/pull/96 do not break anything in collector. 

This is a brother-PR for https://github.com/stackrox/stackrox/pull/84 and https://github.com/stackrox/collector/pull/527

Want to update? See what's new in release notes [rox-ci-image/releases](https://github.com/stackrox/rox-ci-image/releases) (the refactorings in `bash-wrapper` and `cci-export` apply to collector, the rest may be transparent)