### PR TITLE
Check 'circleci' command is available before halt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ commands:
           if [[ ! -s ~/workspace/build-tasks ]]; then
             echo "Nothing was built, skipping this job"
 
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
   dockerized-should-run:
@@ -162,8 +162,8 @@ commands:
         command: |
           if [[ ! -f ~/workspace/pr-metadata/labels/run-dockerized-steps ]]; then
             echo "Skipping dockerized build jobs."
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
   stackrox-io-login:
@@ -683,8 +683,8 @@ jobs:
           if [[ ! -s "${WORKSPACE_ROOT}/task-shard-$(printf '%02d' "$CIRCLE_NODE_INDEX")" ]]; then
             echo "Nothing to be done for this shard."
 
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
     - gcloud-init
@@ -906,14 +906,14 @@ jobs:
         command: |
           if [[ -f "${WORKSPACE_ROOT}/pr-metadata/labels/skip-integration-tests" ]]; then
             echo "Skipping job with skip-integration-tests label."
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
           if [[ "<< parameters.dockerized >>" == "true" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/run-dockerized-steps" ]]; then
             echo "Skipping dockerized build jobs."
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
     - add_ssh_keys
@@ -1001,8 +1001,8 @@ jobs:
         command: |
           if [[ -f "${WORKSPACE_ROOT}/pr-metadata/labels/skip-integration-tests" ]]; then
             echo "Skipping job with skip-integration-tests label."
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
     - run:
@@ -1041,7 +1041,7 @@ jobs:
           command: |
             if [[ "$CIRCLE_BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/test-support-packages" ]]; then
               echo "On a PR without the test-support-packages label. Not building support packages."
-              circleci step halt
+              "${CI_ROOT}/safe-halt.sh"
             fi
 
       - setup_remote_docker:
@@ -1174,8 +1174,8 @@ jobs:
           if [[ ( "$CIRCLE_BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/reload-released-images" ) \
              || ( "$CIRCLE_BRANCH" == "master" && -z "$( find "${mod_build_dir}" -type f -name '*.gz' )" ) ]]; then
             echo "Not reloading released images"
-            circleci step halt
-            exit 0
+            "${CI_ROOT}/safe-halt.sh"
+            exit
           fi
 
     - run:

--- a/.circleci/kernels/10-determine-tasks-for-current-shard.sh
+++ b/.circleci/kernels/10-determine-tasks-for-current-shard.sh
@@ -22,8 +22,8 @@ this_shard_file=~/kobuild-tmp/task-shard-"$(printf '%02d' "$NODE_INDEX")"
 
 if [[ ! -s "$this_shard_file" ]]; then
     echo "Nothing to be done for this shard."
-    circleci step halt
-    exit 0
+    "${CI_ROOT}/safe-halt.sh"
+    exit
 fi
 
 mv "$this_shard_file" ~/kobuild-tmp/local-build-tasks

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 circleci_halt() {
-    if command -v circleci > /dev/null; then
+    if command -v circleci-agent > /dev/null; then
         circleci-agent step halt
         exit 0
     fi
@@ -16,5 +16,5 @@ for _ in {1..5}; do
     circleci_halt
 done
 
-echo >&2 "Failed to run 'circleci' command"
+echo >&2 "Failed to run 'circleci-agent' command"
 exit 1

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -2,12 +2,18 @@
 
 set -euo pipefail
 
-for _ in {1..5}; do
-    if command -v circleci; then
+circleci_halt() {
+    if command -v circleci > /dev/null; then
         circleci step halt
         exit 0
     fi
+}
+
+circleci_halt
+
+for _ in {1..5}; do
     sleep 5
+    circleci_halt
 done
 
 echo >&2 "Failed to run 'circleci' command"

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 circleci_halt() {
     if command -v circleci > /dev/null; then
-        circleci step halt
+        circleci-agent step halt
         exit 0
     fi
 }

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+# This script checks the 'circleci-agent' command exists before attempting to
+# call it. We were having failures in CircleCI where the 'circleci' command was
+# not found, so this script attempts to mitigate this problem by:
+# - Checking the script exists before calling it.
+# - Retry up to 5 times every 5 seconds if the first call fails.
+#
+# The 'circleci' command was also replace by ' circleci-agent', since this last
+# command is actually in charge of handling 'circleci step' calls.
+
 circleci_halt() {
     if command -v circleci-agent > /dev/null; then
         circleci-agent step halt

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # This script checks the 'circleci-agent' command exists before attempting to
 # call it. We were having failures in CircleCI where the 'circleci' command was
 # not found, so this script attempts to mitigate this problem by:
-# - Checking the script exists before calling it.
+# - Checking the command exists before calling it.
 # - Retry up to 5 times every 5 seconds if the first call fails.
 #
-# The 'circleci' command was also replace by ' circleci-agent', since this last
+# The 'circleci' command was also replaced by ' circleci-agent', since this last
 # command is actually in charge of handling 'circleci step' calls.
 
 circleci_halt() {

--- a/.circleci/safe-halt.sh
+++ b/.circleci/safe-halt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for _ in {1..5}; do
+    if command -v circleci; then
+        circleci step halt
+        exit 0
+    fi
+    sleep 5
+done
+
+echo >&2 "Failed to run 'circleci' command"
+exit 1


### PR DESCRIPTION
## Description

A few instances of CI has been failing when halting with a message stating that the command `circleci` is not found, this PR attempts to mitigate that error by wrapping the `circleci step halt` instruction in a script that retries it a few times.

The `circleci` command has also been replaced by `circleci-agent`, as described [here](https://discuss.circleci.com/t/documentation-for-circleci-agent/36594/3), `circleci step` is indirectly handled by `circleci-agent`, so removing the middle man might also help.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

I've run CI 4 times and no error on commands not being found have showed up.
