### PR TITLE
Push builder image to quay

### DIFF
--- a/.circleci/builder/save-collector-builder-image.sh
+++ b/.circleci/builder/save-collector-builder-image.sh
@@ -38,6 +38,6 @@ for repo in "${image_repos[@]}"; do
         docker tag "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}" "${repo}:cache"
 
         docker image inspect "${repo}:cache" > /dev/null
-        "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${repo}:cache"
+        "${SOURCE_ROOT}/scripts/push-as-manifest-list.sh" "${repo}:cache"
     fi
 done

--- a/.circleci/builder/save-collector-builder-image.sh
+++ b/.circleci/builder/save-collector-builder-image.sh
@@ -3,11 +3,34 @@ set -eo pipefail
 
 BRANCH=$1
 
-if [[ "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
-    # Push cache only if creating a new builder
-    docker push "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}"
-fi
-if [[ "$BRANCH" == "master" ]]; then
-    docker tag "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}" stackrox/collector-builder:cache
-    docker push stackrox/collector-builder:cache
-fi
+image_repos=(
+    "${DOCKER_REPO}/collector-builder"
+    "${QUAY_REPO}/collector-builder"
+    "${PUBLIC_REPO}/collector-builder"
+)
+
+for repo in "${image_repos[@]}"; do
+    if [[ "$repo" == "${PUBLIC_REPO}/collector-builder" ]]; then
+        # Relogin on quay is needed
+        docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" -p "$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+    fi
+
+    if [[ "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
+        # Push cache only if creating a new builder
+        docker push "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}"
+
+        image="${repo}:${COLLECTOR_BUILDER_TAG}"
+        echo "Pushing image ${image}"
+        docker image inspect "${image}" > /dev/null
+        "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${image}"
+
+    fi
+
+    if [[ "$BRANCH" == "master" ]]; then
+        image="${repo}:${COLLECTOR_BUILDER_TAG}"
+        echo "Pushing image ${image} as cache"
+        docker tag "${image}" "${repo}:cache"
+        docker image inspect "${repo}:cache" > /dev/null
+        "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${repo}:cache"
+    fi
+done

--- a/.circleci/builder/save-collector-builder-image.sh
+++ b/.circleci/builder/save-collector-builder-image.sh
@@ -20,13 +20,23 @@ for repo in "${image_repos[@]}"; do
     if [[ "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
         # Push cache only if creating a new builder
         echo "Pushing image ${image}"
+
+        # Only Docker image is build at this point, retag it for others.
+        # Tagging Docker image doesn't make any changes.
+        docker tag "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}" "${image}"
+
         docker image inspect "${image}" > /dev/null
         "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${image}"
 
     fi
 
     if [[ "$BRANCH" == "master" ]]; then
-        docker tag "${image}" "${repo}:cache"
+        echo "Pushing image ${repo}:cache"
+
+        # Only Docker image is build at this point, retag it for others.
+        # Tagging Docker image doesn't make any changes.
+        docker tag "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}" "${repo}:cache"
+
         docker image inspect "${repo}:cache" > /dev/null
         "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${repo}:cache"
     fi

--- a/.circleci/builder/save-collector-builder-image.sh
+++ b/.circleci/builder/save-collector-builder-image.sh
@@ -15,11 +15,10 @@ for repo in "${image_repos[@]}"; do
         docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" -p "$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
     fi
 
+    image="${repo}:${COLLECTOR_BUILDER_TAG}"
+
     if [[ "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
         # Push cache only if creating a new builder
-        docker push "stackrox/collector-builder:${COLLECTOR_BUILDER_TAG}"
-
-        image="${repo}:${COLLECTOR_BUILDER_TAG}"
         echo "Pushing image ${image}"
         docker image inspect "${image}" > /dev/null
         "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${image}"
@@ -27,8 +26,6 @@ for repo in "${image_repos[@]}"; do
     fi
 
     if [[ "$BRANCH" == "master" ]]; then
-        image="${repo}:${COLLECTOR_BUILDER_TAG}"
-        echo "Pushing image ${image} as cache"
         docker tag "${image}" "${repo}:cache"
         docker image inspect "${repo}:cache" > /dev/null
         "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${repo}:cache"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,10 +363,15 @@ jobs:
   builder:
     <<: *defaultMachine
     resource_class: large
+    environment:
+    - QUAY_REPO: << pipeline.parameters.quay-repo >>
+    - DOCKER_REPO: "docker.io/stackrox"
+    - PUBLIC_REPO: "quay.io/stackrox-io"
 
     steps:
     - initcommand
     - docker-login-push
+    - quay-login-push
 
     - run:
         name: Restore collector-builder image


### PR DESCRIPTION
## Description

For building open sourced StackRox, builder image has to be pushed to
the public quay as well. Do this similarly to #644.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

CI results are sufficient.