### PR TITLE
Run all tests when `all-integration-tests` label is set in PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
     - run:
         name: Remove all labels
         command: |
-          rm -rf "${WORKSPACE_ROOT}/pr-metadata/labels/*
+          rm -rf "${WORKSPACE_ROOT}/pr-metadata/labels"/*
 
     - run:
         name: Test get-builder-flavor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,8 +253,6 @@ jobs:
     <<: *defaultImage
 
     steps:
-    - initcommand
-
     - run:
         name: Test get-builder-flavor
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,13 @@ jobs:
     <<: *defaultImage
 
     steps:
+    - initcommand
+
+    - run:
+        name: Remove all labels
+        command: |
+          rm -rf "${WORKSPACE_ROOT}/pr-metadata/labels/*
+
     - run:
         name: Test get-builder-flavor
         command: |

--- a/.circleci/integration-test/10-check-whether-to-run-job.sh
+++ b/.circleci/integration-test/10-check-whether-to-run-job.sh
@@ -20,7 +20,7 @@ if [[ "$dockerized" == "true" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/run-
 fi
 
 if [[ "$branch" != "master" && -z "$tag" && "$trigger_source" != "schedule" ]]; then
-    if [[ "$image_family" =~ (ubuntu|rhel) ]]; then
+    if [[ "$image_family" =~ (ubuntu|rhel) || -f "${WORKSPACE_ROOT}/pr-metadata/labels/all-integration-tests" ]]; then
         exit 1
     fi
     log "Skipping job for pr. Running only for master branch and nightly job." >&2


### PR DESCRIPTION
## Description

After merging #641, a subset of integration tests is being run on PRs and the `all-integration-tests` label should be used to force the entirety of them to run. However, this label was not working as expected, this PR should fix it.

It also removes the files created from labels in the `test-scripts` CI job, this is to prevent the labels in a PR from interacting and breaking these tests.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] Run all integration tests when adding the `all-integration-tests` label.