### PR TITLE
ROX-10044: Add SHA256 checksum to support packages

### DIFF
--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -7,7 +7,7 @@ die() {
     exit 1
 }
 
-generate_signature() {
+generate_checksum() {
     directory=$1
     file=$2
     pushd "${directory}"
@@ -47,10 +47,10 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     (   
         cd "$package_root"
         zip -r "${package_out_dir}/${filename}" .
-        generate_signature "${package_out_dir}" "${filename}"
+        generate_checksum "${package_out_dir}" "${filename}"
     )
 
     cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
-    generate_signature "${package_out_dir}" "${latest_filename}"
+    generate_checksum "${package_out_dir}" "${latest_filename}"
     rm -rf "$package_root" || true
 done

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -39,7 +39,10 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     (   
         cd "$package_root"
         zip -r "${package_out_dir}/${filename}" .
+        sha256sum "${package_out_dir}/${filename}" > "${package_out_dir}/${filename}.sig"
     )
+
     cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
+    cp "${package_out_dir}/${filename}.sig" "${package_out_dir}/${latest_filename}.sig"
     rm -rf "$package_root" || true
 done

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -7,6 +7,14 @@ die() {
     exit 1
 }
 
+generate_signature() {
+    directory=$1
+    file=$2
+    pushd "${directory}"
+    sha256sum "${file}" > "${file}.sha256"
+    popd
+}
+
 LICENSE_FILE="$1"
 MD_DIR="$2"
 OUT_DIR="$3"
@@ -39,10 +47,10 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     (   
         cd "$package_root"
         zip -r "${package_out_dir}/${filename}" .
-        sha256sum "${package_out_dir}/${filename}" > "${package_out_dir}/${filename}.sig"
+        generate_signature "${package_out_dir}" "${filename}"
     )
 
     cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
-    cp "${package_out_dir}/${filename}.sig" "${package_out_dir}/${latest_filename}.sig"
+    generate_signature "${package_out_dir}" "${latest_filename}"
     rm -rf "$package_root" || true
 done

--- a/kernel-modules/support-packages/05-create-index.py
+++ b/kernel-modules/support-packages/05-create-index.py
@@ -94,12 +94,12 @@ def load_support_packages(output_dir, mod_md_map):
         except (FileNotFoundError, PermissionError):
             support_pkg_file_latest = None
 
-        support_pkg_sig = f'{support_pkg_file}.sig'
+        support_pkg_sig = f'{support_pkg_file}.sha256'
         if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig)):
             # No signature available for package
             continue
 
-        support_pkg_sig_latest = f'{support_pkg_file_latest}.sig'
+        support_pkg_sig_latest = f'{support_pkg_file_latest}.sha256'
         if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig_latest)):
             # No signature available for package
             support_pkg_sig_latest = None

--- a/kernel-modules/support-packages/05-create-index.py
+++ b/kernel-modules/support-packages/05-create-index.py
@@ -19,15 +19,15 @@ class SupportPackage(object):
                  file_name,
                  latest_file_name,
                  last_update_time,
-                 sig_name,
-                 latest_sig_name):
+                 chk_name,
+                 latest_chk_name):
         self.module_version = module_version
         self.rox_version_ranges = rox_version_ranges
         self.file_name = file_name
         self.latest_file_name = latest_file_name
         self.last_update_time = last_update_time
-        self.sig_name = sig_name
-        self.latest_sig_name = latest_sig_name
+        self.chk_name = chk_name
+        self.latest_chk_name = latest_chk_name
 
     @property
     def download_url(self):
@@ -39,13 +39,13 @@ class SupportPackage(object):
             if self.latest_file_name is not None else None
 
     @property
-    def signature_url(self):
-        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.sig_name)
+    def checksum_url(self):
+        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.chk_name)
 
     @property
-    def signature_url_latest(self):
-        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.latest_sig_name) \
-            if self.latest_sig_name is not None else None
+    def checksum_url_latest(self):
+        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.latest_chk_name) \
+            if self.latest_chk_name is not None else None
 
     def __repr__(self):
         return 'SupportPackage(' + \
@@ -94,15 +94,15 @@ def load_support_packages(output_dir, mod_md_map):
         except (FileNotFoundError, PermissionError):
             support_pkg_file_latest = None
 
-        support_pkg_sig = f'{support_pkg_file}.sha256'
-        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig)):
-            # No signature available for package
+        support_pkg_chk = f'{support_pkg_file}.sha256'
+        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_chk)):
+            # No checksum available for package
             continue
 
-        support_pkg_sig_latest = f'{support_pkg_file_latest}.sha256'
-        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig_latest)):
-            # No signature available for package
-            support_pkg_sig_latest = None
+        support_pkg_chk_latest = f'{support_pkg_file_latest}.sha256'
+        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_chk_latest)):
+            # No checksum available for package
+            support_pkg_chk_latest = None
 
         support_packages.append(
             SupportPackage(mod_ver,
@@ -110,8 +110,8 @@ def load_support_packages(output_dir, mod_md_map):
                            support_pkg_file,
                            support_pkg_file_latest,
                            last_mod_time,
-                           support_pkg_sig,
-                           support_pkg_sig_latest)
+                           support_pkg_chk,
+                           support_pkg_chk_latest)
         )
 
     support_packages.sort(key=lambda p: p.rox_version_ranges[0].max, reverse=True)

--- a/kernel-modules/support-packages/05-create-index.py
+++ b/kernel-modules/support-packages/05-create-index.py
@@ -13,12 +13,21 @@ VersionRange = namedtuple('VersionRange', 'min max')
 
 
 class SupportPackage(object):
-    def __init__(self, module_version, rox_version_ranges, file_name, latest_file_name, last_update_time):
+    def __init__(self,
+                 module_version,
+                 rox_version_ranges,
+                 file_name,
+                 latest_file_name,
+                 last_update_time,
+                 sig_name,
+                 latest_sig_name):
         self.module_version = module_version
         self.rox_version_ranges = rox_version_ranges
         self.file_name = file_name
         self.latest_file_name = latest_file_name
         self.last_update_time = last_update_time
+        self.sig_name = sig_name
+        self.latest_sig_name = latest_sig_name
 
     @property
     def download_url(self):
@@ -27,6 +36,15 @@ class SupportPackage(object):
     @property
     def download_url_latest(self):
         return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.latest_file_name) \
+            if self.latest_file_name is not None else None
+
+    @property
+    def signature_url(self):
+        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.sig_name)
+
+    @property
+    def signature_url_latest(self):
+        return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.latest_sig_name) \
             if self.latest_file_name is not None else None
 
     def __repr__(self):
@@ -73,11 +91,28 @@ def load_support_packages(output_dir, mod_md_map):
         support_pkg_file_latest = 'support-pkg-%s-latest.zip' % (mod_ver[:6])
         try:
             os.stat(os.path.join(mod_out_dir, support_pkg_file_latest))
-        except:
+        except (FileNotFoundError, PermissionError):
             support_pkg_file_latest = None
 
-        support_packages.append(SupportPackage(
-            mod_ver, rox_version_ranges, support_pkg_file, support_pkg_file_latest, last_mod_time))
+        support_pkg_sig = f'{support_pkg_file}.sig'
+        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig)):
+            # No signature available for package
+            continue
+
+        support_pkg_sig_latest = f'{support_pkg_file_latest}.sig'
+        if not os.path.isfile(os.path.join(mod_out_dir, support_pkg_sig_latest)):
+            # No signature available for package
+            support_pkg_sig_latest = None
+
+        support_packages.append(
+            SupportPackage(mod_ver,
+                           rox_version_ranges,
+                           support_pkg_file,
+                           support_pkg_file_latest,
+                           last_mod_time,
+                           support_pkg_sig,
+                           support_pkg_sig_latest)
+        )
 
     support_packages.sort(key=lambda p: p.rox_version_ranges[0].max, reverse=True)
     return support_packages

--- a/kernel-modules/support-packages/05-create-index.py
+++ b/kernel-modules/support-packages/05-create-index.py
@@ -45,7 +45,7 @@ class SupportPackage(object):
     @property
     def signature_url_latest(self):
         return '%s/%s/%s' % (os.getenv('BASE_URL'), self.module_version, self.latest_sig_name) \
-            if self.latest_file_name is not None else None
+            if self.latest_sig_name is not None else None
 
     def __repr__(self):
         return 'SupportPackage(' + \

--- a/kernel-modules/support-packages/README
+++ b/kernel-modules/support-packages/README
@@ -26,6 +26,10 @@ that contains all Rox versions that use a collector with the respective module v
 For every relevant module version, creates a file `OUTPUT/<module version>/<support package filename>.zip`
 containing the relevant probes.
 
+We also calculate the sha256 for each support package and dump it to files with the format
+`OUTPUT/<module version>/<support package filename>.zip.sha256`, making it possible to validate the integrity of the
+packages.
+
 5. Generate index.html file
 -------------------------------------------------
 Generates a file `OUTPUT/index.html` that contains an overview of support packages for all versions.

--- a/kernel-modules/support-packages/templates/index.html
+++ b/kernel-modules/support-packages/templates/index.html
@@ -3242,6 +3242,8 @@
             {% if support_packages %}
             <em>Note:</em> The "stable link" always points to the latest support package for a given version. It will retain
             its validity when a support package is updated, but the contents of the downloaded file change over time.
+            In order to check the integrity of the support package, download the corresponding checksum file to the same
+            directory you stored the package in and run: sha256sum -c &ltchecksum-file&gt
             <p></p>
             <table>
                 <thead>

--- a/kernel-modules/support-packages/templates/index.html
+++ b/kernel-modules/support-packages/templates/index.html
@@ -3245,7 +3245,7 @@
             <p></p>
             <table>
                 <thead>
-                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th></tr>
+                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th><th>Signature</th>/tr>
                 </thead>
                 <tbody>
                     {% for pkg in support_packages %}
@@ -3262,6 +3262,7 @@
                         </td>
                         <td>{{pkg.last_update_time}}</td>
                         <td><a href="{{pkg.download_url}}">Download</a>{% if pkg.download_url_latest %} (<a href="{{pkg.download_url_latest}}">stable link</a>){% endif %}</td>
+                        <td><a href="{{pkg.signature_url}}">SHA256</a>{% if pkg.signature_url_latest %} (<a href="{{pkg.signature_url_latest}}">stable link</a>){% endif %}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/kernel-modules/support-packages/templates/index.html
+++ b/kernel-modules/support-packages/templates/index.html
@@ -3245,7 +3245,7 @@
             <p></p>
             <table>
                 <thead>
-                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th><th>Signature</th>/tr>
+                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th><th>Signature</th></tr>
                 </thead>
                 <tbody>
                     {% for pkg in support_packages %}

--- a/kernel-modules/support-packages/templates/index.html
+++ b/kernel-modules/support-packages/templates/index.html
@@ -3262,7 +3262,7 @@
                         </td>
                         <td>{{pkg.last_update_time}}</td>
                         <td><a href="{{pkg.download_url}}">Download</a>{% if pkg.download_url_latest %} (<a href="{{pkg.download_url_latest}}">stable link</a>){% endif %}</td>
-                        <td><a href="{{pkg.signature_url}}">SHA256</a>{% if pkg.signature_url_latest %} (<a href="{{pkg.signature_url_latest}}">stable link</a>){% endif %}</td>
+                        <td><a href="{{pkg.checksum_url}}">SHA256</a>{% if pkg.checksum_url_latest %} (<a href="{{pkg.checksum_url_latest}}">stable link</a>){% endif %}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/kernel-modules/support-packages/templates/index.html
+++ b/kernel-modules/support-packages/templates/index.html
@@ -3245,7 +3245,7 @@
             <p></p>
             <table>
                 <thead>
-                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th><th>Signature</th></tr>
+                    <tr><th>StackRox Version(s)</th><th>Last updated</th><th>Download Link</th><th>Checksum</th></tr>
                 </thead>
                 <tbody>
                     {% for pkg in support_packages %}


### PR DESCRIPTION
## Description

Added a small step after creating the support package to have the sha256 checksum for said files to be output into an accompanying file with the same name and the `.sha256` extension. Content of the file looks like this:

```
130bfe6e3c95e924675714ac6cd31c7466b241fd27101bdaadd7ef3fb3138455  support-pkg-b6745d-latest.zip
```

So downloading it in the same directory as the support package and running `sha256sum -c support-pkg-b6745d-latest.zip.sha256` directly validates the file.

The checksum will also be added to the published index of packages for interested parties to be able to verify the contents of them.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] ~Added unit tests~
  - [ ] ~Added integration tests~
  - [ ] ~Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Manually download and validate the generated support packages and checksum files.
- [x] Check the index.html is rendered correctly.
