### PR TITLE
Use UBI minimal as the base for collector image

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -1,12 +1,12 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8/ubi
+ARG BASE_IMAGE=ubi8/ubi-minimal
 ARG BASE_TAG=8.5
-
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
 COPY bundle.tar.gz /
+COPY extract-bundle.sh /bundle/
 WORKDIR /bundle
-RUN tar -xzf /bundle.tar.gz
+RUN ./extract-bundle.sh
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 

--- a/collector/container/devel/extract-bundle.sh
+++ b/collector/container/devel/extract-bundle.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+tar -xzf /bundle.tar.gz

--- a/collector/container/rhel/extract-bundle.sh
+++ b/collector/container/rhel/extract-bundle.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+microdnf install -y tar gzip
+tar -xzf /bundle.tar.gz

--- a/collector/container/rhel/final-step.sh
+++ b/collector/container/rhel/final-step.sh
@@ -6,11 +6,11 @@ echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 
 mv collector-wrapper.sh /usr/local/bin/
 chmod 700 bootstrap.sh
-dnf upgrade -y
-dnf install -y kmod
+microdnf upgrade -y
+microdnf install -y kmod findutils
 
-dnf clean all
-rpm --query --all 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' | xargs rpm -e --nodeps
-rm -rf /var/cache/dnf
+microdnf clean all
+rpm --query --all 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'findutils' | xargs -t rpm -e --nodeps
+rm -rf /var/cache/yum
 
 echo "${MODULE_VERSION}" > /kernel-modules/MODULE_VERSION.txt


### PR DESCRIPTION
## Description

In order to diminish the potential attack surface for the collector image, the base image for it has been replaced with ubi-minimal.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI run should be enough.
