### PR TITLE
WIP: Run dockerized commands through a label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,15 @@ commands:
             exit 0
           fi
 
+  dockerized-should-run:
+    steps:
+    - run:
+        if [[ -f ~/workspace/pr-metadata/labels/run-dockerized-steps ]]; then
+          echo "Skipping dockerized build jobs."
+          circleci step halt
+          exit 0
+        fi
+
   stackrox-io-login:
     steps:
     - run:
@@ -721,6 +730,7 @@ jobs:
 
     steps:
     - initcommand
+    - dockerized-should-run
     - docker-login-pull
     - quay-login
     - dockerized-pull-cache-image
@@ -753,6 +763,7 @@ jobs:
 
     steps:
     - initcommand
+    - dockerized-should-run
     - dockerized-check-drivers-built
 
     - run:
@@ -801,6 +812,7 @@ jobs:
 
     steps:
     - initcommand
+    - dockerized-should-run
     - docker-login-pull
     - quay-login-push
     - dockerized-pull-cache-image
@@ -817,6 +829,7 @@ jobs:
 
     steps:
     - initcommand
+    - dockerized-should-run
     - dockerized-check-drivers-built
     - quay-login
 
@@ -834,6 +847,7 @@ jobs:
 
     steps:
     - initcommand
+    - dockerized-should-run
     - quay-login
     - docker-login-push
 
@@ -955,6 +969,12 @@ jobs:
         command: |
           if [[ -f ~/workspace/pr-metadata/labels/skip-integration-tests ]]; then
             echo "Skipping job with skip-integration-tests label."
+            circleci step halt
+            exit 0
+          fi
+
+          if [[ "<< parameters.dockerized >>" == "true" && ! -f ~/workspace/pr-metadata/labels/run-dockerized-steps ]]; then
+            echo "Skipping dockerized build jobs."
             circleci step halt
             exit 0
           fi


### PR DESCRIPTION
## Description

This PR makes it so dockerized steps are only run when adding the `run-dockerized-steps` label. Since the dockerized build is very likely to break, it will be kept behind the flag to keep the master checks passing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Running without the label should skip the steps related to building kernel drivers in a dockerized way, as well as the dockerized integration-tests.
- [ ] Running with the label should run the steps related to building kernel drivers in a dockerized way, as well as the dockerized integration-tests.
