### PR TITLE
Disable ubi-image CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ runOnAllTagsWithIntegrationTestRequires: &runOnAllTagsWithIntegrationTestRequire
     - redhat-developer-account-login
   requires:
   - images
-  - ubi-image
+  # - ubi-image
   - integration-test-local
   - dockerized-build-collector
 
@@ -189,7 +189,7 @@ jobs:
     environment:
     - SOURCE_ROOT: /home/circleci/workspace/go/src/github.com/stackrox/collector
     - CI_ROOT: /home/circleci/workspace/go/src/github.com/stackrox/collector/.circleci
-    - SHARED_ENV: /home/circleci/workspace/shared-env 
+    - SHARED_ENV: /home/circleci/workspace/shared-env
 
     steps:
     - checkout:
@@ -1314,14 +1314,14 @@ workflows:
         - collector
         - kernels
         - join-modules
-    - ubi-image:
-        <<: *runOnAllTags
-        context:
-          - docker-io-push
-          - quay-rhacs-eng-readwrite
-          - redhat-developer-account-login
-        requires:
-        - initjob
+    # - ubi-image:
+    #     <<: *runOnAllTags
+    #     context:
+    #       - docker-io-push
+    #       - quay-rhacs-eng-readwrite
+    #       - redhat-developer-account-login
+    #     requires:
+    #     - initjob
     - run-stackrox-ci:
         <<: *runOnAllTagsWithDockerIOPullCtx
         requires:
@@ -1333,14 +1333,14 @@ workflows:
         requires:
         - images
         - upload-modules
-    - integration-test-local:
-        <<: *runOnAllTagsWithDockerIOPushCtx
-        name: integration-test-local-ubi
-        vm-config: rhel
-        use-ubi: true
-        requires:
-        - ubi-image
-        - upload-modules
+    # - integration-test-local:
+    #     <<: *runOnAllTagsWithDockerIOPushCtx
+    #     name: integration-test-local-ubi
+    #     vm-config: rhel
+    #     use-ubi: true
+    #     requires:
+    #     - ubi-image
+    #     - upload-modules
     - integration-test:
         <<: *runOnAllTagsWithIntegrationTestRequires
         name: test-ebpf-<< matrix.image_family >><<# matrix.dockerized >>-dockerized<</ matrix.dockerized >>


### PR DESCRIPTION
## Description

The UBI image steps have been failing due to expired credentials, we can disable them while we get this sorted out.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Green CI run is enough.
