### PR TITLE
Push images to the public registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ runOnAllTagsWithDockerIOPushCtx: &runOnAllTagsWithDockerIOPushCtx
     - docker-io-push
     - quay-rhacs-eng-readwrite
     - quay-rhacs-eng-readonly
+    - quay-stackrox-io-readwrite
 
 runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequires
   <<: *runOnAllTags
@@ -572,6 +573,7 @@ jobs:
     - INSTALL_DIRECTORY: /tmp
     - QUAY_REPO: << pipeline.parameters.quay-repo >>
     - DOCKER_REPO: "docker.io/stackrox"
+    - PUBLIC_REPO: "quay.io/stackrox-io"
 
     steps:
     - initcommand

--- a/.circleci/images/100-push-images.sh
+++ b/.circleci/images/100-push-images.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 image_repos=(
     "${DOCKER_REPO}/collector"
     "${QUAY_REPO}/collector"
+    "${PUBLIC_REPO}/collector"
 )
 image_tags=(
     "${COLLECTOR_VERSION}"
@@ -12,6 +13,9 @@ image_tags=(
     "${COLLECTOR_VERSION}-latest"
 )
 for repo in "${image_repos[@]}"; do
+    if [[ "$repo" == "${PUBLIC_REPO}/collector" ]]; then
+        docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" -p "$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+    fi
     for tag in "${image_tags[@]}"; do
         image="${repo}:${tag}"
         echo "Pushing image ${image}"

--- a/.circleci/images/70-build-collector-slim-and-base-images.sh
+++ b/.circleci/images/70-build-collector-slim-and-base-images.sh
@@ -18,6 +18,8 @@ docker build \
     -t "${DOCKER_REPO}/collector:${COLLECTOR_VERSION}-slim" \
     -t "${QUAY_REPO}/collector:${COLLECTOR_VERSION}-base" \
     -t "${QUAY_REPO}/collector:${COLLECTOR_VERSION}-slim" \
+    -t "${PUBLIC_REPO}/collector:${COLLECTOR_VERSION}-base" \
+    -t "${PUBLIC_REPO}/collector:${COLLECTOR_VERSION}-slim" \
     "${build_args[@]}" \
     -f "${SOURCE_ROOT}/collector/container/rhel/Dockerfile" \
     "$SOURCE_ROOT/collector/container/rhel"

--- a/.circleci/images/80-build-collector-latest-images.sh
+++ b/.circleci/images/80-build-collector-latest-images.sh
@@ -14,10 +14,13 @@ if [[ "$BRANCH" != "master" && -z "$TAG" && "${BUILD_FULL_IMAGES,,}" == "false" 
     for collector_repo in "${collector_repos[@]}"; do
         docker_full_repo="${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}"
         quay_full_repo="${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}"
+        public_full_repo="${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}"
         docker tag "${docker_full_repo}-base" "${docker_full_repo}"
         docker tag "${docker_full_repo}-base" "${docker_full_repo}-latest"
         docker tag "${quay_full_repo}-base" "${quay_full_repo}"
         docker tag "${quay_full_repo}-base" "${quay_full_repo}-latest"
+        docker tag "${public_full_repo}-base" "${public_full_repo}"
+        docker tag "${public_full_repo}-base" "${public_full_repo}-latest"
     done
     exit 0
 fi
@@ -40,6 +43,8 @@ for collector_repo in "${collector_repos[@]}"; do
         -t "${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}-latest" \
         -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}" \
         -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}-latest" \
+        -t "${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}" \
+        -t "${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}-latest" \
         "${build_args[@]}" \
         "${container_build_dir}"
 done


### PR DESCRIPTION
## Description

Now that StackRox is open source 🎉 , there are a number of other repos and processes that depend on images being found under `quay.io/stackrox-io`. This PR pushes collector images there also. At some future point, it should be possible to remove the private docker.io/stackrox and quay.io/rhacs-eng registries but that would probably break other workflows and processes, so for now the change is yet another repo. (Which entails a somewhat kludgey 2nd login to quay.io in 100-push-images.sh).

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient + validate that images appear at quay.io/stackrox-io.