### PR TITLE
Bump Garden Linux VM to 576.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1485,12 +1485,12 @@ reusejobs: &completeWorkflow
           parameters:
             collection_method: [module, ebpf]
             dockerized: [false, true]
-            image_version: [576-8-7c12cd]
+            image_version: [576-9-229156]
           exclude:
             # Failing due to dockerized module not being built (requires gcc-10).
             - collection_method: module
               dockerized: true
-              image_version: 576-8-7c12cd
+              image_version: 576-9-229156
     - integration-test-data:
         <<: *runOnAllTagsWithDockerIOPullCtx
         requires:


### PR DESCRIPTION
## Description

Bump Garden Linux VM used for testing to 576.9

## Checklist
- [x] Investigated and inspected CI test results.

## Testing Performed
- [x] Garden Linux integration tests pass.