### PR TITLE
Remove SLES-15 SP2 integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1523,15 +1523,16 @@ workflows:
             - image_family: sles-12
               collection_method: ebpf
               dockerized: true
-    - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-sles-15-sp2-sap<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: suse-sap
-        image_family: sles-15-sp2-sap
-        matrix:
-          parameters:
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
+    # Removed while solving ROX-9180
+    # - integration-test:
+    #     <<: *runOnAllTagsWithIntegrationTestRequires
+    #     name: test-<< matrix.collection_method >>-sles-15-sp2-sap<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+    #     vm_type: suse-sap
+    #     image_family: sles-15-sp2-sap
+    #     matrix:
+    #       parameters:
+    #         collection_method: [module, ebpf]
+    #         dockerized: [false, true]
     - integration-test:
         <<: *runOnAllTagsWithIntegrationTestRequires
         name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -1596,8 +1597,9 @@ workflows:
         - test-ebpf-sles-15
         - test-module-sles-15
         - test-module-sles-12
-        - test-ebpf-sles-15-sp2-sap
-        - test-module-sles-15-sp2-sap
+        # Removed while solving ROX-9180
+        # - test-ebpf-sles-15-sp2-sap
+        # - test-module-sles-15-sp2-sap
         - test-ebpf-flatcar-stable
         - test-module-flatcar-stable
         - test-ebpf-fedora-coreos-stable


### PR DESCRIPTION
## Description

As described in [ROX-9180](https://issues.redhat.com/browse/ROX-9180), the newest kernel for SLES-15 SP2 is not being crawled. This PR comments out the affected tests while we investigate the issue further.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

No further testing required other than checking that CI runs correctly and the affected tests are no longer executed.