### PR TITLE
Bump Ubuntu VMs to 22.04 LTS in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -915,7 +915,7 @@ jobs:
           sles-15-sp2-sap,
           ubuntu-1804-lts,
           ubuntu-2004-lts,
-          ubuntu-2110,
+          ubuntu-2204-lts,
           ubuntu-pro-1804-lts
         ]
       image_name:
@@ -1401,12 +1401,12 @@ workflows:
         vm_type: ubuntu-os
         matrix:
           parameters:
-            image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2110]
+            image_family: [ubuntu-1804-lts, ubuntu-2004-lts, ubuntu-2204-lts]
             collection_method: [module, ebpf]
             dockerized: [false, true]
           exclude:
             # Failing due to GLIC 2.33 not available on ubi 8
-            - image_family: ubuntu-2110
+            - image_family: ubuntu-2204-lts
               collection_method: module
               dockerized: true
     - integration-test:
@@ -1502,8 +1502,8 @@ workflows:
         - test-ebpf-ubuntu-1804-lts
         - test-module-ubuntu-2004-lts
         - test-ebpf-ubuntu-2004-lts
-        - test-module-ubuntu-2110
-        - test-ebpf-ubuntu-2110
+        - test-module-ubuntu-2204-lts
+        - test-ebpf-ubuntu-2204-lts
         - test-ebpf-sles-15
         - test-module-sles-15
         - test-module-sles-12

--- a/.circleci/test-scripts/baseline/compare-and-update-baseline.sh
+++ b/.circleci/test-scripts/baseline/compare-and-update-baseline.sh
@@ -5,7 +5,7 @@ pip install --upgrade scipy google-cloud-storage
 
 jq -s 'flatten' "${WORKSPACE_ROOT}"/*perf.json > "${WORKSPACE_ROOT}"/all-perf.json
 
-export BASELINE="${CI_ROOT}/test-scripts/baseline/"
+export BASELINE="${CI_ROOT}/test-scripts/baseline"
 "${BASELINE}"/main.py --test "${WORKSPACE_ROOT}"/all-perf.json \
     | sort \
     | awk -f "${BASELINE}"/format.awk > "${WORKSPACE_ROOT}"/benchmark.md

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -105,7 +105,7 @@ def add_to_baseline_file(input_file_name, data, threshold):
         result = []
         for key, values in group_data(data, "VmConfig", "CollectionMethod"):
             if key not in new_measurement_keys:
-                # Drop removed VMs
+                # Drop removed tests
                 continue
 
             # For every group (vm, method) sort the records in ascending order
@@ -181,8 +181,11 @@ def group_data(content, *columns):
     def record_id(record):
         return " ".join([record.get(c) for c in columns])
 
-    content.sort(key=record_id)
-    return [(key, list(group)) for key, group in groupby(content, key=record_id)]
+    ordered = sorted(content, key=record_id)
+    return [
+        (key, list(group))
+        for key, group in groupby(ordered, key=record_id)
+    ]
 
 
 def split_benchmark(measurements):

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -182,7 +182,7 @@ def group_data(content, *columns):
         return " ".join([record.get(c) for c in columns])
 
     content.sort(key=record_id)
-    return [(key, [group]) for key, group in groupby(content, key=record_id)]
+    return [(key, list(group)) for key, group in groupby(content, key=record_id)]
 
 
 def split_benchmark(measurements):
@@ -223,9 +223,6 @@ def compare(input_file_name, baseline_data):
             tgroup, tvalues = test
 
             assert bgroup == tgroup, "Kernel/Method must not be differrent"
-
-            bvalues = list(bvalues)
-            tvalues = list(tvalues)
 
             baseline_overhead = collector_overhead(bvalues)
             test_overhead = collector_overhead(tvalues)[0]

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -36,8 +36,7 @@ import os
 import sys
 import time
 
-from itertools import groupby, zip_longest
-from collections import Counter
+from itertools import groupby
 from scipy import stats
 
 from google.oauth2 import service_account
@@ -72,7 +71,7 @@ def load_baseline_file(bucket_name, baseline_file):
         contents = blob.download_as_string()
         return json.loads(contents)
 
-    except NotFound as ex:
+    except NotFound:
         print(f"File gs://{bucket_name}/{baseline_file} not found. "
               f"Creating a new empty one.", file=sys.stderr)
 
@@ -98,15 +97,17 @@ def get_timestamp(record):
 def add_to_baseline_file(input_file_name, data, threshold):
     with open(input_file_name, "r") as measure:
         new_measurement = json.load(measure)
-
-        if data:
-            verify_new_data(data, new_measurement)
+        new_measurement_keys = [data[0] for data in group_data(measure, "VmConfig", "CollectionMethod")]
 
         # Baseline contains several tests per one benchmark record
         test_names = set(value["TestName"] for value in data)
 
         result = []
-        for _, values in group_data(data, "VmConfig", "CollectionMethod"):
+        for key, values in group_data(data, "VmConfig", "CollectionMethod"):
+            if key not in new_measurement_keys:
+                # Drop removed VMs
+                continue
+
             # For every group (vm, method) sort the records in ascending order
             # to get rid of the oldest data (at the beginning or the list).
             ordered = sorted(values, key=get_timestamp)
@@ -126,45 +127,35 @@ def add_to_baseline_file(input_file_name, data, threshold):
         return result
 
 
-def verify_new_data(baseline_data, new_data):
+def process_data(baseline_data, new_data):
     """
-    Enforce compatibility between baseline data and a new chunk of numbers. Two
-    invariants needs to be maintained:
+    Remove any tests that are not found in both the baseline and the new data.
 
-    * both baseline and new data have the same set of (VmConfig, CollectionMethod)
-
-    * New data provides equal number of with/without collector benchmark runs
-
-    The function expects baseline is not empty.
-
+    This is done for 2 reasons:
+    - Data that shows up in the baseline but not in the new data is considered a
+      removed test. There is no point in processing this.
+    - Data that shows up in the new data but not in the baseline is considered
+      a new test that doesn't have an associated baseline yet. The baseline for
+      the new test will be added after it is merged into master.
     """
-
     assert baseline_data, "Baseline data must be not empty"
 
     baseline_grouped = process(baseline_data)
     new_grouped = process(new_data)
 
-    for (baseline, new) in zip_longest(baseline_grouped, new_grouped):
-        bgroup, bvalues = baseline
-        ngroup, nvalues = new
+    new_keys = [items[0] for items in new_grouped]
+    baseline_filtered = [
+        data for data in baseline_grouped
+        if data[0] in new_keys
+    ]
 
-        if bgroup != ngroup:
-            raise Exception(f"Benchmark metrics do not match:"
-                            f" {bgroup}, {ngroup} ")
+    baseline_keys = [items[0] for items in baseline_filtered]
+    new_filtered = [
+        data for data in new_grouped
+        if data[0] in baseline_keys
+    ]
 
-        counter = Counter()
-        for v in nvalues:
-            counter.update(v.keys())
-
-        # We rely only on baseline/collector hackbench at the moment. As soon
-        # as data for more tests will be collected, this section has to be
-        # extended accordingly.
-        no_overhead_count = counter.get("baseline_benchmark", 0)
-        overhead_count = counter.get("collector_benchmark", 0)
-
-        if (no_overhead_count != overhead_count):
-            raise Exception(f"Number of with/without overhead do not match:"
-                            f" {no_overhead_count}, {overhead_count} ")
+    return (baseline_filtered, new_filtered)
 
 
 def process(content):
@@ -190,8 +181,8 @@ def group_data(content, *columns):
     def record_id(record):
         return " ".join([record.get(c) for c in columns])
 
-    ordered = sorted(content, key=record_id)
-    return groupby(ordered, key=record_id)
+    content.sort(key=record_id)
+    return [(key, [group]) for key, group in groupby(content, key=record_id)]
 
 
 def split_benchmark(measurements):
@@ -225,10 +216,7 @@ def compare(input_file_name, baseline_data):
 
     with open(input_file_name, "r") as measurement:
         test_data = json.load(measurement)
-        verify_new_data(baseline_data, test_data)
-
-        baseline_grouped = process(baseline_data)
-        test_grouped = process(test_data)
+        baseline_grouped, test_grouped = process_data(baseline_data, test_data)
 
         for (baseline, test) in zip(baseline_grouped, test_grouped):
             bgroup, bvalues = baseline


### PR DESCRIPTION
## Description

Version 22.04 is the next LTS release for Ubuntu, this PR bumps the previous short term support VMs used in integration tests to this version instead.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Updated documentation accordingly~

**Automated testing**
  - [ ] ~Added unit tests~
  - [ ] ~Added integration tests~
  - [ ] ~Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Integration tests on Ubuntu 22.04 LTS pass.
- [x] Automated performance PR comment is properly generated.
- [x] Dockerized tests work with eBPF and is not run with kernel module.