### PR TITLE
Specify the main branch for protobuf submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,7 @@
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/protocolbuffers/protobuf.git
+    branch = main
 [submodule "third_party/googleapis"]
 	path = third_party/googleapis
 	url = https://github.com/googleapis/googleapis.git


### PR DESCRIPTION
For the collector issue: [current hypothesis](https://chat.google.com/room/AAAATiT7PR8/AWoswJ8-jxw) is that Cachito needs you to specify the branch in submodules where the branch is not "master", due to https://github.com/gitpython-developers/GitPython/issues/1058; and also https://github.com/protocolbuffers/protobuf/blob/master/src/README.md renamed the main branch to "main" recently, as shown by the github redirection. We just have to [update .gitmodules](https://github.com/jaegertracing/jaeger/pull/3452/files#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584) (edited)