### PR TITLE
Fix updating baseline data

### DIFF
--- a/.circleci/test-scripts/baseline/compare-and-update-baseline.sh
+++ b/.circleci/test-scripts/baseline/compare-and-update-baseline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pip install --upgrade scipy google-cloud-storage
+pip -q install --upgrade scipy google-cloud-storage
 
 jq -s 'flatten' "${WORKSPACE_ROOT}"/*perf.json > "${WORKSPACE_ROOT}"/all-perf.json
 

--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -94,7 +94,10 @@ def add_to_baseline_file(input_file_name, baseline_data, threshold):
         new_measurement = json.load(measure)
         verify_data(new_measurement)
 
-        new_measurement_keys = [data[0] for data in group_data(measure, "VmConfig", "CollectionMethod")]
+        new_measurement_keys = [
+            data[0] for data in group_data(new_measurement,
+                                           "VmConfig", "CollectionMethod")
+        ]
 
         # Baseline contains several tests per one benchmark record
         test_names = set(value["TestName"] for value in baseline_data)


### PR DESCRIPTION
## Description
 
Fix updating baseline data in 74324522c . The issue was about `measure` iterator, which was used directly for producing the result. As soon as other operations started to consume the iterator before that, it become empty and the update is not correctly performed.

On the way do cosmetic improvements for the installation process. Baseline requires some dependencies, installed via `pip`. Do this silently to reduce noise.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
Local testing.