### PR TITLE
Remove dockerized drivers steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequire
   - images
   - ubi-image
   - integration-test-local
-  - dockerized-build-collector
+  # - dockerized-build-collector
 
 orbs:
   slack: circleci/slack@3.4.2
@@ -1378,43 +1378,43 @@ workflows:
         <<: *runOnAllTagsWithDockerIOPushCtx
         requires:
         - builder
-    - dockerized-task-file:
-        <<: *runOnAllTags
-        context:
-          - docker-io-pull
-          - quay-rhacs-eng-readonly
-          - redhat-developer-account-login
-        requires:
-        - lint
-    - dockerized-build-drivers:
-        <<: *runOnAllTags
-        context:
-          - docker-io-pull
-          - quay-rhacs-eng-readwrite
-          - redhat-developer-account-login
-        requires:
-        - dockerized-task-file
-    - dockerized-unify-images:
-        <<: *runOnAllTags
-        context:
-          - docker-io-pull
-          - quay-rhacs-eng-readwrite
-        requires:
-          - dockerized-build-drivers
-    - dockerized-check-failures:
-        <<: *runOnAllTags
-        context:
-          - quay-rhacs-eng-readonly
-        requires:
-          - dockerized-unify-images
-    - dockerized-build-collector:
-        <<: *runOnAllTags
-        context:
-          - docker-io-push
-          - quay-rhacs-eng-readonly
-        requires:
-          - dockerized-unify-images
-          - images
+    # - dockerized-task-file:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - docker-io-pull
+    #       - quay-rhacs-eng-readonly
+    #       - redhat-developer-account-login
+    #     requires:
+    #     - lint
+    # - dockerized-build-drivers:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - docker-io-pull
+    #       - quay-rhacs-eng-readwrite
+    #       - redhat-developer-account-login
+    #     requires:
+    #     - dockerized-task-file
+    # - dockerized-unify-images:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - docker-io-pull
+    #       - quay-rhacs-eng-readwrite
+    #     requires:
+    #       - dockerized-build-drivers
+    # - dockerized-check-failures:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - quay-rhacs-eng-readonly
+    #     requires:
+    #       - dockerized-unify-images
+    # - dockerized-build-collector:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - docker-io-push
+    #       - quay-rhacs-eng-readonly
+    #     requires:
+    #       - dockerized-unify-images
+    #       - images
     - prepare-kernels:
         <<: *runOnAllTagsWithDockerIOPullCtx
         requires:
@@ -1472,7 +1472,7 @@ workflows:
         matrix:
           parameters:
             image_family: [cos-stable, cos-beta, cos-dev, cos-81-lts, cos-85-lts, cos-89-lts]
-            dockerized: [false, true]
+            dockerized: [false]
     - integration-test:
         <<: *runOnAllTagsWithIntegrationTestRequires
         name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -1481,7 +1481,7 @@ workflows:
           parameters:
             image_family: [rhel-7, rhel-8]
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
     - integration-test:
         <<: *runOnAllTagsWithIntegrationTestRequires
         name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -1490,7 +1490,7 @@ workflows:
           parameters:
             image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2104]
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
           exclude:
             # Failing due to GLIC 2.33 not available on ubi 8
             - image_family: ubuntu-2104
@@ -1504,7 +1504,7 @@ workflows:
           parameters:
             image_family: [sles-12, sles-15]
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
           exclude:
             - image_family: sles-12
               collection_method: ebpf
@@ -1520,7 +1520,7 @@ workflows:
         matrix:
           parameters:
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
     - integration-test:
         <<: *runOnAllTagsWithIntegrationTestRequires
         name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -1529,7 +1529,7 @@ workflows:
         matrix:
           parameters:
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
           exclude:
             # Failing due to GLIC 2.33 not available on ubi 8
             - collection_method: module
@@ -1542,7 +1542,7 @@ workflows:
         matrix:
           parameters:
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
           exclude:
             # Failing due to GLIC 2.33 not available on ubi 8
             - collection_method: module
@@ -1556,7 +1556,7 @@ workflows:
         matrix:
           parameters:
             collection_method: [module, ebpf]
-            dockerized: [false, true]
+            dockerized: [false]
             image_version: [576-2-9e22b9]
           exclude:
             # Failing due to dockerized module not being built (requires gcc-10).


### PR DESCRIPTION
This PR removes dockerized drivers steps while we work on fixing the current caching issue.