### PR TITLE
Use SCAP environment variable at build time

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -23,7 +23,7 @@ LABEL name="collector" \
 
 ENV COLLECTOR_VERSION=${collector_version} \
     MODULE_VERSION=${module_version} \
-    COLLECTOR_HOST_ROOT=/host
+    SCAP_HOST_ROOT_ENV_VAR_NAME=/host
 
 WORKDIR /
 

--- a/collector/container/Dockerfile.ubi
+++ b/collector/container/Dockerfile.ubi
@@ -71,7 +71,7 @@ LABEL version="${COLLECTOR_VERSION}"
 ARG USE_VALGRIND=false
 ARG ADDRESS_SANITIZER=false
 
-ENV COLLECTOR_HOST_ROOT=/host
+ENV SCAP_HOST_ROOT_ENV_VAR_NAME=/host
 
 RUN rm -rf /etc/rhsm-host
 COPY --from=builder /etc/pki/entitlement /etc/pki/entitlement

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -237,8 +237,8 @@ std::string Base64Decode(std::string const& encoded_string) {
 }
 
 std::string GetHostPath(const std::string& file) {
-  const char* host_root = std::getenv("COLLECTOR_HOST_ROOT");
-  if (!host_root) host_root = "";
+  const char* host_root = scap_get_host_root();
+
   std::string host_file(host_root);
   // Check if we are joining paths without a seperator,
   if (host_file.length() && file.length() &&

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -59,7 +59,7 @@ services:
       - COLLECTION_METHOD=ebpf
       - MODULE_DOWNLOAD_BASE_URL=https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656
       - MODULE_VERSION=b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62
-      - COLLECTOR_HOST_ROOT=/host
+      - SCAP_HOST_ROOT_ENV_VAR_NAME=/host
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock:ro
       - /proc:/host/proc:ro


### PR DESCRIPTION
## Description

This PR is a sibling of stackrox/falcosecurity-libs#10. It adds the necessary changes for us to properly set the `SCAP_HOST_ROOT_ENV_VAR_NAME` environment variable at build time. The merging order for the PRs should be:
- Merge PR in falco fork.
- Change the falco commit in this PR to the HEAD of master in the falco fork.
- Merge this PR into master.

Once this PR is merged, we will need to issue a patch to gerrit/CPaaS, otherwise collector builds will be broken downstream.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Integration tests passing should be enough.
