### PR TITLE
RS-413: Use job links in artifact locator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequire
 
 orbs:
   slack: circleci/slack@3.4.2
-  ci-artifacts: stackrox/ci-artifacts-orb@0.0.11
+  ci-artifacts: stackrox/ci-artifacts-orb@0.1.0
 
 commands:
   initcommand:


### PR DESCRIPTION
As per title. Uses the orb with this approach.