### PR TITLE
Make necessary changes for compatibility with cPaaS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
     default: "quay.io/rhacs-eng"
   dockerized-parallel:
     type: integer
-    default: 8
+    default: 32
   dockerized-cache-tag:
     type: string
     default: cache-v2
@@ -456,7 +456,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 8
+    parallelism: 32
     environment:
     - BUILD_CONTAINER_TAG: stackrox/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: stackrox/collector-builder:kobuilder-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
     default: "quay.io/rhacs-eng"
   dockerized-parallel:
     type: integer
-    default: 32
+    default: 8
   dockerized-cache-tag:
     type: string
     default: cache-v2
@@ -456,7 +456,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 32
+    parallelism: 8
     environment:
     - BUILD_CONTAINER_TAG: stackrox/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: stackrox/collector-builder:kobuilder-cache

--- a/.circleci/kernels/build-modules.sh
+++ b/.circleci/kernels/build-modules.sh
@@ -19,7 +19,7 @@ for task_file in ~/kobuild-tmp/local-build-tasks.*; do
         -v "${shard_output_dir}:/output" \
         --tmpfs /scratch:exec \
         "build-kernel-modules-${flavor}" \
-        build-kos < "$task_file"
+        build-wrapper.sh < "$task_file"
 done
 sudo chown -R "$(id -u):$(id -g)" "$shard_output_dir"
 find "${shard_output_dir}/FAILURES" -type d -empty -depth -exec rmdir {} \;

--- a/kernel-modules/build/Dockerfile
+++ b/kernel-modules/build/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get autoremove -y
 RUN dpkg --compare-versions $(dpkg-query -f='${Version}' --show binutils) lt 2.31
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile
+++ b/kernel-modules/build/Dockerfile
@@ -38,6 +38,7 @@ RUN dpkg --compare-versions $(dpkg-query -f='${Version}' --show binutils) lt 2.3
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 WORKDIR /scratch

--- a/kernel-modules/build/Dockerfile.fc36
+++ b/kernel-modules/build/Dockerfile.fc36
@@ -20,7 +20,7 @@ RUN dnf update -y || true; \
     mkdir -p /output; \
     dnf autoremove -y
 
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.fc36
+++ b/kernel-modules/build/Dockerfile.fc36
@@ -21,6 +21,7 @@ RUN dnf update -y || true; \
     dnf autoremove -y
 
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 WORKDIR /scratch

--- a/kernel-modules/build/Dockerfile.hirsute
+++ b/kernel-modules/build/Dockerfile.hirsute
@@ -28,7 +28,7 @@ RUN apt-get update \
 RUN apt-get autoremove -y
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.hirsute
+++ b/kernel-modules/build/Dockerfile.hirsute
@@ -29,6 +29,7 @@ RUN apt-get autoremove -y
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 WORKDIR /scratch

--- a/kernel-modules/build/Dockerfile.linuxkit
+++ b/kernel-modules/build/Dockerfile.linuxkit
@@ -26,7 +26,7 @@ RUN rm -rf /usr/bin/clang \
  && ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.linuxkit
+++ b/kernel-modules/build/Dockerfile.linuxkit
@@ -27,6 +27,7 @@ RUN rm -rf /usr/bin/clang \
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 WORKDIR /scratch

--- a/kernel-modules/build/Dockerfile.modern
+++ b/kernel-modules/build/Dockerfile.modern
@@ -34,6 +34,7 @@ RUN apt-get autoremove -y
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 WORKDIR /scratch

--- a/kernel-modules/build/Dockerfile.modern
+++ b/kernel-modules/build/Dockerfile.modern
@@ -33,7 +33,7 @@ RUN rm -rf /usr/bin/clang \
 RUN apt-get autoremove -y
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.oracle
+++ b/kernel-modules/build/Dockerfile.oracle
@@ -19,7 +19,7 @@ RUN yum -y update && yum -y install yum-utils && \
     yum install -y rh-dotnet20-clang rh-dotnet20-llvm
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.oracle
+++ b/kernel-modules/build/Dockerfile.oracle
@@ -20,6 +20,7 @@ RUN yum -y update && yum -y install yum-utils && \
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 COPY oracle-entrypoint.sh /oracle-entrypoint.sh

--- a/kernel-modules/build/Dockerfile.redhat
+++ b/kernel-modules/build/Dockerfile.redhat
@@ -7,7 +7,7 @@ RUN yum -y groupinstall "Development Tools" && \
     ;
 
 RUN mkdir -p /output
-COPY build-kos /usr/bin/
+COPY build-kos /scripts/
 COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 

--- a/kernel-modules/build/Dockerfile.redhat
+++ b/kernel-modules/build/Dockerfile.redhat
@@ -8,6 +8,7 @@ RUN yum -y groupinstall "Development Tools" && \
 
 RUN mkdir -p /output
 COPY build-kos /usr/bin/
+COPY build-wrapper.sh /usr/bin/
 COPY prepare-src /usr/bin
 
 COPY redhat-entrypoint.sh /redhat-entrypoint.sh

--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -39,8 +39,8 @@ build_ko() (
 
         echo "Building collector module for kernel version ${kernel_version} and module version ${module_version}."
 
-        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${kernel_src_dir}" make clean
-        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${kernel_src_dir}" make -j 6 all
+        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${KERNEL_SRC_DIR}" make clean
+        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${KERNEL_SRC_DIR}" make -j 6 all
 
         collector_ko=collector.ko
         strip -g "$collector_ko"
@@ -89,7 +89,7 @@ build_ko() (
 
         echo "Building collector eBPF probe for kernel version ${kernel_version} and module version ${module_version}."
 
-        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${kernel_src_dir}" make -j 6 -C bpf
+        KERNELDIR="$kernel_build_dir" BUILD_ROOT="${KERNEL_SRC_DIR}" make -j 6 -C bpf
 
         collector_probe="bpf/probe.o"
 

--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -107,10 +107,3 @@ build_ko() (
         return 1
     fi
 )
-
-# The input is in the form <kernel-version> <module-version> <probe-type>.
-kernel_version="$1"
-module_version="$2"
-probe_type="$3"
-
-build_ko "$kernel_version" "$module_version" "${probe_type}"

--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -16,33 +16,6 @@ build_ko() (
         [[ -d "$module_src_dir" ]] || cp -r "/sources/${module_version}" "$module_src_dir"
     fi
 
-    local kernel_src_dir="/scratch/kernel-src/${kernel_version}"
-    if [[ ! -d "$kernel_src_dir" ]]; then
-        rm -rf /scratch/kernel-src/* 2> /dev/null || true
-        mkdir -p "$kernel_src_dir"
-        tar -C "$kernel_src_dir" -xzf "/bundles/bundle-${kernel_version}.tgz"
-    fi
-
-    [[ -f "${kernel_src_dir}/BUNDLE_BUILD_DIR" ]] || {
-        echo "No BUNDLE_BUILD_DIR entry found in kernel source bundle!"
-        return 1
-    }
-
-    local kernel_build_dir
-    kernel_build_dir="${kernel_src_dir}/$(cat "${kernel_src_dir}/BUNDLE_BUILD_DIR")"
-
-    [[ -f "${kernel_src_dir}/BUNDLE_UNAME" ]] || {
-        echo "No BUNDLE_UNAME entry found in kernel source bundle!"
-        return 1
-    }
-
-    # Extract bundle details
-    local bundle_uname bundle_version bundle_major bundle_distro
-    bundle_uname="$(cat "${kernel_src_dir}/BUNDLE_UNAME")"
-    bundle_version="$(cat "${kernel_src_dir}/BUNDLE_VERSION")"
-    bundle_major="$(cat "${kernel_src_dir}/BUNDLE_MAJOR")"
-    bundle_distro="$(cat "${kernel_src_dir}/BUNDLE_DISTRO")"
-
     cd "$module_src_dir"
 
     local rhel7_kernel_with_ebpf=false
@@ -135,39 +108,9 @@ build_ko() (
     fi
 )
 
-build_kos() {
-    while read -r -a line || [[ "${#line[@]}" -gt 0 ]]; do
-        local kernel_version="${line[0]}"
-        local module_version="${line[1]}"
-        local probe_type="${line[2]}"
+# The input is in the form <kernel-version> <module-version> <probe-type>.
+kernel_version="$0"
+module_version="$1"
+probe_type="$2"
 
-        failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
-        mkdir -p "$(dirname "$failure_output_file")"
-        if ! build_ko "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
-            echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
-        else
-            rm "$failure_output_file"
-        fi
-    done
-}
-
-DOCKERIZED=${DOCKERIZED:-0}
-
-if ((DOCKERIZED)); then
-    FAILURE_DIR="/FAILURES"
-    MODULE_BASE_DIR="/kernel-modules"
-    mkdir -p "$FAILURE_DIR"
-    mkdir -p "$MODULE_BASE_DIR"
-else
-    FAILURE_DIR="/output/FAILURES"
-    MODULE_BASE_DIR="/output"
-fi
-
-# The input is in the form <kernel-version> <module-version>. Sort it to make sure that we first build all modules
-# for a given kernel version before advancing to the next kernel version.
-sort | uniq | build_kos
-
-# Remove empty directories
-if ((DOCKERIZED)); then
-    find "$FAILURE_DIR" -mindepth 1 -type d -empty -delete
-fi
+build_ko "$kernel_version" "$module_version" "${probe_type}"

--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -109,8 +109,8 @@ build_ko() (
 )
 
 # The input is in the form <kernel-version> <module-version> <probe-type>.
-kernel_version="$0"
-module_version="$1"
-probe_type="$2"
+kernel_version="$1"
+module_version="$2"
+probe_type="$3"
 
 build_ko "$kernel_version" "$module_version" "${probe_type}"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -exuo pipefail
+
 # This script handles decompressing the bundles tarballs and setting environment
 # variables needed by the kernel driver compilation script.
 

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# This script handles decompressing the bundles tarballs and setting environment
+# variables needed by the kernel driver compilation script.
+
+KERNEL_SRC_DIR=""
+
+extract_bundle() {
+    local kernel_version="$1"
+
+    KERNEL_SRC_DIR="/scratch/kernel-src/${kernel_version}"
+
+    if [[ ! -d "$KERNEL_SRC_DIR" ]]; then
+        rm -rf /scratch/kernel-src/* 2> /dev/null || true
+        mkdir -p "$KERNEL_SRC_DIR"
+        tar -C "$KERNEL_SRC_DIR" -xzf "/bundles/bundle-${kernel_version}.tgz"
+    fi
+
+    [[ -f "${KERNEL_SRC_DIR}/BUNDLE_BUILD_DIR" ]] || {
+        echo "No BUNDLE_BUILD_DIR entry found in kernel source bundle!"
+        return 1
+    }
+
+    [[ -f "${KERNEL_SRC_DIR}/BUNDLE_UNAME" ]] || {
+        echo "No BUNDLE_UNAME entry found in kernel source bundle!"
+        return 1
+    }
+}
+
+export_env_variables() {
+    export bundle_uname
+    export bundle_version
+    export bundle_major
+    export bundle_distro
+    export kernel_build_dir
+
+    bundle_uname="$(cat "${KERNEL_SRC_DIR}/BUNDLE_UNAME")"
+    bundle_version="$(cat "${KERNEL_SRC_DIR}/BUNDLE_VERSION")"
+    bundle_major="$(cat "${KERNEL_SRC_DIR}/BUNDLE_MAJOR")"
+    bundle_distro="$(cat "${KERNEL_SRC_DIR}/BUNDLE_DISTRO")"
+    kernel_build_dir="${KERNEL_SRC_DIR}/$(cat "${KERNEL_SRC_DIR}/BUNDLE_BUILD_DIR")"
+}
+
+clean_env_variables() {
+    unset bundle_uname
+    unset bundle_version
+    unset bundle_major
+    unset bundle_distro
+    unset kernel_build_dir
+}
+
+build() {
+    while read -r -a line || [[ "${#line[@]}" -gt 0 ]]; do
+        local kernel_version="${line[0]}"
+        local module_version="${line[1]}"
+        local probe_type="${line[2]}"
+
+        if extract_bundle "${kernel_version}"; then
+            echo >&2 "Failed to extract kernel bundle for version '${kernel_version}'"
+            exit 1
+        fi
+
+        export_env_variables
+
+        failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
+        mkdir -p "$(dirname "$failure_output_file")"
+        if ! ./build-kos "${kernel_version}" "${module_version}" "${probe_type}"; then
+            echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
+        else
+            rm "$failure_output_file"
+        fi
+
+        clean_env_variables
+    done
+}
+
+DOCKERIZED=${DOCKERIZED:-0}
+
+if ((DOCKERIZED)); then
+    FAILURE_DIR="/FAILURES"
+    export MODULE_BASE_DIR="/kernel-modules"
+    mkdir -p "$FAILURE_DIR"
+    mkdir -p "$MODULE_BASE_DIR"
+else
+    FAILURE_DIR="/output/FAILURES"
+    export MODULE_BASE_DIR="/output"
+fi
+
+# The input is in the form <kernel-version> <module-version>. Sort it to make sure that we first build all modules
+# for a given kernel version before advancing to the next kernel version.
+sort | uniq | build
+
+# Remove empty directories
+if ((DOCKERIZED)); then
+    find "$FAILURE_DIR" -mindepth 1 -type d -empty -delete
+fi

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -68,7 +68,7 @@ build() {
 
         failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
         mkdir -p "$(dirname "$failure_output_file")"
-        if ! ./build-kos "${kernel_version}" "${module_version}" "${probe_type}"; then
+        if ! build-kos "${kernel_version}" "${module_version}" "${probe_type}"; then
             echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
         else
             rm "$failure_output_file"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 KERNEL_SRC_DIR=""
 
+# shellcheck source=/dev/null
+source "/scripts/build-kos"
+
 extract_bundle() {
     local kernel_version="$1"
 
@@ -71,7 +74,7 @@ build() {
 
         failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
         mkdir -p "$(dirname "$failure_output_file")"
-        if ! build-kos "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
+        if ! build_ko "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
             echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
         else
             rm "$failure_output_file"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -80,6 +80,8 @@ build() {
 
 DOCKERIZED=${DOCKERIZED:-0}
 
+export DOCKERIZED
+
 if ((DOCKERIZED)); then
     FAILURE_DIR="/FAILURES"
     export MODULE_BASE_DIR="/kernel-modules"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -71,7 +71,7 @@ build() {
 
         failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
         mkdir -p "$(dirname "$failure_output_file")"
-        if ! build-kos "${kernel_version}" "${module_version}" "${probe_type}"; then
+        if ! build_ko "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
             echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
         else
             rm "$failure_output_file"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -71,7 +71,7 @@ build() {
 
         failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
         mkdir -p "$(dirname "$failure_output_file")"
-        if ! build_ko "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
+        if ! build_kos "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
             echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
         else
             rm "$failure_output_file"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -10,6 +10,7 @@ KERNEL_SRC_DIR=""
 extract_bundle() {
     local kernel_version="$1"
 
+    export KERNEL_SRC_DIR
     KERNEL_SRC_DIR="/scratch/kernel-src/${kernel_version}"
 
     if [[ ! -d "$KERNEL_SRC_DIR" ]]; then
@@ -51,6 +52,8 @@ clean_env_variables() {
     unset bundle_major
     unset bundle_distro
     unset kernel_build_dir
+
+    unset KERNEL_SRC_DIR
 }
 
 build() {

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
 
 # This script handles decompressing the bundles tarballs and setting environment
 # variables needed by the kernel driver compilation script.
@@ -27,6 +27,8 @@ extract_bundle() {
         echo "No BUNDLE_UNAME entry found in kernel source bundle!"
         return 1
     }
+
+    return 0
 }
 
 export_env_variables() {

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -71,7 +71,7 @@ build() {
 
         failure_output_file="${FAILURE_DIR}/${kernel_version}/${module_version}/${probe_type}.log"
         mkdir -p "$(dirname "$failure_output_file")"
-        if ! build_kos "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
+        if ! build-kos "$kernel_version" "$module_version" "${probe_type}" 2> >(tee "$failure_output_file" >&2); then
             echo >&2 "Failed to build ${probe_type} probe version ${module_version} for kernel ${kernel_version}"
         else
             rm "$failure_output_file"

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -59,7 +59,7 @@ build() {
         local module_version="${line[1]}"
         local probe_type="${line[2]}"
 
-        if extract_bundle "${kernel_version}"; then
+        if ! extract_bundle "${kernel_version}"; then
             echo >&2 "Failed to extract kernel bundle for version '${kernel_version}'"
             exit 1
         fi

--- a/kernel-modules/dockerized/Dockerfile
+++ b/kernel-modules/dockerized/Dockerfile
@@ -38,7 +38,7 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /usr/bin
+COPY /collector/kernel-modules/build/build-kos /scripts/
 COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-8-base AS patcher
@@ -104,7 +104,7 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /usr/bin
+COPY /collector/kernel-modules/build/build-kos /scripts/
 COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-7-base AS rhel-7-builder

--- a/kernel-modules/dockerized/Dockerfile
+++ b/kernel-modules/dockerized/Dockerfile
@@ -38,7 +38,7 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /scripts
+COPY /collector/kernel-modules/build/build-kos /usr/bin
 COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-8-base AS patcher
@@ -104,7 +104,7 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /scripts
+COPY /collector/kernel-modules/build/build-kos /usr/bin
 COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-7-base AS rhel-7-builder

--- a/kernel-modules/dockerized/Dockerfile
+++ b/kernel-modules/dockerized/Dockerfile
@@ -38,7 +38,8 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /scripts/compile.sh
+COPY /collector/kernel-modules/build/build-kos /scripts
+COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-8-base AS patcher
 
@@ -103,7 +104,8 @@ RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT
 # This directory goes separately to prevent it from being modified/deleted when switching branches
 COPY /collector/kernel-modules/dockerized/scripts /scripts
 COPY /collector/kernel-modules/build/prepare-src /scripts/prepare-src.sh
-COPY /collector/kernel-modules/build/build-kos /scripts/compile.sh
+COPY /collector/kernel-modules/build/build-kos /scripts
+COPY /collector/kernel-modules/build/build-wrapper.sh /scripts/compile.sh
 
 FROM rhel-7-base AS rhel-7-builder
 


### PR DESCRIPTION
## Description

This PR refactors some actions previously executed by the drivers compilation script into a separate wrapper script. This is done in order to allow builds done in the RH infrastructure to use a separate script for setting up the environment, while still maintaining most of the build logic in a common script executed by both infrastructures.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Building of drivers should keep working after the changes, so running CI with `build-legacy-probes`, `no-cache` and `dockerized-no-cache` should be enough.