### PR TITLE
Jv/rox 9457 enable core dumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -865,6 +865,8 @@ jobs:
         name: "Running integration tests"
         no_output_timeout: 45m
         command: |
+          sudo cp /proc/sys/kernel/core_pattern /tmp/core_pattern
+          echo '/tmp/core.out' | sudo tee /proc/sys/kernel/core_pattern
           export REMOTE_HOST_TYPE=local
           export COLLECTION_METHOD="kernel_module"
           export VM_CONFIG="circle_local_<< parameters.vm-config >>"
@@ -872,7 +874,13 @@ jobs:
           export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}"
           export USE_VALGRIND=$VALGRIND_INTEGRATION_TESTS
           export USE_HELGRIND=$HELGRIND_INTEGRATION_TESTS
-          make -C "${SOURCE_ROOT}" integration-tests-repeat-network integration-tests-missing-proc-scrape integration-tests-image-label-json integration-tests integration-tests-report
+          make -C "${SOURCE_ROOT}" integration-tests-repeat-network integration-tests-missing-proc-scrape integration-tests-image-label-json integration-tests integration-tests-report || exit_code=$?
+          if [ "${exit_code}" -ne 0 ]; then
+                  if [ -f /tmp/core.out ]; then
+                    sudo chmod 755 /tmp/core.out
+                  fi
+                  exit "${exit_code}"
+          fi
           [[ -z "$CIRCLE_BRANCH" ]] || gsutil cp ~/workspace/go/src/github.com/stackrox/collector/integration-tests/integration-test-report.xml "gs://stackrox-ci-results/circleci/collector/${CIRCLE_BRANCH}/$(date +%Y-%m-%d)-${CIRCLE_BUILD_NUM}/"
 
     - run:
@@ -889,6 +897,12 @@ jobs:
             "${CI_ROOT}/check-file-for-valgrind-errors.sh" "$file" "$VALGRIND_INTEGRATION_TESTS" "$HELGRIND_INTEGRATION_TESTS"
           done
 
+    - run:
+        name: "Resore core_dump file"
+        command: |
+          cat /tmp/core_pattern | sudo tee /proc/sys/kernel/core_pattern
+        when: always
+
     - store_test_results:
         path: ~/workspace/go/src/github.com/stackrox/collector/integration-tests/integration-test-report.xml
     - ci-artifacts/store:
@@ -900,6 +914,8 @@ jobs:
     - ci-artifacts/store:
         path: ~/workspace/go/src/github.com/stackrox/collector/integration-tests/perf.json
         destination: "kernel_module-circle_local_<< parameters.vm-config >>-perf.json"
+    - ci-artifacts/store:
+        path: /tmp/core.out
 
   integration-test:
     parameters:
@@ -1002,6 +1018,7 @@ jobs:
         name: "Running integration tests"
         no_output_timeout: 45m
         command: |
+          echo '/tmp/core.%e.%p' | sudo tee /proc/sys/kernel/core_pattern
           <<# parameters.dockerized >>export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"<</ parameters.dockerized >>
           echo "Running tests with image '${COLLECTOR_IMAGE}'"
           make -C "${SOURCE_ROOT}" integration-tests-repeat-network integration-tests-baseline integration-tests integration-tests-report
@@ -1044,6 +1061,8 @@ jobs:
         destination: "<< parameters.collection_method >>-<< parameters.vm_type >>-<< parameters.image_family >>-perf.json"
     - ci-artifacts/store:
         path: ~/workspace/serial-output
+    - ci-artifacts/store:
+        path: /tmp/core.out
 
     - persist_to_workspace:
         root: ~/workspace

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -50,6 +50,8 @@ BoolEnvVar set_curl_verbose("ROX_COLLECTOR_SET_CURL_VERBOSE", false);
 
 BoolEnvVar set_enable_afterglow("ROX_ENABLE_AFTERGLOW", true);
 
+BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
@@ -182,6 +184,10 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
     curl_verbose_ = true;
   }
 
+  if (set_enable_core_dump) {
+    enable_core_dump_ = true;
+  }
+
   HandleAfterglowEnvVars();
 
   host_config_ = ProcessHostHeuristics(*this);
@@ -268,6 +274,10 @@ std::string CollectorConfig::LogLevel() const {
 
 int64_t CollectorConfig::AfterglowPeriod() const {
   return afterglow_period_micros_;
+}
+
+bool CollectorConfig::IsCoreDumpEnabled() const {
+  return enable_core_dump_;
 }
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -101,6 +101,7 @@ end
   bool CurlVerbose() const { return curl_verbose_; }
   virtual bool ForceKernelModules() const { return force_kernel_modules_; }
   bool EnableAfterglow() const { return enable_afterglow_; }
+  bool IsCoreDumpEnabled() const;
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -124,6 +125,7 @@ end
   HostConfig host_config_;
   int64_t afterglow_period_micros_ = 300000000;  //5 minutes in microseconds
   bool enable_afterglow_ = true;
+  bool enable_core_dump_ = false;
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/docs/references.md
+++ b/docs/references.md
@@ -2,6 +2,9 @@
 
 ## Configuration options
 
+ENABLE_CORE_DUMP: Controls whether a core dump file is created in the event of a crash.
+Allowed values are true and false. The default is false.
+
 ## Supported systems
 
 ## Glossary


### PR DESCRIPTION
## Description

If core dumps are enabled we should see them when Collector crashes. Core dumps should be enabled for integration tests and it should be possible to turn them on optionally.

## Checklist
- [x] Investigated and inspected CI test results
- [x] See core dump when there is a purposeful SIGABRT locally
- [x] See core dump when there is a purposeful SIGABRT in CircleCI
- [x] Don't see core dump when core dumps are disabled locally

**Automated testing**
No added testing

## Testing Performed

See checklist
