### PR TITLE
Bump 5.17.6+ Fedora 34 kernel to build on fc36

### DIFF
--- a/.circleci/kernels/get-builder-flavor.sh
+++ b/.circleci/kernels/get-builder-flavor.sh
@@ -46,6 +46,10 @@ getFlavorFor5_13_plus() {
         flavor_local="fc36"
     elif [[ "$version" =~ ^5\.1[3-9]\.[0-9]+-[0-9]+\.fc3[5-9] ]]; then
         flavor_local="fc36"
+    elif [[ "$version" =~ ^5\.17\.[6-9]+-[0-9]+\.fc34 ]]; then
+        flavor_local="fc36"
+    elif [[ "$version" =~ ^5\.1[8-9]\.[0-9]+-[0-9]+\.fc34 ]]; then
+        flavor_local="fc36"
     else
         flavor_local="hirsute"
     fi

--- a/.circleci/test-scripts/get-builder-flavor/TestInput.txt
+++ b/.circleci/test-scripts/get-builder-flavor/TestInput.txt
@@ -4406,3 +4406,4 @@
 5.9.9-100.fc32.x86_64 redhat modern
 5.9.9-200.fc33.x86_64 redhat modern
 4.19.94-minikube minikube modern
+5.17.6-100.fc34.x86_64 redhat fc36


### PR DESCRIPTION
## Description

A 5.17.6 kernel for Fedora 34 is failing to compile because of missing the compiler flag `-mharden-sls`.  We had a similar issue that lead us to implement the `fc36` builder in #621, so bumping kernels 5.17.6+ for Fedora 34 to use this same builder should solve the issue.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Updated documentation accordingly~

**Automated testing**
  - [ ] ~Added unit tests~
  - [ ] ~Added integration tests~
  - [ ] ~Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Green CI is enough.
