### PR TITLE
Bump Garden Linux VM version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1444,12 +1444,12 @@ workflows:
           parameters:
             collection_method: [module, ebpf]
             dockerized: [false, true]
-            image_version: [576-7-7d3c7d]
+            image_version: [576-8-7c12cd]
           exclude:
             # Failing due to dockerized module not being built (requires gcc-10).
             - collection_method: module
               dockerized: true
-              image_version: 576-7-7d3c7d
+              image_version: 576-8-7c12cd
     - integration-test-data:
         <<: *runOnAllTagsWithDockerIOPullCtx
         requires:


### PR DESCRIPTION
## Description

Bumps version of the Garden Linux VM used in integration tests to 576.8

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Garden Linux integration tests are still working