### PR TITLE
Jv/3.6.x fix skip prepare legacy sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,11 +371,6 @@ jobs:
           "${CI_ROOT}/prepare-kernels/prepare-source.sh"
 
     - run:
-        name: Prepare legacy sources
-        command: |
-          "${CI_ROOT}/prepare-kernels/prepare-legacy-sources.sh" "${CIRCLE_TAG}" "${CIRCLE_BRANCH}"
-
-    - run:
         name: Prepare Kernel module build cache lookup
         command: |
           "${CI_ROOT}/prepare-kernels/prepare-kernel-module-build-cache-lookup.sh"

--- a/.circleci/prepare-kernels/prepare-legacy-sources.sh
+++ b/.circleci/prepare-kernels/prepare-legacy-sources.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 TAG=$1
 BRANCH=$2
 
+exit 0
 if [[ -n "$TAG" && "$BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/build-legacy-probes" ]]; then
   echo "Not preparing legacy sources for a tag"
   exit 0

--- a/.circleci/prepare-kernels/prepare-legacy-sources.sh
+++ b/.circleci/prepare-kernels/prepare-legacy-sources.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 TAG=$1
 BRANCH=$2
 
-if [[ -z "$TAG" && "$BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/build-legacy-probes" ]]; then
+if [[ -n "$TAG" && "$BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/build-legacy-probes" ]]; then
   echo "Not preparing legacy sources for a tag"
   exit 0
 fi

--- a/.circleci/prepare-kernels/prepare-legacy-sources.sh
+++ b/.circleci/prepare-kernels/prepare-legacy-sources.sh
@@ -4,8 +4,7 @@ set -eo pipefail
 TAG=$1
 BRANCH=$2
 
-exit 0
-if [[ -n "$TAG" && "$BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/build-legacy-probes" ]]; then
+if [[ -z "$TAG" && "$BRANCH" != "master" && ! -f "${WORKSPACE_ROOT}/pr-metadata/labels/build-legacy-probes" ]]; then
   echo "Not preparing legacy sources for a tag"
   exit 0
 fi


### PR DESCRIPTION
## Description

prepare-legacy-sources.sh should not run when a tag is used.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

See above
