### PR TITLE
Retry on some CI operations

### DIFF
--- a/.circleci/envbuilder.sh
+++ b/.circleci/envbuilder.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# shellcheck source=SCRIPTDIR/retry.sh
+source "retry.sh"
+
 createGCPVM() {
     local GCP_VM_NAME="$1"
     shift
@@ -17,7 +20,7 @@ createGCPVM() {
     for zone in us-central1-a us-central1-b; do
         echo "Trying zone $zone"
         gcloud config set compute/zone "${zone}"
-        if gcloud compute instances create \
+        if retry gcloud compute instances create \
             --image-family "$GCP_IMAGE_FAMILY" \
             --image-project "$GCP_IMAGE_PROJECT" \
             --service-account=circleci-collector@stackrox-ci.iam.gserviceaccount.com \
@@ -60,7 +63,7 @@ createGCPVMFromImage() {
     for zone in us-central1-a us-central1-b; do
         echo "Trying zone $zone"
         gcloud config set compute/zone "${zone}"
-        if gcloud compute instances create \
+        if retry gcloud compute instances create \
             --image "$GCP_IMAGE_NAME" \
             --image-project "$GCP_IMAGE_PROJECT" \
             --service-account=circleci-collector@stackrox-ci.iam.gserviceaccount.com \

--- a/.circleci/retry.sh
+++ b/.circleci/retry.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function retry {
+    local n=1
+    local max=5
+    local delay=5
+    while true; do
+        # shellcheck disable=SC2015 # an info note, break is needed here to stop
+        # after the command was successfully executed
+        "$@" && break || {
+            if [[ $n -lt $max ]]; then
+                ((n++))
+                echo "Command failed. Attempt $n/$max:"
+                sleep $delay
+            else
+                echo "The command has failed after $n attempts." >&2
+                exit 1
+            fi
+        }
+    done
+}


### PR DESCRIPTION
## Description

Some operations performed during integration testing have a small chance
to fail due to unrelated factors e.g. networking failures. To make tests
more robust add simple uniform retries with max number of loops for:

* pulling images with docker
* creating VMs with gcloud

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

I've run retry script locally with failing/succeeding docker pull.