### PR TITLE
Keep original baseline data

### DIFF
--- a/.circleci/test-scripts/baseline/main.py
+++ b/.circleci/test-scripts/baseline/main.py
@@ -105,7 +105,10 @@ def add_to_baseline_file(input_file_name, baseline_data, threshold):
         result = []
         for key, values in group_data(baseline_data, "VmConfig", "CollectionMethod"):
             if key not in new_measurement_keys:
-                # Drop removed tests
+                # Keep the original data in baseline, even if there is nothing
+                # like that in the new benchmark. No need for any kind of
+                # verification.
+                result.extend(values)
                 continue
 
             # For every group (vm, method) sort the records in ascending order


### PR DESCRIPTION
## Description

The original implementation dropped benchmark data for all tests, that
are not present either in the baseline or in the test. This approach
leads to data overwriting in situations when different jobs have
different set of tests (e.g. a normal testing flow, vs extended
"nightly" run). To prevent that, keep the original set of baseline data
untouched from run to run.

As a side effect this means that "dead" tests that were removed at some
point will stay in the baseline until manually removed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed
Local testing.