### PR TITLE
Stop shfmt from checking removed scripts

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -14,7 +14,7 @@ if command -v shfmt --version > /dev/null; then
         if ! shfmt -d "$file"; then
             shfmt_status=1
         fi
-    done < <(git diff --name-only --cached --relative | grep -E '\.sh$$|^githooks/')
+    done < <(git diff --name-only --cached --relative --diff-filter=d | grep -E '\.sh$$|^githooks/')
 
     if ((shfmt_status)); then
         echo "Format errors found! Run 'make shfmt-format' in order to fix them."


### PR DESCRIPTION
## Description

This Pr fixes a smell problem with the pre-commit git hook, which fails if a script is deleted.

When comitting a deleted script, `shfmt` fails with the following message:
```
lstat kernel-modules/dockerized/scripts/compile.sh: no such file or directory
Format errors found! Run 'make shfmt-format' in order to fix them.
Use the '--no-verify' flag in order to bypass the pre-commit check altogether.
```

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

## Testing Performed

This is a simple git hook fix, manual testing should be enough
