### PR TITLE
Bump builder for fc34 5.17.10+ kernels

### DIFF
--- a/.circleci/kernels/get-builder-flavor.sh
+++ b/.circleci/kernels/get-builder-flavor.sh
@@ -48,6 +48,8 @@ getFlavorFor5_13_plus() {
         flavor_local="fc36"
     elif [[ "$version" =~ ^5\.17\.[6-9]+-[0-9]+\.fc34 ]]; then
         flavor_local="fc36"
+    elif [[ "$version" =~ ^5\.17\.[1-9][0-9]+-[0-9]+\.fc34 ]]; then
+        flavor_local="fc36"
     elif [[ "$version" =~ ^5\.1[8-9]\.[0-9]+-[0-9]+\.fc34 ]]; then
         flavor_local="fc36"
     else

--- a/.circleci/test-scripts/get-builder-flavor/TestInput.txt
+++ b/.circleci/test-scripts/get-builder-flavor/TestInput.txt
@@ -4407,3 +4407,5 @@
 5.9.9-200.fc33.x86_64 redhat modern
 4.19.94-minikube minikube modern
 5.17.6-100.fc34.x86_64 redhat fc36
+5.17.12-100.fc34.x86_64 redhat fc36
+5.17.11-100.fc34.x86_64 redhat fc36


### PR DESCRIPTION
## Description

Kernels for fc34 that had 2 numbers on the patch version were missed in #680, this PR adds those to the bump

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Updated documentation accordingly~

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] The bumped kernel modules build correctly.
