### PR TITLE
Jv/rox 8809 reduce shellcheck errors part 1

### DIFF
--- a/builder/build/build-ubi.sh
+++ b/builder/build/build-ubi.sh
@@ -6,6 +6,7 @@
 
 set -eux
 
+# shellcheck source=SCRIPTDIR/../install/versions.sh
 source ./builder/install/versions.sh
 
 export WITH_RHEL8_RPMS="true"
@@ -38,14 +39,14 @@ ADDRESS_SANITIZER="${ADDRESS_SANITIZER:-false}"
 
 cp -a collector/generated src/generated
 
-if [ $ADDRESS_SANITIZER = "true" ]; then
+if [ "$ADDRESS_SANITIZER" = "true" ]; then
     # Needed for address sanitizer to work. See https://github.com/grpc/grpc/issues/22238.
     # When Collector is built with address sanitizer it sets GRPC_ASAN_ENABLED, which changes a struct in the grpc library.
     # If grpc is compiled without that flag and is then linked with Collector the struct will have
     # two different definitions and Collector will crash when trying to connect to a grpc server.
-    for file in $(grep -rl port_platform.h src/generated --include=*.h); do
-        sed -i 's|#include <grpc/impl/codegen/port_platform.h>|#include <grpc/impl/codegen/port_platform.h>\n#ifdef GRPC_ASAN_ENABLED\n#  undef GRPC_ASAN_ENABLED\n#endif|' $file
-    done
+    while read -r file; do
+        sed -i 's|#include <grpc/impl/codegen/port_platform.h>|#include <grpc/impl/codegen/port_platform.h>\n#ifdef GRPC_ASAN_ENABLED\n#  undef GRPC_ASAN_ENABLED\n#endif|' "$file"
+    done < <(grep -rl port_platform.h src/generated --include=*.h)
 fi
 
 echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig

--- a/builder/install/99-strip-binaries.sh
+++ b/builder/install/99-strip-binaries.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-while read f; do
+while read -r f; do
     [[ -f "$f" ]] || continue
     # Only strip executable files that are ELFs, as well as anything that looks like a
     # .so or .a file.

--- a/builder/install/install.sh
+++ b/builder/install/install.sh
@@ -6,6 +6,7 @@ export LICENSE_DIR="/THIRD_PARTY_NOTICES"
 
 mkdir -p "${LICENSE_DIR}"
 cd /install-tmp/
+# shellcheck source=SCRIPTDIR/versions.sh
 source ./versions.sh
 for f in [0-9][0-9]-*.sh; do
     ./"$f"

--- a/kernel-modules/support-packages/03-group-by-module-version.sh
+++ b/kernel-modules/support-packages/03-group-by-module-version.sh
@@ -14,7 +14,6 @@ MD_DIR="$1"
 
 for version_dir in "${MD_DIR}/collector-versions"/*; do
     [[ -d "$version_dir" ]] || continue
-    version="$(basename "$version_dir")"
 
     module_version="$(< "${version_dir}/MODULE_VERSION")"
 

--- a/scripts/push-as-manifest-list.sh
+++ b/scripts/push-as-manifest-list.sh
@@ -19,6 +19,7 @@ docker tag "$image" "$arch_image"
 
 # Try pushing image a few times for the case when quay.io has issues such as "unknown blob"
 pushed=0
+# shellcheck disable=SC2034 # This turns off the check for unused variables on the next line
 for i in {1..5}; do
     if docker push "$arch_image"; then
         pushed=1


### PR DESCRIPTION
## Description

Fixed shellcheck errors and smells in

builder/build/build-collector.sh
builder/build/build-ubi.sh
builder/install/99-strip-binaries.sh
builder/install/install.sh
kernel-modules/support-packages/03-group-by-module-version.sh
scripts/push-as-manifest-list.sh

## Checklist
- [x] Investigated and inspected CI test results
- [x] CI test results with Address Sanitizer
- [x] CI test results with debug and Valgrind

**Automated testing**
No automated testing was added, as no new functionality was added. Some changes were made to scripts. Manual testing relevant to these scripts will be done.

If any of these don't apply, please comment below.

## Testing Performed

CircleCI should be sufficient to test the changes here. The changes have a potential to effect VALGRIND, compiling Collector in debug mode, address sanitizer, the reload-released-images CI job, and the update-support-packages CI job.
