### PR TITLE
Block failing kernels

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -13,6 +13,8 @@
 4.19.0-14-amd64
 5.16.0-1-cloud-amd64
 5.16.0-1-amd64
+5.17.0-2-cloud-amd64
+5.17.0-2-amd64
 # backport 5.8
 5.8.*20.04
 # TODO(ROX-6789) - backport 5.7+ patches to legacy collector versions
@@ -53,3 +55,5 @@
 4.19.121-dockerdesktop-2021-01-21-15-36-34
 # TODO(ROX-10917)
 4.18.0-372.9.1.rt7.166.el8.x86_64 * mod
+# TODO(ROX-11190)
+5.18.0-60.fc37.x86_64 * mod


### PR DESCRIPTION
## Description

The kernels added to the blocklist are failing to compile, they will remain bloked until further research can be done to find a fix for them.

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Updated documentation accordingly~

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] The blocked kernels don't show up in the `kernel-module-build-failures-check` CI step.
