### PR TITLE
Prevent overwriting cache image for dockerized drivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
     default: "quay.io/rhacs-eng"
   dockerized-parallel:
     type: integer
-    default: 32
+    default: 8
   dockerized-cache-tag:
     type: string
     default: cache-v1


### PR DESCRIPTION
This PR fixes a bug where the cache image is created empty when running with the output tag set to the cache tag, causing the cache to be flushed.