### PR TITLE
(WIP) Build support package and collector image from cPaaS drivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,7 +1139,6 @@ jobs:
     <<: *defaultImage
     environment:
     - QUAY_REPO: << pipeline.parameters.quay-repo >>
-    - DOCKER_REPO: "docker.io/stackrox"
     - PUBLIC_REPO: "quay.io/stackrox-io"
 
     steps:
@@ -1149,7 +1148,6 @@ jobs:
 
       - setup_remote_docker:
           docker_layer_caching: true
-      - docker-login-push
       - quay-login-push
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,18 @@ commands:
             exit
           fi
 
+  cpaas-should-run:
+    steps:
+    - run:
+        name: Check if cPaaS job should run
+        command: |
+          echo "Trigger source: '<< pipeline.trigger_source >>'"
+          if [[ ! -f ~/workspace/pr-metadata/labels/run-cpaas-steps && "<< pipeline.trigger_source >>" != "scheduled_pipeline" ]]; then
+            echo "Skipping dockerized build jobs."
+            "${CI_ROOT}/safe-halt.sh"
+            exit
+          fi
+
   stackrox-io-login:
     steps:
     - run:
@@ -958,7 +970,8 @@ jobs:
                 << parameters.image_family >> \
                 << pipeline.trigger_source >> \
                 "$CIRCLE_BRANCH" \
-                "$CIRLCE_TAG"; then
+                "$CIRLCE_TAG" \
+                << parameters.cpaas_drivers >>; then
               "${CI_ROOT}/safe-halt.sh"
               exit
           fi
@@ -1076,6 +1089,7 @@ jobs:
     <<: *defaultMachine
     steps:
       - initcommand
+      - cpaas-should-run
       - gcloud-init
 
       - run:
@@ -1094,6 +1108,7 @@ jobs:
     <<: *defaultImage
     steps:
       - initcommand
+      - cpaas-should-run
       - gcloud-init
 
       - attach_workspace:
@@ -1129,6 +1144,7 @@ jobs:
 
     steps:
       - initcommand
+      - cpaas-should-run
       - gcloud-init
 
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,32 @@ commands:
         command: |
           "${CI_ROOT}/install-hub-comment.sh"
 
+  init-support-package:
+    parameters:
+      download_base_url:
+        type: string
+      relative_path:
+        type: string
+      gcloud_bucket:
+        type: string
+      public_relative_path:
+        type: string
+      public_gcloud_bucket:
+        type: string
+    steps:
+    - run:
+        name: Initialize environment
+        command: |
+          relative_path="<< parameters.relative_path >>"
+          if [[ "$CIRCLE_BRANCH" != "master" ]]; then
+            relative_path="${relative_path}/.test-${CIRCLE_BUILD_NUM}"
+          fi
+          cci-export BASE_URL "<< parameters.download_base_url >>/${relative_path}"
+          cci-export SUPPORT_PKG_SRC_ROOT "${SOURCE_ROOT}/kernel-modules/support-packages"
+          cci-export LICENSE_FILE "${SOURCE_ROOT}/collector/LICENSE-kernel-modules.txt"
+          cci-export GCLOUD_TARGET "<< parameters.gcloud_bucket >>/${relative_path}"
+          cci-export PUBLIC_GCLOUD_TARGET "<< parameters.public_gcloud_bucket >>/<< parameters.public_relative_path >>"
+
 jobs:
   initjob:
     <<: *defaultImage
@@ -1042,6 +1068,54 @@ jobs:
     - ci-artifacts/store:
         path: ~/workspace/benchmark.csv
 
+  cpaas-extract-drivers:
+    <<: *defaultMachine
+    steps:
+      - initcommand
+      - gcloud-init
+
+      - run:
+          name: Extract and upload drivers
+          command: |
+            "${CI_ROOT}/cpaas/10-extract-drivers.sh" \
+              "${CIRCLE_TAG}" \
+              "$CIRCLE_BRANCH"
+
+      - persist_to_workspace:
+          root: /tmp/cpaas-support-packages
+          paths:
+          - metadata
+
+  cpaas-support-package:
+    <<: *defaultImage
+    steps:
+      - initcommand
+      - gcloud-init
+
+      - attach_workspace:
+          at: /tmp/cpaas-support-packages
+
+      - init-support-package:
+          download_base_url: "https://install.stackrox.io"
+          relative_path: "collector/support-packages/cpaas"
+          gcloud_bucket: "gs://sr-roxc"
+          public_relative_path: "offline/v1/support-packages/cpaas"
+          public_gcloud_bucket: "gs://collector-support-public/cpaas"
+
+      - run:
+          name: Create support package files
+          command: |
+            "${SUPPORT_PKG_SRC_ROOT}/04-create-support-packages.sh" \
+              "${LICENSE_FILE}" \
+              /tmp/cpaas-support-packages/metadata \
+              /tmp/cpaas-support-packages/output \
+              "gs://stackrox-collector-modules-staging/cpaas/${CIRCLE_BRANCH}"
+
+      - run:
+          name: Upload to GCloud
+          command: |
+            gsutil -m rsync -r /tmp/cpaas-support-packages/output "$GCLOUD_TARGET"
+
   update-support-packages:
     <<: *defaultImage
     environment:
@@ -1067,18 +1141,12 @@ jobs:
       - quay-login
       - gcloud-init
 
-      - run:
-          name: Initialize environment
-          command: |
-            relative_path="$RELATIVE_PATH"
-            if [[ "$CIRCLE_BRANCH" != "master" ]]; then
-              relative_path="${relative_path}/.test-${CIRCLE_BUILD_NUM}"
-            fi
-            cci-export BASE_URL "${DOWNLOAD_BASE_URL}/${relative_path}"
-            cci-export SUPPORT_PKG_SRC_ROOT "${SOURCE_ROOT}/kernel-modules/support-packages"
-            cci-export LICENSE_FILE "${SOURCE_ROOT}/collector/LICENSE-kernel-modules.txt"
-            cci-export GCLOUD_TARGET "${GCLOUD_BUCKET}/${relative_path}"
-            cci-export PUBLIC_GCLOUD_TARGET "${PUBLIC_GCLOUD_BUCKET}/${PUBLIC_RELATIVE_PATH}"
+      - init-support-package:
+          download_base_url: "https://install.stackrox.io"
+          relative_path: "collector/support-packages"
+          gcloud_bucket: "gs://sr-roxc"
+          public_relative_path: "offline/v1/support-packages"
+          public_gcloud_bucket: "gs://collector-support-public"
 
       - run:
           name: Install Jinja2
@@ -1108,7 +1176,10 @@ jobs:
           name: Create support package files
           command: |
             "${SUPPORT_PKG_SRC_ROOT}/04-create-support-packages.sh" \
-              "${LICENSE_FILE}" /tmp/support-packages/metadata /tmp/support-packages/output
+              "${LICENSE_FILE}" \
+              /tmp/support-packages/metadata \
+              /tmp/support-packages/output \
+              "${COLLECTOR_MODULES_BUCKET}"
 
       - run:
           name: Create index file
@@ -1501,6 +1572,18 @@ reusejobs: &completeWorkflow
           - collector-support
         requires:
           - upload-modules
+    - cpaas-extract-drivers:
+        <<: *runOnAllTags
+        context:
+          - rhacs-automation-credentials
+        requires:
+          - initjob
+    - cpaas-support-package:
+        <<: *runOnAllTags
+        context:
+          - quay-rhacs-eng-readonly
+        requires:
+          - cpaas-extract-drivers
     - update-support-packages:
         <<: *runOnAllTags
         context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,6 +941,9 @@ jobs:
       dockerized:
         type: boolean
         default: false
+      cpaas_drivers:
+        type: boolean
+        default: false
     <<: *defaultMachine
     working_directory: ~/workspace
 
@@ -974,7 +977,8 @@ jobs:
             "<< parameters.image_family >>" \
             "<< parameters.image_name >>" \
             "<< parameters.dockerized >>" \
-            "$CIRCLE_BUILD_NUM"
+            "$CIRCLE_BUILD_NUM" \
+            "<< parameters.cpaas_drivers >>"
 
     - run:
         name: "Extract gcp ssh public key from environment variable"
@@ -1115,6 +1119,37 @@ jobs:
           name: Upload to GCloud
           command: |
             gsutil -m rsync -r /tmp/cpaas-support-packages/output "$GCLOUD_TARGET"
+
+  cpaas-build-collector:
+    <<: *defaultImage
+    environment:
+    - QUAY_REPO: << pipeline.parameters.quay-repo >>
+    - DOCKER_REPO: "docker.io/stackrox"
+    - PUBLIC_REPO: "quay.io/stackrox-io"
+
+    steps:
+      - initcommand
+      - gcloud-init
+
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - docker-login-push
+      - quay-login-push
+
+      - run:
+          name: Download drivers
+          command: |
+            "${CI_ROOT}/cpaas/collector/10-download-drivers.sh" "${CIRCLE_BRANCH}"
+
+      - run:
+          name: Build collector
+          command: |
+            "${CI_ROOT}/cpaas/collector/20-create-image.sh"
+
+      - run:
+          name: Push images
+          command: |
+            "${CI_ROOT}/cpaas/collector/30-push-images.sh"
 
   update-support-packages:
     <<: *defaultImage
@@ -1584,6 +1619,24 @@ reusejobs: &completeWorkflow
           - quay-rhacs-eng-readonly
         requires:
           - cpaas-extract-drivers
+    - cpaas-build-collector:
+        <<: *runOnAllTagsWithDockerIOPushCtx
+        requires:
+          - cpaas-extract-drivers
+          - images
+    - integration-test:
+        <<: *runOnAllTagsWithIntegrationTestRequires
+        requires:
+          - cpaas-build-collector
+        name: test-<< matrix.collection_method >>-<< matrix.image_family >>-cpaas
+        vm_type: rhel
+        cpaas_drivers: true
+        offline: true
+        matrix:
+          parameters:
+            image_family: [rhel-7, rhel-8]
+            collection_method: [module, ebpf]
+
     - update-support-packages:
         <<: *runOnAllTags
         context:

--- a/.circleci/cpaas/10-extract-drivers.sh
+++ b/.circleci/cpaas/10-extract-drivers.sh
@@ -14,7 +14,7 @@ docker login \
 
 docker run --pull always --rm \
     -v "${WORKSPACE_ROOT}/cpaas/kernel-modules/":/output \
-    brew.registry.redhat.io/rh-osbs/rhacs-collector-drivers-rhel8:rhacs-0.1-rhel-8-containers-candidate-59258-20220510095241 \
+    brew.registry.redhat.io/rh-osbs/rhacs-collector-drivers-rhel8:rhacs-0.1-rhel-8-containers-candidate-41317-20220531103428 \
     "cp -r /kernel-modules/* /output/"
 
 ls -la "${WORKSPACE_ROOT}/cpaas/kernel-modules"/**

--- a/.circleci/cpaas/10-extract-drivers.sh
+++ b/.circleci/cpaas/10-extract-drivers.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TAG=$1
+BRANCH=$2
+
+mkdir -p "${WORKSPACE_ROOT}/cpaas/kernel-modules/"
+
+docker login \
+    --username "${REDHAT_USERNAME}" \
+    --password "${REDHAT_PASSWORD}" \
+    brew.registry.redhat.io
+
+docker run --pull always --rm \
+    -v "${WORKSPACE_ROOT}/cpaas/kernel-modules/":/output \
+    brew.registry.redhat.io/rh-osbs/rhacs-collector-drivers-rhel8:rhacs-0.1-rhel-8-containers-candidate-59258-20220510095241 \
+    "cp -r /kernel-modules/* /output/"
+
+ls -la "${WORKSPACE_ROOT}/cpaas/kernel-modules"/**
+
+# Create the metadata directories
+for version in "${WORKSPACE_ROOT}/cpaas/kernel-modules"/*/; do
+    md_version="$(basename "$version")"
+    mkdir -p "/tmp/cpaas-support-packages/metadata/module-versions/$md_version"
+done
+
+# sync modules
+target="${COLLECTOR_MODULES_BUCKET}/cpaas/"
+if [[ "$BRANCH" != "master" && -z "$TAG" ]]; then
+    target="gs://stackrox-collector-modules-staging/cpaas/${BRANCH}"
+fi
+
+shopt -s nullglob
+shopt -s dotglob
+for driver_dir in "${WORKSPACE_ROOT}/cpaas/kernel-modules"/*; do
+    files=("${driver_dir}"/*.{gz,unavail})
+    [[ "${#files[@]}" -gt 0 ]] || continue
+    printf '%s\n' "${files[@]}" | gsutil -m cp -n -I "${target}/$(basename "$driver_dir")/"
+done

--- a/.circleci/cpaas/collector/10-download-drivers.sh
+++ b/.circleci/cpaas/collector/10-download-drivers.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+BRANCH=$1
+
+BUCKET="gs://stackrox-collector-modules-staging/cpaas/${BRANCH}"
+MODULE_VERSION="$(cat "${SOURCE_ROOT}/kernel-modules/MODULE_VERSION")"
+
+mkdir -p "${SOURCE_ROOT}/kernel-modules/container/kernel-modules"
+gsutil -m cp -n \
+    "${BUCKET}/${MODULE_VERSION}/*.gz" \
+    "${SOURCE_ROOT}/kernel-modules/container/kernel-modules"

--- a/.circleci/cpaas/collector/20-create-image.sh
+++ b/.circleci/cpaas/collector/20-create-image.sh
@@ -9,16 +9,14 @@ container_build_dir="${SOURCE_ROOT}/kernel-modules/container"
 layer_count="$("${container_build_dir}/partition-probes.py" -1 "$MAX_LAYER_MB" "${container_build_dir}/kernel-modules" "-")"
 for collector_repo in "${collector_repos[@]}"; do
     build_args=(
-        --build-arg collector_repo="${DOCKER_REPO}/${collector_repo}"
-        --build-arg collector_version="$COLLECTOR_VERSION"
+        --build-arg collector_repo="${QUAY_REPO}/${collector_repo}"
+        --build-arg collector_version="${COLLECTOR_VERSION}-slim"
         --build-arg module_version="$(cat "${SOURCE_ROOT}/kernel-modules/MODULE_VERSION")"
         --build-arg max_layer_size="$MAX_LAYER_MB"
         --build-arg max_layer_depth="$layer_count"
     )
     docker build \
         --target="probe-layer-${layer_count}" \
-        -t "${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \
-        -t "${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas-latest" \
         -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \
         -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas-latest" \
         -t "${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \

--- a/.circleci/cpaas/collector/20-create-image.sh
+++ b/.circleci/cpaas/collector/20-create-image.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+collector_repos=(
+    "collector"
+)
+
+container_build_dir="${SOURCE_ROOT}/kernel-modules/container"
+layer_count="$("${container_build_dir}/partition-probes.py" -1 "$MAX_LAYER_MB" "${container_build_dir}/kernel-modules" "-")"
+for collector_repo in "${collector_repos[@]}"; do
+    build_args=(
+        --build-arg collector_repo="${DOCKER_REPO}/${collector_repo}"
+        --build-arg collector_version="$COLLECTOR_VERSION"
+        --build-arg module_version="$(cat "${SOURCE_ROOT}/kernel-modules/MODULE_VERSION")"
+        --build-arg max_layer_size="$MAX_LAYER_MB"
+        --build-arg max_layer_depth="$layer_count"
+    )
+    docker build \
+        --target="probe-layer-${layer_count}" \
+        -t "${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \
+        -t "${DOCKER_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas-latest" \
+        -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \
+        -t "${QUAY_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas-latest" \
+        -t "${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas" \
+        -t "${PUBLIC_REPO}/${collector_repo}:${COLLECTOR_VERSION}-cpaas-latest" \
+        "${build_args[@]}" \
+        "${container_build_dir}"
+done

--- a/.circleci/cpaas/collector/20-create-image.sh
+++ b/.circleci/cpaas/collector/20-create-image.sh
@@ -10,7 +10,7 @@ layer_count="$("${container_build_dir}/partition-probes.py" -1 "$MAX_LAYER_MB" "
 for collector_repo in "${collector_repos[@]}"; do
     build_args=(
         --build-arg collector_repo="${QUAY_REPO}/${collector_repo}"
-        --build-arg collector_version="${COLLECTOR_VERSION}-slim"
+        --build-arg collector_version="${COLLECTOR_VERSION}"
         --build-arg module_version="$(cat "${SOURCE_ROOT}/kernel-modules/MODULE_VERSION")"
         --build-arg max_layer_size="$MAX_LAYER_MB"
         --build-arg max_layer_depth="$layer_count"

--- a/.circleci/cpaas/collector/30-push-images.sh
+++ b/.circleci/cpaas/collector/30-push-images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This script is a subset of .circleci/images/100-push-images.sh
+# We should try to unify them in the near future.
+
+image_repos=(
+    "${QUAY_REPO}/collector"
+)
+image_tags=(
+    "${COLLECTOR_VERSION}-cpaas"
+    "${COLLECTOR_VERSION}-cpaas-latest"
+)
+for repo in "${image_repos[@]}"; do
+    for tag in "${image_tags[@]}"; do
+        image="${repo}:${tag}"
+        echo "Pushing image ${image}"
+        docker image inspect "${image}" > /dev/null
+        "${WORKSPACE_ROOT}/go/src/github.com/stackrox/collector/scripts/push-as-manifest-list.sh" "${image}"
+    done
+done

--- a/.circleci/integration-test/10-check-whether-to-run-job.sh
+++ b/.circleci/integration-test/10-check-whether-to-run-job.sh
@@ -6,6 +6,7 @@ image_family=$2
 trigger_source=$3
 branch=$4
 tag=$5
+cpaas=$6
 
 log() { echo "$*" >&2; }
 
@@ -16,6 +17,11 @@ fi
 
 if [[ "$dockerized" == "true" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/run-dockerized-steps" ]]; then
     log "Skipping dockerized build jobs." >&2
+    exit 0
+fi
+
+if [[ "$cpaas" == "true" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/run-cpaas-steps" ]]; then
+    log "Skipping cpaas build jobs." >&2
     exit 0
 fi
 

--- a/.circleci/integration-test/20-setup-env-vars.sh
+++ b/.circleci/integration-test/20-setup-env-vars.sh
@@ -8,9 +8,10 @@ image_family=$4
 image_name=$5
 dockerized=$6
 BUILD_NUM=$7
+cpaas_drivers=$8
 
 COLLECTOR_REPO="quay.io/rhacs-eng/collector"
-if [[ -f pr-metadata/labels/ci-run-against-ubi && "$dockerized" != "true" ]]; then
+if [[ -f pr-metadata/labels/ci-run-against-ubi && "$dockerized" != "true" && "$cpaas_drivers" != "true" ]]; then
     COLLECTOR_REPO="quay.io/rhacs-eng/collector-test-cpaas"
 fi
 
@@ -35,5 +36,9 @@ EOF
 if [[ "$dockerized" == "true" ]]; then
     cat >> "$BASH_ENV" <<- EOF
       export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-dockerized"
+EOF
+elif [[ "$cpaas_drivers" == "true" ]]; then
+    cat >> "$BASH_ENV" <<- EOF
+        export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${COLLECTOR_TAG}-cpaas"
 EOF
 fi

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -7,22 +7,30 @@ die() {
     exit 1
 }
 
-generate_checksum() {
+generate_checksum() (
     directory=$1
     file=$2
-    pushd "${directory}"
+    cd "${directory}"
     sha256sum "${file}" > "${file}.sha256"
-    popd
-}
+)
+
+compress_files() (
+    package_root=$1
+    output_file=$2
+
+    cd "${package_root}"
+    zip -r "${output_file}" .
+)
 
 LICENSE_FILE="$1"
 MD_DIR="$2"
 OUT_DIR="$3"
+GCP_BUCKET="$4"
 
 [[ -n "$LICENSE_FILE" && -n "$MD_DIR" && -n "$OUT_DIR" ]] || die "Usage: $0 <license-file> <metadata directory> <output directory>"
 [[ -d "$MD_DIR" ]] || die "Metadata directory $MD_DIR does not exist or is not a directory."
 
-[[ -n "${COLLECTOR_MODULES_BUCKET:-}" ]] || die "Must specify a COLLECTOR_MODULES_BUCKET"
+[[ -n "${GCP_BUCKET:-}" ]] || die "Must specify a COLLECTOR_MODULES_BUCKET"
 
 mkdir -p "$OUT_DIR" || die "Failed to create output directory ${OUT_DIR}."
 
@@ -35,7 +43,7 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     # For now we create *full* kernel support packages, not only deltas, in order to
     # support the slim collector use-case.
     # Remains to be clarified; we might provide more fine granular download options in the future.
-    gsutil -m cp "${COLLECTOR_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
+    gsutil -m cp "${GCP_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
 
     package_out_dir="${OUT_DIR}/${mod_ver}"
     mkdir -p "$package_out_dir"
@@ -49,11 +57,8 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
 
     cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
 
-    (   
-        cd "$package_root"
-        zip -r "${package_out_dir}/${filename}" .
-        generate_checksum "${package_out_dir}" "${filename}"
-    )
+    compress_files "$package_root" "${package_out_dir}/${filename}"
+    generate_checksum "${package_out_dir}" "${filename}"
 
     cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
     generate_checksum "${package_out_dir}" "${latest_filename}"


### PR DESCRIPTION
## Description

The ultimate target for this PR is to be able to create a support package and a collector image that use the drivers built in cpaas, particularly in this patch: https://code.engineering.redhat.com/gerrit/c/rhacs/+/309821

The way the support package works right now is:
- We pull the image holding the drivers from cPaaS, extract them and push them to a GCP bucket acting as a cache.
- We pull the drivers back form the GCP bucket cache and compress them using the same script use to create the regular support package.
- Finally we push the support package to a separate GCP bucket.

The collector image works in a similar manner:
- We pull the drivers back form the GCP bucket cache
- We use those drivers in place of the regular ones to build a `-cpaas-latest` flavor of the collector image.
- We run integration tests on RHEL VMs (only platform supported by cPaaS ATM) in offline mode to ensure the drivers used are the ones embedded in the image.

TODO:
- Merge the gerrit patch and configure it to run daily.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
