### PR TITLE
Specify main/master branch for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,36 @@
 [submodule "grpc"]
 	path = third_party/grpc
 	url = https://github.com/grpc/grpc
+	branch = master
 [submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git
+	branch = master
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/protocolbuffers/protobuf.git
+	branch = main
 [submodule "third_party/googleapis"]
 	path = third_party/googleapis
 	url = https://github.com/googleapis/googleapis.git
+	branch = master
 [submodule "third_party/luajit"]
 	path = third_party/luajit
 	url = https://luajit.org/git/luajit.git
+	branch = master
 [submodule "third_party/prometheus-cpp"]
 	path = third_party/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp
+	branch = master
 [submodule "third_party/civetweb"]
 	path = third_party/civetweb
 	url = https://github.com/civetweb/civetweb.git
+	branch = master
 [submodule "third_party/libb64"]
 	path = third_party/libb64
 	url = https://github.com/libb64/libb64.git
+	branch = master
 [submodule "falcosecurity-libs"]
 	path = falcosecurity-libs
 	url = https://github.com/stackrox/falcosecurity-libs
+	branch = master


### PR DESCRIPTION
## Description

Due to a bug in GitPython (used by CPaaS), submodules having a `main` branch are not properly cloned. This PR adds the `branch` value to every submodule in `.gitmodules` which seems to workaround this issue.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Regular CI run should be enough.
