### PR TITLE
Setup nightly run for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,18 +49,237 @@ runOnAllTagsWithDockerIOPushCtx: &runOnAllTagsWithDockerIOPushCtx
     - quay-rhacs-eng-readwrite
     - quay-rhacs-eng-readonly
 
-runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequires
+runOnAllTagsWithIntegrationTestContext: &runOnAllTagsWithIntegrationTestContext
   <<: *runOnAllTags
   context:
     - docker-io-pull
     - quay-rhacs-eng-readonly
     - ubuntu-esm-subscription-token # Provides environment variable UBUNTU_ESM_SUBSCRIPTION_TOKEN.
     - redhat-developer-account-login
+
+BuildIntegrationTestRequires: &BuildIntegrationTestRequires
   requires:
   - images
   - ubi-image
   - integration-test-local
   - dockerized-build-collector
+
+runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequires
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *BuildIntegrationTestRequires
+
+
+COSIntegrationTest: &COSIntegrationTest
+  name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: cos
+  collection_method: ebpf
+
+BuildCOSIntegrationTest: &BuildCOSIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *COSIntegrationTest
+  matrix:
+    parameters:
+      image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
+      dockerized: [false, true]
+
+NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *COSIntegrationTest
+  matrix:
+    parameters:
+      image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
+      dockerized: [false]
+
+
+RHELIntegrationTest: &RHELIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: rhel
+
+BuildRHELIntegrationTest: &BuildRHELIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *RHELIntegrationTest
+  matrix:
+    parameters:
+      image_family: [rhel-7, rhel-8]
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+
+NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *RHELIntegrationTest
+  matrix:
+    parameters:
+      image_family: [rhel-7, rhel-8]
+      collection_method: [module, ebpf]
+      dockerized: [false]
+
+
+UbuntuIntegrationTest: &UbuntuIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: ubuntu-os
+
+BuildUbuntuIntegrationTest: &BuildUbuntuIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *UbuntuIntegrationTest
+  matrix:
+    parameters:
+      image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+    exclude:
+      # Failing due to GLIC 2.33 not available on ubi 8
+      - image_family: ubuntu-2110
+        collection_method: module
+        dockerized: true
+
+NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *UbuntuIntegrationTest
+  matrix:
+    parameters:
+      image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
+      collection_method: [module, ebpf]
+      dockerized: [false]
+
+
+UbuntuProIntegrationTest: &UbuntuProIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: ubuntu-os-pro
+
+BuildUbuntuProIntegrationTest: &BuildUbuntuProIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *UbuntuProIntegrationTest
+  matrix:
+    parameters:
+      image_family: [ubuntu-pro-1804-lts]
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+
+NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *UbuntuProIntegrationTest
+  matrix:
+    parameters:
+      image_family: [ubuntu-pro-1804-lts]
+      collection_method: [module, ebpf]
+      dockerized: [false]
+
+
+SUSEIntegrationTest: &SUSEIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: suse
+
+BuildSUSEIntegrationTest: &BuildSUSEIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *SUSEIntegrationTest
+  matrix:
+    parameters:
+      image_family: [sles-12, sles-15]
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+    exclude:
+      - image_family: sles-12
+        collection_method: ebpf
+        dockerized: false
+      - image_family: sles-12
+        collection_method: ebpf
+        dockerized: true
+
+NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *SUSEIntegrationTest
+  matrix:
+    parameters:
+      image_family: [sles-12, sles-15]
+      collection_method: [module, ebpf]
+      dockerized: [false]
+    exclude:
+      - image_family: sles-12
+        collection_method: ebpf
+        dockerized: false
+
+
+FlatcarIntegrationTest: &FlatcarIntegrationTest
+  name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  vm_type: flatcar
+  image_family: flatcar-stable
+
+BuildFlatcarIntegrationTest: &BuildFlatcarIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *FlatcarIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+    exclude:
+      # Failing due to GLIC 2.33 not available on ubi 8
+      - collection_method: module
+        dockerized: true
+
+NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *FlatcarIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false]
+
+
+FedoraIntegrationTest: &FedoraIntegrationTest
+  name: test-<< matrix.collection_method >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  image_family: fedora-coreos-stable
+  vm_type: fedora-coreos
+
+BuildFedoraIntegrationTest: &BuildFedoraIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *FedoraIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+    exclude:
+      # Failing due to GLIC 2.33 not available on ubi 8
+      - collection_method: module
+        dockerized: true
+
+NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *FedoraIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false]
+
+
+GardenIntegrationTest: &GardenIntegrationTest
+  name: test-<< matrix.collection_method >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
+  image_family: garden-linux
+  image_name: gardenlinux-gcp-cloud-gardener--prod-<< matrix.image_version >>
+  vm_type: garden-linux
+
+BuildGardenIntegrationTest: &BuildGardenIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *GardenIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false, true]
+      image_version: [576-2-9e22b9]
+    exclude:
+      # Failing due to dockerized module not being built (requires gcc-10).
+      - collection_method: module
+        dockerized: true
+        image_version: 576-2-9e22b9
+
+NightlyGardenIntegrationTest: &NightlyGardenIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *GardenIntegrationTest
+  matrix:
+    parameters:
+      collection_method: [module, ebpf]
+      dockerized: [false]
+      image_version: [576-2-9e22b9]
+
 
 orbs:
   slack: circleci/slack@3.4.2
@@ -1495,62 +1714,15 @@ workflows:
         - ubi-image
         - upload-modules
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: cos
-        collection_method: ebpf
-        matrix:
-          parameters:
-            image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
-            dockerized: [false, true]
+        <<: *BuildCOSIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: rhel
-        matrix:
-          parameters:
-            image_family: [rhel-7, rhel-8]
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
+        <<: *BuildRHELIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: ubuntu-os
-        matrix:
-          parameters:
-            image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
-          exclude:
-            # Failing due to GLIC 2.33 not available on ubi 8
-            - image_family: ubuntu-2110
-              collection_method: module
-              dockerized: true
+        <<: *BuildUbuntuIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: ubuntu-os-pro
-        matrix:
-          parameters:
-            image_family: [ubuntu-pro-1804-lts]
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
+        <<: *BuildUbuntuProIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: suse
-        matrix:
-          parameters:
-            image_family: [sles-12, sles-15]
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
-          exclude:
-            - image_family: sles-12
-              collection_method: ebpf
-              dockerized: false
-            - image_family: sles-12
-              collection_method: ebpf
-              dockerized: true
+        <<: *BuildSUSEIntegrationTest
     # Removed while solving ROX-9180
     # - integration-test:
     #     <<: *runOnAllTagsWithIntegrationTestRequires
@@ -1562,47 +1734,11 @@ workflows:
     #         collection_method: [module, ebpf]
     #         dockerized: [false, true]
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        vm_type: flatcar
-        image_family: flatcar-stable
-        matrix:
-          parameters:
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
-          exclude:
-            # Failing due to GLIC 2.33 not available on ubi 8
-            - collection_method: module
-              dockerized: true
+        <<: *BuildFlatcarIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        image_family: fedora-coreos-stable
-        vm_type: fedora-coreos
-        matrix:
-          parameters:
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
-          exclude:
-            # Failing due to GLIC 2.33 not available on ubi 8
-            - collection_method: module
-              dockerized: true
+        <<: *BuildFedoraIntegrationTest
     - integration-test:
-        <<: *runOnAllTagsWithIntegrationTestRequires
-        name: test-<< matrix.collection_method >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
-        image_family: garden-linux
-        image_name: gardenlinux-gcp-cloud-gardener--prod-<< matrix.image_version >>
-        vm_type: garden-linux
-        matrix:
-          parameters:
-            collection_method: [module, ebpf]
-            dockerized: [false, true]
-            image_version: [576-2-9e22b9]
-          exclude:
-            # Failing due to dockerized module not being built (requires gcc-10).
-            - collection_method: module
-              dockerized: true
-              image_version: 576-2-9e22b9
+        <<: *BuildGardenIntegrationTest
     - integration-test-data:
         <<: *runOnAllTagsWithDockerIOPullCtx
         requires:
@@ -1650,3 +1786,31 @@ workflows:
           - collector-support
         requires:
           - upload-modules
+
+  nightly:
+    jobs:
+    - integration-test:
+        <<: *NightlyCOSIntegrationTest
+    - integration-test:
+        <<: *NightlyRHELIntegrationTest
+    - integration-test:
+        <<: *NightlyUbuntuIntegrationTest
+    - integration-test:
+        <<: *NightlyUbuntuProIntegrationTest
+    - integration-test:
+        <<: *NightlySUSEIntegrationTest
+    - integration-test:
+        <<: *NightlyFlatcarIntegrationTest
+    - integration-test:
+        <<: *NightlyFedoraIntegrationTest
+    - integration-test:
+        <<: *NightlyGardenIntegrationTest
+    triggers:
+    # Run everyday at 0:00
+    - schedule:
+        cron: "0 0 * * *"
+        filters:
+          branches:
+            only:
+            - master
+            - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1821,12 +1821,12 @@ workflows:
         <<: *NightlyFedoraIntegrationTest
     - integration-test:
         <<: *NightlyGardenIntegrationTest
-    triggers:
-    # Run everyday at 0:00
-    - schedule:
-        cron: "0 0 * * *"
-        filters:
-          branches:
-            only:
-            - master
-            - main
+    # triggers:
+    # # Run everyday at 0:00
+    # - schedule:
+    #     cron: "0 0 * * *"
+    #     filters:
+    #       branches:
+    #         only:
+    #         - master
+    #         - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1237,10 +1237,10 @@ jobs:
         name: "Running integration tests"
         no_output_timeout: 45m
         command: |
+          <<# parameters.dockerized >>export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"<</ parameters.dockerized >>
+
           if [[ -n "<< parameters.collector_tag >>" ]]; then
             export COLLECTOR_IMAGE="${COLLECTOR_REPO}:<< parameters.collector_tag >>"
-          else
-            <<# parameters.dockerized >>export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"<</ parameters.dockerized >>
           fi
 
           echo "Running tests with image '${COLLECTOR_IMAGE}'"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,17 +68,14 @@ NightlyIntegrationTestRequires: &NightlyIntegrationTestRequires
   requires:
   - initjob
 
-runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequires
-  <<: *runOnAllTagsWithIntegrationTestContext
-  <<: *BuildIntegrationTestRequires
-
 
 COSIntegrationTest: &COSIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: cos
   collection_method: ebpf
 
 BuildCOSIntegrationTest: &BuildCOSIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *COSIntegrationTest
   name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -87,7 +84,6 @@ BuildCOSIntegrationTest: &BuildCOSIntegrationTest
       dockerized: [false, true]
 
 NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *COSIntegrationTest
   name: test-ebpf-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -99,10 +95,11 @@ NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
 
 
 RHELIntegrationTest: &RHELIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: rhel
 
 BuildRHELIntegrationTest: &BuildRHELIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *RHELIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -112,7 +109,6 @@ BuildRHELIntegrationTest: &BuildRHELIntegrationTest
       dockerized: [false, true]
 
 NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *RHELIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -125,10 +121,11 @@ NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
 
 
 UbuntuIntegrationTest: &UbuntuIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: ubuntu-os
 
 BuildUbuntuIntegrationTest: &BuildUbuntuIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *UbuntuIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -143,7 +140,6 @@ BuildUbuntuIntegrationTest: &BuildUbuntuIntegrationTest
         dockerized: true
 
 NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *UbuntuIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -156,10 +152,11 @@ NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
 
 
 UbuntuProIntegrationTest: &UbuntuProIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: ubuntu-os-pro
 
 BuildUbuntuProIntegrationTest: &BuildUbuntuProIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *UbuntuProIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -169,7 +166,6 @@ BuildUbuntuProIntegrationTest: &BuildUbuntuProIntegrationTest
       dockerized: [false, true]
 
 NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *UbuntuProIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -182,10 +178,11 @@ NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
 
 
 SUSEIntegrationTest: &SUSEIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: suse
 
 BuildSUSEIntegrationTest: &BuildSUSEIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *SUSEIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -202,7 +199,6 @@ BuildSUSEIntegrationTest: &BuildSUSEIntegrationTest
         dockerized: true
 
 NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *SUSEIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -219,11 +215,12 @@ NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
 
 
 FlatcarIntegrationTest: &FlatcarIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   vm_type: flatcar
   image_family: flatcar-stable
 
 BuildFlatcarIntegrationTest: &BuildFlatcarIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *FlatcarIntegrationTest
   name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -236,7 +233,6 @@ BuildFlatcarIntegrationTest: &BuildFlatcarIntegrationTest
         dockerized: true
 
 NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *FlatcarIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -248,11 +244,12 @@ NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
 
 
 FedoraIntegrationTest: &FedoraIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   image_family: fedora-coreos-stable
   vm_type: fedora-coreos
 
 BuildFedoraIntegrationTest: &BuildFedoraIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *FedoraIntegrationTest
   name: test-<< matrix.collection_method >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -265,7 +262,6 @@ BuildFedoraIntegrationTest: &BuildFedoraIntegrationTest
         dockerized: true
 
 NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *FedoraIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
@@ -277,12 +273,13 @@ NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
 
 
 GardenIntegrationTest: &GardenIntegrationTest
+  <<: *runOnAllTagsWithIntegrationTestContext
   image_family: garden-linux
   image_name: gardenlinux-gcp-cloud-gardener--prod-<< matrix.image_version >>
   vm_type: garden-linux
 
 BuildGardenIntegrationTest: &BuildGardenIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestRequires
+  <<: *BuildIntegrationTestRequires
   <<: *GardenIntegrationTest
   name: test-<< matrix.collection_method >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
@@ -297,7 +294,6 @@ BuildGardenIntegrationTest: &BuildGardenIntegrationTest
         image_version: 576-2-9e22b9
 
 NightlyGardenIntegrationTest: &NightlyGardenIntegrationTest
-  <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *GardenIntegrationTest
   name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ BuildIntegrationTestRequires: &BuildIntegrationTestRequires
   - integration-test-local
   - dockerized-build-collector
 
+NightlyIntegrationTestRequires: &NightlyIntegrationTestRequires
+  requires:
+  - initjob
+
 runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequires
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *BuildIntegrationTestRequires
@@ -84,6 +88,7 @@ BuildCOSIntegrationTest: &BuildCOSIntegrationTest
 
 NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *COSIntegrationTest
   matrix:
     parameters:
@@ -107,6 +112,7 @@ BuildRHELIntegrationTest: &BuildRHELIntegrationTest
 
 NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *RHELIntegrationTest
   matrix:
     parameters:
@@ -136,6 +142,7 @@ BuildUbuntuIntegrationTest: &BuildUbuntuIntegrationTest
 
 NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *UbuntuIntegrationTest
   matrix:
     parameters:
@@ -160,6 +167,7 @@ BuildUbuntuProIntegrationTest: &BuildUbuntuProIntegrationTest
 
 NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *UbuntuProIntegrationTest
   matrix:
     parameters:
@@ -191,6 +199,7 @@ BuildSUSEIntegrationTest: &BuildSUSEIntegrationTest
 
 NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *SUSEIntegrationTest
   matrix:
     parameters:
@@ -223,6 +232,7 @@ BuildFlatcarIntegrationTest: &BuildFlatcarIntegrationTest
 
 NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *FlatcarIntegrationTest
   matrix:
     parameters:
@@ -250,6 +260,7 @@ BuildFedoraIntegrationTest: &BuildFedoraIntegrationTest
 
 NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *FedoraIntegrationTest
   matrix:
     parameters:
@@ -280,6 +291,7 @@ BuildGardenIntegrationTest: &BuildGardenIntegrationTest
 
 NightlyGardenIntegrationTest: &NightlyGardenIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
+  <<: *NightlyIntegrationTestRequires
   <<: *GardenIntegrationTest
   matrix:
     parameters:
@@ -1805,6 +1817,8 @@ workflows:
 
   nightly:
     jobs:
+    - initjob:
+        <<: *runOnAllTagsWithDockerIOPullCtx
     - integration-test:
         <<: *NightlyCOSIntegrationTest
     - integration-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
     parameters:
       image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 RHELIntegrationTest: &RHELIntegrationTest
@@ -112,6 +113,7 @@ NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
       image_family: [rhel-7, rhel-8]
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 UbuntuIntegrationTest: &UbuntuIntegrationTest
@@ -140,6 +142,7 @@ NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
       image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 UbuntuProIntegrationTest: &UbuntuProIntegrationTest
@@ -163,6 +166,7 @@ NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
       image_family: [ubuntu-pro-1804-lts]
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 SUSEIntegrationTest: &SUSEIntegrationTest
@@ -193,6 +197,7 @@ NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
       image_family: [sles-12, sles-15]
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
     exclude:
       - image_family: sles-12
         collection_method: ebpf
@@ -223,6 +228,7 @@ NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
     parameters:
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 FedoraIntegrationTest: &FedoraIntegrationTest
@@ -249,6 +255,7 @@ NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
     parameters:
       collection_method: [module, ebpf]
       dockerized: [false]
+      collector_tag: [3.6.0-slim]
 
 
 GardenIntegrationTest: &GardenIntegrationTest
@@ -279,6 +286,7 @@ NightlyGardenIntegrationTest: &NightlyGardenIntegrationTest
       collection_method: [module, ebpf]
       dockerized: [false]
       image_version: [576-2-9e22b9]
+      collector_tag: [3.6.0-slim]
 
 
 orbs:
@@ -1155,6 +1163,9 @@ jobs:
       dockerized:
         type: boolean
         default: false
+      collector_tag:
+        type: string
+        default: ""
     <<: *defaultMachine
     working_directory: ~/workspace
 
@@ -1214,7 +1225,12 @@ jobs:
         name: "Running integration tests"
         no_output_timeout: 45m
         command: |
-          <<# parameters.dockerized >>export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"<</ parameters.dockerized >>
+          if [[ -n "<< parameters.collector_tag >>" ]]; then
+            export COLLECTOR_IMAGE="${COLLECTOR_REPO}:<< parameters.collector_tag >>"
+          else
+            <<# parameters.dockerized >>export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"<</ parameters.dockerized >>
+          fi
+
           echo "Running tests with image '${COLLECTOR_IMAGE}'"
           make -C "${SOURCE_ROOT}" integration-tests-baseline integration-tests integration-tests-report
           cp "${SOURCE_ROOT}/integration-tests/perf.json" "${WORKSPACE_ROOT}/${TEST_NAME}-perf.json"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,13 @@ runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequire
 
 
 COSIntegrationTest: &COSIntegrationTest
-  name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: cos
   collection_method: ebpf
 
 BuildCOSIntegrationTest: &BuildCOSIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *COSIntegrationTest
+  name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
@@ -90,6 +90,7 @@ NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *COSIntegrationTest
+  name: test-ebpf-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [cos-stable, cos-beta, cos-dev, cos-85-lts, cos-89-lts]
@@ -98,12 +99,12 @@ NightlyCOSIntegrationTest: &NightlyCOSIntegrationTest
 
 
 RHELIntegrationTest: &RHELIntegrationTest
-  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: rhel
 
 BuildRHELIntegrationTest: &BuildRHELIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *RHELIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [rhel-7, rhel-8]
@@ -114,6 +115,7 @@ NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *RHELIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [rhel-7, rhel-8]
@@ -123,12 +125,12 @@ NightlyRHELIntegrationTest: &NightlyRHELIntegrationTest
 
 
 UbuntuIntegrationTest: &UbuntuIntegrationTest
-  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: ubuntu-os
 
 BuildUbuntuIntegrationTest: &BuildUbuntuIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *UbuntuIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
@@ -144,6 +146,7 @@ NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *UbuntuIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
@@ -153,12 +156,12 @@ NightlyUbuntuIntegrationTest: &NightlyUbuntuIntegrationTest
 
 
 UbuntuProIntegrationTest: &UbuntuProIntegrationTest
-  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: ubuntu-os-pro
 
 BuildUbuntuProIntegrationTest: &BuildUbuntuProIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *UbuntuProIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [ubuntu-pro-1804-lts]
@@ -169,6 +172,7 @@ NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *UbuntuProIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [ubuntu-pro-1804-lts]
@@ -178,12 +182,12 @@ NightlyUbuntuProIntegrationTest: &NightlyUbuntuProIntegrationTest
 
 
 SUSEIntegrationTest: &SUSEIntegrationTest
-  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: suse
 
 BuildSUSEIntegrationTest: &BuildSUSEIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *SUSEIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [sles-12, sles-15]
@@ -201,6 +205,7 @@ NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *SUSEIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       image_family: [sles-12, sles-15]
@@ -214,13 +219,13 @@ NightlySUSEIntegrationTest: &NightlySUSEIntegrationTest
 
 
 FlatcarIntegrationTest: &FlatcarIntegrationTest
-  name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   vm_type: flatcar
   image_family: flatcar-stable
 
 BuildFlatcarIntegrationTest: &BuildFlatcarIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *FlatcarIntegrationTest
+  name: test-<< matrix.collection_method >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]
@@ -234,6 +239,7 @@ NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *FlatcarIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-flatcar-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]
@@ -242,13 +248,13 @@ NightlyFlatcarIntegrationTest: &NightlyFlatcarIntegrationTest
 
 
 FedoraIntegrationTest: &FedoraIntegrationTest
-  name: test-<< matrix.collection_method >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   image_family: fedora-coreos-stable
   vm_type: fedora-coreos
 
 BuildFedoraIntegrationTest: &BuildFedoraIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *FedoraIntegrationTest
+  name: test-<< matrix.collection_method >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]
@@ -262,6 +268,7 @@ NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *FedoraIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-fedora-coreos-stable<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]
@@ -270,7 +277,6 @@ NightlyFedoraIntegrationTest: &NightlyFedoraIntegrationTest
 
 
 GardenIntegrationTest: &GardenIntegrationTest
-  name: test-<< matrix.collection_method >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   image_family: garden-linux
   image_name: gardenlinux-gcp-cloud-gardener--prod-<< matrix.image_version >>
   vm_type: garden-linux
@@ -278,6 +284,7 @@ GardenIntegrationTest: &GardenIntegrationTest
 BuildGardenIntegrationTest: &BuildGardenIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestRequires
   <<: *GardenIntegrationTest
+  name: test-<< matrix.collection_method >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]
@@ -293,6 +300,7 @@ NightlyGardenIntegrationTest: &NightlyGardenIntegrationTest
   <<: *runOnAllTagsWithIntegrationTestContext
   <<: *NightlyIntegrationTestRequires
   <<: *GardenIntegrationTest
+  name: test-<< matrix.collection_method >>-<< matrix.collector_tag >>-garden-linux<<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>
   matrix:
     parameters:
       collection_method: [module, ebpf]

--- a/.circleci/envbuilder.sh
+++ b/.circleci/envbuilder.sh
@@ -65,7 +65,7 @@ createGCPVMFromImage() {
             --image-project "$GCP_IMAGE_PROJECT" \
             --service-account=circleci-collector@stackrox-ci.iam.gserviceaccount.com \
             --machine-type e2-standard-2 \
-            --labels="stackrox-ci=true,stackrox-ci-job=${CIRCLE_JOB},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID}" \
+            --labels="stackrox-ci=true,stackrox-ci-job=${CIRCLE_JOB//./-},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID}" \
             --boot-disk-size=20GB \
             "$GCP_VM_NAME"; then
             success=true

--- a/.circleci/envbuilder.sh
+++ b/.circleci/envbuilder.sh
@@ -22,7 +22,7 @@ createGCPVM() {
             --image-project "$GCP_IMAGE_PROJECT" \
             --service-account=circleci-collector@stackrox-ci.iam.gserviceaccount.com \
             --machine-type e2-standard-2 \
-            --labels="stackrox-ci=true,stackrox-ci-job=${CIRCLE_JOB},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID}" \
+            --labels="stackrox-ci=true,stackrox-ci-job=${CIRCLE_JOB//./-},stackrox-ci-workflow=${CIRCLE_WORKFLOW_ID}" \
             --boot-disk-size=20GB \
             "$GCP_VM_NAME"; then
             success=true


### PR DESCRIPTION
## Description

This PR sets up a nightly run that will execute integration tests using a specific tag for the collector image. The purpose of this first setup is to ensure probes for supported versions of collector are still being built and work as intended.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

