### PR TITLE
Use absolute overhead, not relative

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1512,8 +1512,9 @@ workflows:
         # - test-module-sles-15-sp2-sap
         - test-ebpf-flatcar-stable
         - test-module-flatcar-stable
-        - test-ebpf-fedora-coreos-stable
-        - test-module-fedora-coreos-stable
+        # Temporary ignore, waiting for falcosecurity/libs/pull/317
+        # - test-ebpf-fedora-coreos-stable
+        # - test-module-fedora-coreos-stable
         - test-ebpf-garden-linux
         - test-module-garden-linux
         - test-module-ubuntu-pro-1804-lts

--- a/.circleci/test-scripts/baseline/format.awk
+++ b/.circleci/test-scripts/baseline/format.awk
@@ -3,6 +3,6 @@ BEGIN {
     print "|---|---|---|---|---|---|---|"
 }
 {
-    warn = ($7==1) ? " :question:" : "";
-    printf "|%s|%s|%s|%s|%s|%s|%s%s|%s",$1,$2,$3,$4,$5,$6,$7,warn,ORS
+    warn = ($7==1) ? ":green_circle:" : ":red_circle:";
+    printf "|%s|%s|%s|%s|%s|%s|%s|%s",$1,$2,$3,$4,$5,$6,warn,ORS
 }

--- a/.circleci/test-scripts/baseline/format.awk
+++ b/.circleci/test-scripts/baseline/format.awk
@@ -3,6 +3,6 @@ BEGIN {
     print "|---|---|---|---|---|---|---|"
 }
 {
-    warn = ($7==1) ? ":green_circle:" : ":red_circle:";
+    warn = ($7==1) ? ":red_circle:" : ":green_circle:";
     printf "|%s|%s|%s|%s|%s|%s|%s|%s",$1,$2,$3,$4,$5,$6,warn,ORS
 }

--- a/.circleci/test-scripts/baseline/format.awk
+++ b/.circleci/test-scripts/baseline/format.awk
@@ -3,6 +3,6 @@ BEGIN {
     print "|---|---|---|---|---|---|---|"
 }
 {
-    warn = ($7<=0.05) ? " :question:" : "";
+    warn = ($7==1) ? " :question:" : "";
     printf "|%s|%s|%s|%s|%s|%s|%s%s|%s",$1,$2,$3,$4,$5,$6,$7,warn,ORS
 }

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -29,6 +29,7 @@ import time
 from collections import Counter
 from itertools import groupby
 from scipy import stats
+import numpy as np
 
 from google.oauth2 import service_account
 from google.cloud import storage
@@ -264,7 +265,7 @@ def compare(input_file_name, baseline_data):
             # The original implementation used single sample ttest, but it's
             # too sensitive for such variance.
             # result, pvalue = stats.ttest_1samp(baseline_overhead,
-                                               # test_overhead)
+            #                                    test_overhead)
 
             # Test the new data to be a 1.5 outlier
             iqr = stats.iqr(baseline_overhead)

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -239,12 +239,15 @@ def split_benchmark(measurements):
 
 
 def collector_overhead(measurements):
+    """
+    Express collector overhead in absolute difference in hackbench_avg_time.
+    Due to variance a relative difference (i.e. overhead / no overhead) will
+    also have higher variance, because the actual delta will be smaller/larger
+    relative to the total timing.
+    """
     no_overhead, overhead = split_benchmark(measurements)
 
-    return [
-        round(100 * x / y, 2)
-        for (x, y) in zip(overhead, no_overhead)
-    ]
+    return [x - y for (x, y) in zip(overhead, no_overhead)]
 
 
 def compare(input_file_name, baseline_data):

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -13,21 +13,11 @@ overwrite existing baseline file on GCS.
 
 To compare a new benchmark with the baseline, use --test <new.json> command.
 This will fetch the baseline, and calculate an overhead captured in it and in
-the test file (with/without collector). Then it will do a t-test for mean
-values -- this will give the P-value, the probability of getting as or more
-extreme values assuming the null hypothesis is true (i.e. the value we're
-testing is different from the mean value from baseline only by chance). P-value
-is distributed between [0, 1], bigger values means that the new benchmark
-values differences from the baseline are not significant.
+the test file (with/without collector). Then it will perform an IQR test to
+find out if the test data is 1.5-outlier.
 
-The procedure described above is a bit cheating though. While we're most likely
-working with normally distributed values (hackbench_avg_time is an average, and
-averages of samples are distributed normally following central theorem), the
-test expects us to compare mean values, but we use a single sample as a second
-argument. Essentially it means t-test answers the question "how likely it is
-that the samples with mean M_0 has actual mean M_1", where M_0 is mean of the
-baseline, and M_1 is the current value we're testing. How much is this problem
-in practice needs to be verified empirically.
+NOTE: Originally it was doing t-test for mean values, but it seems to be too
+sensitive for such variance.
 """
 
 import argparse
@@ -271,8 +261,17 @@ def compare(input_file_name, baseline_data):
 
             baseline_overhead = collector_overhead(bvalues)
             test_overhead = collector_overhead(tvalues)[0]
-            result, pvalue = stats.ttest_1samp(baseline_overhead,
-                                               test_overhead)
+            # The original implementation used single sample ttest, but it's
+            # too sensitive for such variance.
+            # result, pvalue = stats.ttest_1samp(baseline_overhead,
+                                               # test_overhead)
+
+            # Test the new data to be a 1.5 outlier
+            iqr = stats.iqr(baseline_overhead)
+            q1, q3 = np.percentile(baseline_overhead, [25, 75])
+            lower = q1 - 1.5 * iqr
+            upper = q3 + 1.5 * iqr
+            outlier = 0 if lower < test_overhead < upper else 1
 
             benchmark_baseline, benchmark_collector = split_benchmark(bvalues)
             test_baseline, test_collector = split_benchmark(tvalues)
@@ -281,7 +280,7 @@ def compare(input_file_name, baseline_data):
             collector_median = round(stats.tmean(benchmark_collector), 2)
 
             print(f"{bgroup} {test_baseline[0]} {test_collector[0]} "
-                  f"{baseline_median} {collector_median} {round(pvalue, 2)}")
+                  f"{baseline_median} {collector_median} {outlier}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Benchmark numbers have high variance, which makes relative overhead vary
significantly as well. Use absolute overhead value numbers, as they seem
more stable.

## Checklist

- [ ] Investigated and inspected CI test results

## Testing Performed

Local testing with the baseline data, captured so far.