### PR TITLE
Re-add update-suppport-package CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
     environment:
     - SOURCE_ROOT: /home/circleci/workspace/go/src/github.com/stackrox/collector
     - CI_ROOT: /home/circleci/workspace/go/src/github.com/stackrox/collector/.circleci
-    - SHARED_ENV: /home/circleci/workspace/shared-env 
+    - SHARED_ENV: /home/circleci/workspace/shared-env
 
     steps:
     - checkout:
@@ -1488,6 +1488,14 @@ workflows:
           - docker-io-and-stackrox-io-push
           - quay-rhacs-eng-readonly
           - quay-rhacs-eng-readwrite
+          - collector-support
+        requires:
+          - upload-modules
+    - update-support-packages:
+        <<: *runOnAllTags
+        context:
+          - docker-io-and-stackrox-io-push
+          - quay-rhacs-eng-readonly
           - collector-support
         requires:
           - upload-modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1495,7 +1495,6 @@ workflows:
         <<: *runOnAllTags
         context:
           - docker-io-and-stackrox-io-push
-          - quay-rhacs-eng-readonly
           - collector-support
         requires:
           - upload-modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1495,6 +1495,7 @@ workflows:
         <<: *runOnAllTags
         context:
           - docker-io-and-stackrox-io-push
+          - quay-rhacs-eng-readonly
           - collector-support
         requires:
           - upload-modules


### PR DESCRIPTION
## Description

The CI step seems to have been removed by accident during some refactoring

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Run PR with `test-support-packages` label.
