### PR TITLE
Fix blocklist for 5.16.0 kernel

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -11,7 +11,8 @@
 # TODO(ROX-6615) - Kernel crawler deletes debian kernels
 4.19.0-10-cloud-amd64
 4.19.0-14-amd64
-5.16.0-1
+5.16.0-1-cloud-amd64
+5.16.0-1-amd64
 # backport 5.8
 5.8.*20.04
 # TODO(ROX-6789) - backport 5.7+ patches to legacy collector versions


### PR DESCRIPTION
## Description

This PR sets the blocklist for 5.16 kernels correctly.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Green CI with `build-legacy-probes` tag set.
