### PR TITLE
Append unreleased tags to support packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1051,7 +1051,7 @@ jobs:
 
       - setup_remote_docker:
           version: 20.10.11
-      - stackrox-io-login
+      - docker-login-push
       - gcloud-init
 
       - run:
@@ -1499,3 +1499,4 @@ workflows:
           - collector-support
         requires:
           - upload-modules
+          - images

--- a/kernel-modules/support-packages/01-collector-to-rox-version-map.py
+++ b/kernel-modules/support-packages/01-collector-to-rox-version-map.py
@@ -4,9 +4,12 @@ import collections
 import os
 import re
 import sys
+import subprocess
 
 strip_comment_re = re.compile(r'\s*(#.*)?$')
 space_re = re.compile(r'\s+')
+version_re = re.compile(r'(\d+)\.(\d+)\.(\d+)')
+
 
 def parse_released_versions(f):
     result = collections.defaultdict(list)
@@ -24,6 +27,41 @@ def parse_released_versions(f):
         result[collector_version].append(rox_version)
 
     return result
+
+
+def append_unreleased_tags(version_map, released_versions_file):
+    def tag_to_version(tag):
+        version = version_re.match(tag)
+
+        if not version:
+            return None
+
+        return (int(version[1]), int(version[2]), int(version[3]))
+
+    # Create a list of tupples holding the version as ints, this makes it
+    # easier to compare them.
+    versions = []
+    for key in version_map:
+        versions.append(tag_to_version(key))
+
+    max_version = max(versions)
+
+    tags_cmd = subprocess.check_output(["git", "tag"],
+                                       cwd=os.path.dirname(released_versions_file),
+                                       text=True)
+
+    for tag in tags_cmd.splitlines():
+        if tag in version_map:
+            continue
+
+        # We only want to add tags with a version higher than the latest
+        # released one
+        version = tag_to_version(tag)
+        if not version or version < max_version:
+            continue
+
+        version_map[tag] = ["0.0.0"]
+
 
 def write_versions_metadata(version_map, metadata_dir):
     collector_versions_dir = os.path.join(metadata_dir, 'collector-versions')
@@ -48,7 +86,10 @@ def main(args):
     with open(released_versions_file) as f:
         version_map = parse_released_versions(f)
 
+    append_unreleased_tags(version_map, released_versions_file)
+
     write_versions_metadata(version_map, metadata_dir)
+
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/kernel-modules/support-packages/02-fetch-collectors-metadata.sh
+++ b/kernel-modules/support-packages/02-fetch-collectors-metadata.sh
@@ -16,7 +16,7 @@ for version_dir in "${MD_DIR}/collector-versions"/*; do
     [[ -d "$version_dir" ]] || continue
     version="$(basename "$version_dir")"
 
-    collector_image="collector.stackrox.io/collector:${version}"
+    collector_image="docker.io/stackrox/collector:${version}"
     docker pull "$collector_image"
     tmp_output="$(mktemp)"
 


### PR DESCRIPTION
## Description

This PR aims at making support packages for unreleased versions of collector available before a full stackrox release is tagged, which is needed by the downstream release to create a full collector image. Since there is no point in publishing and releasing the support packages to the general public before a stackrox release, these changes make it so the support package is created and uploaded but it won't be listed in https://cdn.stackrox.io/collector/support-packages/index.html. The instructions for managing a release will need to be updated to directly download the support package using `gsutil` + the module version found in `kernel-modules/MODULE_VERSION`

In order to properly test the logic in this PR I created the `99.99.99` tag which uses the `2.0.0` module version, this properly creates a set of support packages for this new module version without the need of an associated stackrox version and does not show said support package in the generated `index.html`

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] New support packages for unreleased tags and new module versions are created and uploaded, the `index.html` file does not show those versions. ([CI run](https://app.circleci.com/pipelines/github/stackrox/collector/8211/workflows/d03b9bc5-a847-41c3-be8b-7934d15ce97b/jobs/209962))
