### PR TITLE
ROX-8830: Bump ci-image to test recent changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
 
 defaultImage: &defaultImage
   docker: 
-  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:snapshot-collector-0.3.22-10-gb5ac40be83" # TODO(do not merge): After upstream PR is merged, cut a tag and update this
+  - image: "<< pipeline.parameters.quay-repo >>/apollo-ci:collector-0.3.24"
     auth:
       username: $QUAY_RHACS_ENG_RO_USERNAME
       password: $QUAY_RHACS_ENG_RO_PASSWORD


### PR DESCRIPTION
This PR exists to make sure that the changes from:
- https://github.com/stackrox/rox-ci-image/pull/99
- and https://github.com/stackrox/rox-ci-image/pull/102

are not breaking anything.

Brother-PRs:
- https://github.com/stackrox/stackrox/pull/190/ && https://github.com/stackrox/stackrox/pull/241
- https://github.com/stackrox/scanner/pull/572