### PR TITLE
Add a make target to build full dev images

### DIFF
--- a/kernel-modules/Makefile
+++ b/kernel-modules/Makefile
@@ -1,5 +1,6 @@
 BUILD_CONTAINER_TAG ?= build-kernel-modules
 BUILD_CONTAINER_CACHE_IMAGES ?=
+DEV_DRIVER_BUILDER ?= fc36
 
 CUSTOM_FLAVORS := $(patsubst build/Dockerfile.%,%,$(wildcard build/Dockerfile.*))
 
@@ -40,3 +41,18 @@ push-build-containers: push-build-container $(CUSTOM_FLAVORS:%=push-build-contai
 .PHONY: print-custom-flavors
 print-custom-flavors:
 	@printf "%s\n" $(CUSTOM_FLAVORS)
+
+.PHONY: drivers
+drivers: build-container-$(DEV_DRIVER_BUILDER)
+	docker run --rm \
+		-v $(CURDIR)/..:/collector \
+		-v /usr/include/bpf:/usr/include/bpf:ro \
+		-v /lib/modules/:/lib/modules/:ro \
+		-v /usr/src/kernels/:/usr/src/kernels/:ro \
+		build-kernel-modules-$(DEV_DRIVER_BUILDER):latest \
+		/collector/kernel-modules/dev/build-drivers.sh
+
+.PHONY: clean-drivers
+clean-drivers:
+	rm -rf ../falcosecurity-libs/build/
+	rm -rf container/kernel-modules/

--- a/kernel-modules/dev/build-drivers.sh
+++ b/kernel-modules/dev/build-drivers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+OUTPUT_DIR="/collector/kernel-modules/container/kernel-modules"
+
+package_kmod() {
+    kernel=$1
+    driver_dir=$2
+
+    gzip -c "${driver_dir}/build/driver/collector.ko" \
+        > "${OUTPUT_DIR}/collector-${kernel}.ko.gz"
+}
+
+package_probe() {
+    kernel=$1
+    driver_dir=$2
+
+    gzip -c "${driver_dir}/build/driver/bpf/probe.o" \
+        > "${OUTPUT_DIR}/collector-ebpf-${kernel}.o.gz"
+}
+
+KERNEL_VERSION="$(uname -r)"
+DRIVER_DIR="/collector/falcosecurity-libs"
+
+mkdir -p "${DRIVER_DIR}/build"
+
+cmake -S ${DRIVER_DIR} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-fno-pie" \
+    -DPROBE_NAME=collector \
+    -DBUILD_USERSPACE=OFF \
+    -DBUILD_DRIVER=ON \
+    -DENABLE_DKMS=OFF \
+    -DBUILD_BPF=ON \
+    -B ${DRIVER_DIR}/build
+make -C ${DRIVER_DIR}/build/driver
+
+mkdir -p "${OUTPUT_DIR}"
+package_kmod "$KERNEL_VERSION" "$DRIVER_DIR"
+package_probe "$KERNEL_VERSION" "$DRIVER_DIR"
+
+# No reason to leave this hanging about
+rm -rf "${DRIVER_DIR}/build"


### PR DESCRIPTION
## Description

The new make target builds on top of the image-dev target, the kernel builders and the Dockerfile used to create the full images to create a collector image with embedded kernel modules and eBPF probe compiled by the system the target is run on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

It would be appreciated if reviewers could run the new `image-dev-full` target in different systems to make sure it works on most developer environments.
