### PR TITLE
Fix dockerized tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,14 +764,13 @@ jobs:
     steps:
     - initcommand
     - dockerized-should-run
-    - quay-login
-    - docker-login-push
+    - quay-login-push
 
     - run:
         name: Build full collector image
         command: |
           "${SOURCE_ROOT}/.circleci/dockerized-drivers/build-full-collector.sh" \
-            "docker.io/stackrox"
+            "<< pipeline.parameters.quay-repo >>"
 
   run-stackrox-ci:
     <<: *defaultImage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1313,8 +1313,7 @@ workflows:
     - dockerized-build-collector:
         <<: *runOnAllTags
         context:
-          - docker-io-push
-          - quay-rhacs-eng-readonly
+          - quay-rhacs-eng-readwrite
         requires:
           - dockerized-unify-images
           - images


### PR DESCRIPTION
## Description

After #674 was merged, a mismatch between the registry to where the dockerized collector image is pushed and the one the integration tests try to pull them from was introduced. This PR solves this mismatch.

You can see this failure happening in #673. ([CI run](https://app.circleci.com/pipelines/github/stackrox/collector/8768/workflows/c862dd5b-3cff-4e83-ae4b-fbca87d54527))

## Checklist
- [x] Investigated and inspected CI test results
- [ ]  ~Updated documentation accordingly~

**Automated testing**
  - [ ] ~Added unit tests~
  - [ ] ~Added integration tests~
  - [ ] ~Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run the PR with the `run-dockerized-steps` label and have all checks green.
