### PR TITLE
Use ubi as a base image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM registry.access.redhat.com/ubi8/ubi:8.5
 
 ARG NPROCS=6
 ARG USE_VALGRIND=false


### PR DESCRIPTION
## Description

Centos 8 is EOL, which causes troubles when updating builder image. Use
ubi as a base image, it should be reasonably compatible.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

None yet.