### PR TITLE
ROX-9140: Do no use artifact SA if not necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequire
 
 orbs:
   slack: circleci/slack@3.4.2
-  ci-artifacts: stackrox/ci-artifacts-orb@dev:41faaeb
+  ci-artifacts: stackrox/ci-artifacts-orb@0.1.1
 
 commands:
   initcommand:


### PR DESCRIPTION
## Description

https://github.com/stackrox/ci-artifacts-orb/pull/18

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

CI is sufficient - failures are not related to this PR. The artifacts are copied as expected.