### PR TITLE
Output config parse errors

### DIFF
--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -205,7 +205,7 @@ CollectorArgs::checkCollectorConfig(const option::Option& option, bool msg) {
   bool parsingSuccessful = reader.parse(arg.c_str(), root);
   if (!parsingSuccessful) {
     if (msg) {
-      this->message = "A valid JSON configuration is required to start the collector. ";
+      this->message = "A valid JSON configuration is required to start the collector: ";
       this->message += reader.getFormattedErrorMessages();
     }
     return ARG_ILLEGAL;


### PR DESCRIPTION
When the configuration json contains errors and could not be parsed it's
hard to figure out what's wrong. The debugging message right before:

```
  CLOG(DEBUG) << "Incoming: " << arg;
```

doesn't seem to help, because no log level is set yet, and the default
one is INFO. The error message itself that collector shows also provides
no clues what exactly is wrong. Add getFormattedErrorMessages into the
output to make such situations easier to analyze.

The original output looks like:

```
[F 20220111 093539 collector.cpp:228] A valid JSON configuration is required to start the collector.
```

The modified:

```
[F 20220111 094050 collector.cpp:228] A valid JSON configuration is required to start the collector. * Line 1, Column 2
  Missing '}' or object member name
```