### PR TITLE
Giles/bump ci cache v19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,8 +329,8 @@ jobs:
     - restore_cache:
         name: Restore Kernel module build cache
         keys:
-          - kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
-          - kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-master-
+          - kernel-module-cache-v19-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
+          - kernel-module-cache-v19-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-master-
 
     - run:
         name: Unpack module sources
@@ -520,7 +520,7 @@ jobs:
 
     - save_cache:
         name: Saving Kernel module build cache
-        key: kernel-module-cache-v18-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
+        key: kernel-module-cache-v19-{{ checksum "/tmp/cache/kernel-modules-version.txt" }}-{{ .Branch }}-{{ .Revision }}
         paths:
           - /tmp/cache/
 


### PR DESCRIPTION
## Description

Bumps the CI cache to allow rebuilding of 1.0.0 eBPF probes. This affects all eBPF probes.

`gsutil ls -l ${COLLECTOR_MODULES_BUCKET}/1.0.0/ | grep '^.*ebpf.*$'`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.