### PR TITLE
Jv/improve missing probe troubleshooting script

### DIFF
--- a/utilities/troubleshooting/missing-probe.sh
+++ b/utilities/troubleshooting/missing-probe.sh
@@ -157,7 +157,7 @@ else
     probe_type_array=("$probe_type")
 fi
 
-for pt in "${probe_type_array[@]}"; do	
+for pt in "${probe_type_array[@]}"; do
     check_if_probe_exists_for_module_version "$module_version" "$pt"
     check_if_probe_is_marked_unavailable_for_module_version "$module_version" "$pt"
     check_if_probe_exists_for_any_module_version "$pt"


### PR DESCRIPTION
## Description

Three improvements to the troubleshooting/missing-probe.sh script were made. The check for the kernel in KERNEL_VERSIONS was fixed. A check for .unavail files was added. The script now checks for mod and bpf probes in one run instead of taking the probe type as an option.

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
There is no testing for the missing-probe.sh script.

## Testing Performed

Ran

./missing-probe.sh 4.18.0-305.28.1.rt7.100.el8_4.x86_64 b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62

There are no probes for this and it is not in KERNEL_VERSION. The script correctly identified this.

-----------------------------------------------------------------------------------
Ran

./missing-probe.sh 4.9.16-coreos-r1 b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62

The .unavail file exists for the ebpf probe and that is reported by the script

------------------------------------------------------------------------------------
Ran

./missing-probe.sh 3.10.0-1160.11.1.el7.x86_64 b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62

The .unvail files do not exist. Worked as expected.
