### PR TITLE
Ignore 5.15+ Debian and flatcar 5.10.96 kernels in dockerized build

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -11,9 +11,9 @@
 # TODO(ROX-6615) - Kernel crawler deletes debian kernels
 4.19.0-10-cloud-amd64
 4.19.0-14-amd64
+5.16.0-1
 # backport 5.8
 5.8.*20.04
-5.16.0-1
 # TODO(ROX-6789) - backport 5.7+ patches to legacy collector versions
 ~5\.([7-9]|1[0-9])\..* 1123dde0458e72a49880b06922e135dbcd36fb784fed530ab84ddfa8924e5c05
 ~5\.([7-9]|1[0-9])\..* 612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656

--- a/kernel-modules/dockerized/BLOCKLIST
+++ b/kernel-modules/dockerized/BLOCKLIST
@@ -11,6 +11,7 @@
 # for the time being
 *-dockerdesktop-*
 # Kernel modules requiring a specific GCC/GLIBC version
+# Tracked in RS-284 and RS-335
 4.9.0-0.bpo.6-amd64 * mod
 ~4\.9\.0-[0-9]+-amd64 * mod
 ~4\.19\.0-17(-cloud)?-amd64 * *


### PR DESCRIPTION
## Description

This PR generalizes the block on some Debian kernels that require `gcc-11` as the compiler in dockerized builds. It also ignores Flatcar's 5.10.96 because of a known GLIBC version issue. We also ignore 5.16.0-1 on the main build, since those kernel sources have been deleted and are causing a failure in the legacy version of collector.

Issues tracking the failures on ignored kernels:
- [RS-284](https://issues.redhat.com/browse/RS-284) 
- [RS-335](https://issues.redhat.com/browse/RS-335)
- [ROX-6615](https://issues.redhat.com/browse/ROX-6615)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Green CI on the dockerized and non-dockerized build of drivers workflow is enough.
