### PR TITLE
Refactored docker use in integration tests

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -16,7 +16,7 @@ export COLLECTOR_IMAGE
 
 .PHONY: docker-clean
 docker-clean:
-	docker rm -fv container-stats benchmark collector grpc-server || true
+	docker rm -fv $(shell docker ps -a --format '{{.Names}}' | grep 'collector-int-') 2>/dev/null || true
 
 .PHONY: tests
 tests: docker-clean

--- a/integration-tests/docker.go
+++ b/integration-tests/docker.go
@@ -1,0 +1,150 @@
+package integrationtests
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	containerNamePrefix = "collector-int-"
+)
+
+// Docker is a wrapper around the Executor to provide
+// docker-specific commands, centralizing all logic related
+// to running docker.
+type Docker struct {
+	executor Executor
+}
+
+// NewDocker creates a new Docker object, using the provided Executor
+func NewDocker(executor Executor) Docker {
+	return Docker{
+		executor,
+	}
+}
+
+// Logs gets the log for a given container. It is equivalent to running
+// docker logs <name>
+func (d *Docker) Logs(name string) (string, error) {
+	logs, err := d.runDocker("logs", d.containerName(name))
+	if err != nil {
+		return "", err
+	}
+
+	return logs, nil
+}
+
+// Run starts a new container, with the provided name, and using the given args.
+func (d *Docker) Run(name string, args ...string) (string, error) {
+	cmd := []string{
+		"--name", d.containerName(name),
+	}
+
+	cmd = append(cmd, args...)
+	return d.runDocker("run", cmd...)
+}
+
+// Exec runs a command within a given named container.
+func (d *Docker) Exec(name string, cmd ...string) (string, error) {
+	args := append([]string{d.containerName(name)}, cmd...)
+	return d.runDocker("exec", args...)
+}
+
+// PS is equivalent to docker ps <args>
+func (d *Docker) PS(args ...string) (string, error) {
+	return d.runDocker("ps", args...)
+}
+
+// Inspect is equivalent to docker inspect <args>
+func (d *Docker) Inspect(name string, args ...string) (string, error) {
+	args = append(args, d.containerName(name))
+	return d.runDocker("inspect", args...)
+}
+
+// Stop attempts to stop the named containers, up to the given timeout.
+// If the timeout passes, the containers will be forcibly killed.
+func (d *Docker) Stop(timeout time.Duration, names ...string) error {
+	args := append([]string{"-t", fmt.Sprintf("%d", timeout)}, d.containerNames(names)...)
+	_, err := d.runDocker("stop", args...)
+	return err
+}
+
+// Remove will remove the named containers.
+// It is equivalent to docker rm -fv <names>
+func (d *Docker) Remove(names ...string) error {
+	args := append([]string{"-fv"}, d.containerNames(names)...)
+	_, err := d.runDocker("rm", args...)
+	return err
+}
+
+// Kill attempts to kill the named containers.
+// It is equivalent to docker kill <names>
+func (d *Docker) Kill(names ...string) error {
+	_, err := d.runDocker("kill", d.containerNames(names)...)
+	return err
+}
+
+// ImageExists checks for the existence of a given image within the docker
+// context
+func (d *Docker) ImageExists(image string) bool {
+	_, err := d.runDocker("image", "inspect", image)
+	return err == nil
+}
+
+// Pull attempts to pull the given image, repeating as necessary until an error
+// or until the image has been successfully pulled.
+func (d *Docker) Pull(image string) error {
+	_, err := d.runDockerRetry("pull", image)
+	return err
+}
+
+// ExitCode gets the exit code for the named container.
+func (d *Docker) ExitCode(name string) (int, error) {
+	result, err := d.Inspect(name, "--format='{{.State.ExitCode}}'")
+	if err != nil {
+		return -1, err
+	}
+	return strconv.Atoi(strings.Trim(result, "\"'"))
+}
+
+// IsContainerRunning checks if the named container is currently running.
+func (d *Docker) IsContainerRunning(name string) (bool, error) {
+	result, err := d.Inspect(name, "--format='{{.State.Running}}'")
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(strings.Trim(result, "\"'"))
+}
+
+// runDocker runs the docker client, with the provided command and args.
+// It uses the executor, which may run locally, over SSH, or using gcloud
+func (d *Docker) runDocker(cmd string, args ...string) (string, error) {
+	fullCmd := append([]string{"docker", cmd}, args...)
+	return d.executor.Exec(fullCmd...)
+}
+
+// runDocker runs the docker client, with the provided command and args, a number
+// of times until failure, or success.
+// It uses the executor, which may run locally, over SSH, or using gcloud
+func (d *Docker) runDockerRetry(cmd string, args ...string) (string, error) {
+	fullCmd := append([]string{"docker", cmd}, args...)
+	return d.executor.ExecRetry(fullCmd...)
+}
+
+// containerName appends a prefix to the container name to better distinguish
+// containers associated with the integration tests.
+func (d *Docker) containerName(name string) string {
+	return fmt.Sprintf("%s%s", containerNamePrefix, name)
+}
+
+// containerNames is a helper function that prefixes a list of names
+// for the same reasons as containerName() above.
+func (d *Docker) containerNames(names []string) []string {
+	processed := make([]string, len(names))
+	for i, name := range names {
+		processed[i] = d.containerName(name)
+	}
+	return processed
+}

--- a/integration-tests/executor.go
+++ b/integration-tests/executor.go
@@ -16,9 +16,6 @@ var (
 
 type Executor interface {
 	CopyFromHost(src string, dst string) (string, error)
-	PullImage(image string) error
-	IsContainerRunning(image string) (bool, error)
-	ExitCode(container string) (int, error)
 	Exec(args ...string) (string, error)
 	ExecRetry(args ...string) (string, error)
 }
@@ -194,31 +191,6 @@ func (e *executor) CopyFromHost(src string, dst string) (res string, err error) 
 		}
 	}
 	return res, err
-}
-
-func (e *executor) PullImage(image string) error {
-	_, err := e.Exec("docker", "image", "inspect", image)
-	if err == nil {
-		return nil
-	}
-	_, err = e.ExecRetry("docker", "pull", image)
-	return err
-}
-
-func (e *executor) IsContainerRunning(containerID string) (bool, error) {
-	result, err := e.Exec("docker", "inspect", containerID, "--format='{{.State.Running}}'")
-	if err != nil {
-		return false, err
-	}
-	return strconv.ParseBool(strings.Trim(result, "\"'"))
-}
-
-func (e *executor) ExitCode(containerID string) (int, error) {
-	result, err := e.Exec("docker", "inspect", containerID, "--format='{{.State.ExitCode}}'")
-	if err != nil {
-		return -1, err
-	}
-	return strconv.Atoi(strings.Trim(result, "\"'"))
 }
 
 func (e *localCommandBuilder) ExecCommand(execArgs ...string) *exec.Cmd {


### PR DESCRIPTION
## Description

Refactors and centralises the docker use throughout the integration tests, to improve usability a little and allow me to enforce a naming prefix to the docker container names. This allows us to more easily clean up residual containers after the integration tests finish. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Tested locally. Relying on CI to test more generally across the necessary platforms. 

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
