### PR TITLE
ROX-10260 - Fix afterglow bug

### DIFF
--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -195,10 +195,10 @@ class ConnectionTracker {
 /* static */
 template <typename T>
 void ConnectionTracker::UpdateOldState(UnorderedMap<T, ConnStatus>* old_state, const UnorderedMap<T, ConnStatus>& new_state, int64_t time_micros, int64_t afterglow_period_micros) {
-  // Remove inactive connections that are older than the afterglow period and add unexpired new connections to the old state
+  // Remove connections that are older than the afterglow period and add unexpired new connections to the old state
   for (auto it = old_state->begin(); it != old_state->end();) {
     auto& old_conn = *it;
-    if (old_conn.second.WasRecentlyActive(time_micros, afterglow_period_micros)) {
+    if (old_conn.second.IsInAfterglowPeriod(time_micros, afterglow_period_micros)) {
       ++it;
     } else {
       it = old_state->erase(it);

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1076,7 +1076,7 @@ TEST(ConnTrackerTest, TestUpdateOldStateSameConnectionInOldAndNew) {
   EXPECT_THAT(old_state, new_state);
 }
 
-TEST(ConnTrackerTest, TestUpdateOldStateActiveExpiredConnectionNotRemovedFromOldState) {
+TEST(ConnTrackerTest, TestUpdateOldStateActiveExpiredConnectionRemovedFromOldState) {
   Endpoint a(Address(192, 168, 0, 1), 80);
   Endpoint b(Address(192, 168, 1, 10), 9999);
 
@@ -1090,7 +1090,7 @@ TEST(ConnTrackerTest, TestUpdateOldStateActiveExpiredConnectionNotRemovedFromOld
   ConnMap expected_old_state = {{conn1, ConnStatus(connection_time1, true)}};
 
   CT::UpdateOldState(&old_state, new_state, time_micros, afterglow_period_micros);
-  EXPECT_THAT(old_state, expected_old_state);
+  EXPECT_THAT(old_state, IsEmpty());
 }
 
 void GetNextAddress(int address_parts[4], int& port) {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -55,7 +55,6 @@ func TestMissingProcScrape(t *testing.T) {
 	}
 }
 
-//Need to update the comments in these tests
 func TestRepeatedNetworkFlow(t *testing.T) {
 	// Perform 11 curl commands with a 2 second sleep between each curl command.
 	// The scrapeInterval is increased to 4 seconds to reduce the chance that jiter will effect the results.
@@ -93,7 +92,7 @@ func TestRepeatedNetworkFlowWithZeroAfterglowPeriod(t *testing.T) {
 }
 
 func TestRepeatedNetworkFlowThreeCurlsNoAfterglow(t *testing.T) {
-	// The afterglow period is set to 0 so this has the same behavior as if afterglow was disabled.
+	// The afterglow period is set to 0 so afterglow is disabled
 	repeatedNetworkFlowTestSuite := &RepeatedNetworkFlowTestSuite{
 		afterglowPeriod:        0,
 		scrapeInterval:         4,


### PR DESCRIPTION
## Description

Fix bug in afterglow where connections are not cleared from old_conn_state and are sent multiple times.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Ran locally and did not see duplicated networking events in debugging branch

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

See above