### PR TITLE
ROX-11096 insert interfaces for testability

### DIFF
--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -87,10 +87,11 @@ void CollectorService::RunForever() {
     CLOG(INFO) << "GRPC server connectivity is successful";
 
     if (!config_.DisableNetworkFlows()) {
+      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc());
       conn_tracker = std::make_shared<ConnectionTracker>();
       UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
       conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
-      net_status_notifier = MakeUnique<NetworkStatusNotifier>(config_.Hostname(), config_.HostProc(),
+      net_status_notifier = MakeUnique<NetworkStatusNotifier>(config_.Hostname(), conn_scraper,
                                                               config_.ScrapeInterval(), config_.ScrapeListenEndpoints(),
                                                               config_.TurnOffScrape(),
                                                               conn_tracker, config_.grpc_channel,

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -91,11 +91,12 @@ void CollectorService::RunForever() {
       conn_tracker = std::make_shared<ConnectionTracker>();
       UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
       conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
-      net_status_notifier = MakeUnique<NetworkStatusNotifier>(config_.Hostname(), conn_scraper,
-                                                              config_.ScrapeInterval(), config_.ScrapeListenEndpoints(),
-                                                              config_.TurnOffScrape(),
-                                                              conn_tracker, config_.grpc_channel,
-                                                              config_.AfterglowPeriod(), config_.EnableAfterglow());
+
+      auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
+
+      net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
+                                                              conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
+                                                              network_connection_info_service_comm);
       net_status_notifier->Start();
     }
   }

--- a/collector/lib/ConnScraper.h
+++ b/collector/lib/ConnScraper.h
@@ -38,8 +38,15 @@ namespace collector {
 // ExtractContainerID tries to extract a container ID from a cgroup line. Exposed for testing.
 StringView ExtractContainerID(StringView cgroup_line);
 
+// Abstract interface for a ConnScraper. Useful to inject testing implementation.
+class IConnScraper {
+ public:
+  virtual bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) = 0;
+  virtual ~IConnScraper() {}
+};
+
 // ConnScraper is a class that allows scraping a `/proc`-like directory structure for active network connections.
-class ConnScraper {
+class ConnScraper : public IConnScraper {
  public:
   explicit ConnScraper(std::string proc_path) : proc_path_(std::move(proc_path)) {}
 

--- a/collector/lib/DuplexGRPC.h
+++ b/collector/lib/DuplexGRPC.h
@@ -195,8 +195,10 @@ class Result final {
     return status_ == Status::TIMEOUT;
   }
 
- private:
+  // made public for testing purpose
   explicit Result(bool ok) : status_(ok ? Status::OK : Status::ERROR) {}
+
+ private:
   explicit Result(Status status) : status_(status) {}
   explicit Result(grpc::CompletionQueue::NextStatus status) {
     switch (status) {
@@ -262,7 +264,10 @@ class IDuplexClient {
   virtual void TryCancel() = 0;
   virtual Result Shutdown() = 0;
 
-  // Templated and utility methods
+  /* Templated and utility methods.
+
+     We need to have these in this interface because templates and virtual methods don't mix.
+     Each templated method maps to one virtual method and calls it after converting time types. */
 
   // Wait for the specified time for the stream to become ready.
   template <typename TS = time_point>

--- a/collector/lib/DuplexGRPC.h
+++ b/collector/lib/DuplexGRPC.h
@@ -196,10 +196,10 @@ class Result final {
   }
 
   // made public for testing purpose
-  explicit Result(bool ok) : status_(ok ? Status::OK : Status::ERROR) {}
+  explicit Result(Status status) : status_(status) {}
 
  private:
-  explicit Result(Status status) : status_(status) {}
+  explicit Result(bool ok) : status_(ok ? Status::OK : Status::ERROR) {}
   explicit Result(grpc::CompletionQueue::NextStatus status) {
     switch (status) {
       case grpc::CompletionQueue::SHUTDOWN:

--- a/collector/lib/NetworkConnectionInfoServiceComm.cpp
+++ b/collector/lib/NetworkConnectionInfoServiceComm.cpp
@@ -1,0 +1,70 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include "NetworkConnectionInfoServiceComm.h"
+
+#include "GRPCUtil.h"
+#include "Utility.h"
+
+namespace collector {
+
+constexpr char NetworkConnectionInfoServiceComm::kHostnameMetadataKey[];
+constexpr char NetworkConnectionInfoServiceComm::kCapsMetadataKey[];
+constexpr char NetworkConnectionInfoServiceComm::kSupportedCaps[];
+
+std::unique_ptr<grpc::ClientContext> NetworkConnectionInfoServiceComm::CreateClientContext() const {
+  auto ctx = MakeUnique<grpc::ClientContext>();
+  ctx->AddMetadata(kHostnameMetadataKey, hostname_);
+  ctx->AddMetadata(kCapsMetadataKey, kSupportedCaps);
+  return ctx;
+}
+
+NetworkConnectionInfoServiceComm::NetworkConnectionInfoServiceComm(std::string hostname, std::shared_ptr<grpc::Channel> channel) : hostname_(std::move(hostname)), channel_(std::move(channel)), stub_(sensor::NetworkConnectionInfoService::NewStub(channel_)) {
+}
+
+void NetworkConnectionInfoServiceComm::ResetClientContext() {
+  WITH_LOCK(context_mutex_) {
+    context_ = CreateClientContext();
+  }
+}
+
+bool NetworkConnectionInfoServiceComm::WaitForConnectionReady(const std::function<bool()>& check_interrupted) {
+  return WaitForChannelReady(channel_, check_interrupted);
+}
+
+void NetworkConnectionInfoServiceComm::TryCancel() {
+  WITH_LOCK(context_mutex_) {
+    if (context_) context_->TryCancel();
+  }
+}
+
+std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> NetworkConnectionInfoServiceComm::PushNetworkConnectionInfoOpenStream(std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) {
+  if (!context_)
+    ResetClientContext();
+
+  return DuplexClient::CreateWithReadCallback(
+      &sensor::NetworkConnectionInfoService::Stub::AsyncPushNetworkConnectionInfo,
+      channel_, context_.get(), std::move(receive_func));
+}
+
+}  // namespace collector

--- a/collector/lib/NetworkConnectionInfoServiceComm.h
+++ b/collector/lib/NetworkConnectionInfoServiceComm.h
@@ -1,0 +1,90 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#ifndef COLLECTOR_NETWORKCONNECTIONINFOSERVICECOMM_H
+#define COLLECTOR_NETWORKCONNECTIONINFOSERVICECOMM_H
+
+#include <memory>
+
+#include <grpc/grpc.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+
+#include "internalapi/sensor/network_connection_iservice.grpc.pb.h"
+
+#include "DuplexGRPC.h"
+
+namespace collector {
+
+// Gathers all the communication routines targeted at NetworkConnectionInfoService.
+// A simple gRPC mock is not sufficient for testing, since it doesn't abstract Streams.
+class INetworkConnectionInfoServiceComm {
+ public:
+  virtual ~INetworkConnectionInfoServiceComm() {}
+
+  virtual void ResetClientContext() = 0;
+  // return false on failure
+  virtual bool WaitForConnectionReady(const std::function<bool()>& check_interrupted) = 0;
+  virtual void TryCancel() = 0;
+
+  virtual sensor::NetworkConnectionInfoService::StubInterface* GetStub() = 0;
+
+  virtual std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> PushNetworkConnectionInfoOpenStream(std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) = 0;
+};
+
+class NetworkConnectionInfoServiceComm : public INetworkConnectionInfoServiceComm {
+ public:
+  NetworkConnectionInfoServiceComm(std::string hostname, std::shared_ptr<grpc::Channel> channel);
+
+  void ResetClientContext() override;
+  bool WaitForConnectionReady(const std::function<bool()>& check_interrupted) override;
+  void TryCancel() override;
+
+  sensor::NetworkConnectionInfoService::StubInterface* GetStub() override {
+    return stub_.get();
+  }
+
+  std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> PushNetworkConnectionInfoOpenStream(std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) override;
+
+ private:
+  static constexpr char kHostnameMetadataKey[] = "rox-collector-hostname";
+  static constexpr char kCapsMetadataKey[] = "rox-collector-capabilities";
+
+  // Keep this updated with all capabilities supported. Format it as a comma-separated list with NO spaces.
+  static constexpr char kSupportedCaps[] = "public-ips,network-graph-external-srcs";
+
+  std::unique_ptr<grpc::ClientContext> CreateClientContext() const;
+
+  std::string hostname_;
+  std::shared_ptr<grpc::Channel> channel_;
+  std::unique_ptr<sensor::NetworkConnectionInfoService::Stub> stub_;
+
+  std::mutex context_mutex_;
+  std::unique_ptr<grpc::ClientContext> context_;
+};
+
+}  // namespace collector
+
+#endif

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -212,7 +212,7 @@ bool NetworkStatusNotifier::UpdateAllConnsAndEndpoints() {
   std::vector<Connection> all_conns;
   std::vector<ContainerEndpoint> all_listen_endpoints;
   WITH_TIMER(CollectorStats::net_scrape_read) {
-    bool success = conn_scraper_.Scrape(&all_conns, scrape_listen_endpoints_ ? &all_listen_endpoints : nullptr);
+    bool success = conn_scraper_->Scrape(&all_conns, scrape_listen_endpoints_ ? &all_listen_endpoints : nullptr);
     if (!success) {
       CLOG(ERROR) << "Failed to scrape connections and no pending connections to send";
       return false;

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -79,12 +79,14 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   void OnRecvControlMessage(const sensor::NetworkFlowsControlMessage* msg);
 
   void Run();
-  void WaitUntilWriterStarted(DuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer, int wait_time);
+  void WaitUntilWriterStarted(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer, int wait_time);
   bool UpdateAllConnsAndEndpoints();
-  void RunSingle(DuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
-  void RunSingleAfterglow(DuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
+  void RunSingle(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
+  void RunSingleAfterglow(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
   void ReceivePublicIPs(const sensor::IPAddressList& public_ips);
   void ReceiveIPNetworks(const sensor::IPNetworkList& networks);
+
+  virtual std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> CreateWriter();
 
   std::string hostname_;
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -47,13 +47,13 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
  public:
   using Stub = sensor::NetworkConnectionInfoService::Stub;
 
-  NetworkStatusNotifier(std::string hostname, std::string proc_dir, int scrape_interval, bool scrape_listen_endpoints,
+  NetworkStatusNotifier(std::string hostname, std::shared_ptr<IConnScraper> conn_scraper, int scrape_interval, bool scrape_listen_endpoints,
                         bool turn_off_scrape,
                         std::shared_ptr<ConnectionTracker> conn_tracker,
                         std::shared_ptr<grpc::Channel> channel,
                         int64_t afterglow_period_micros,
                         bool use_afterglow)
-      : hostname_(std::move(hostname)), conn_scraper_(std::move(proc_dir)), scrape_interval_(scrape_interval), turn_off_scraping_(turn_off_scrape), scrape_listen_endpoints_(scrape_listen_endpoints), conn_tracker_(std::move(conn_tracker)), channel_(std::move(channel)), stub_(sensor::NetworkConnectionInfoService::NewStub(channel_)), afterglow_period_micros_(afterglow_period_micros), enable_afterglow_(use_afterglow) {
+      : hostname_(std::move(hostname)), conn_scraper_(conn_scraper), scrape_interval_(scrape_interval), turn_off_scraping_(turn_off_scrape), scrape_listen_endpoints_(scrape_listen_endpoints), conn_tracker_(std::move(conn_tracker)), channel_(std::move(channel)), stub_(sensor::NetworkConnectionInfoService::NewStub(channel_)), afterglow_period_micros_(afterglow_period_micros), enable_afterglow_(use_afterglow) {
   }
 
   void Start();
@@ -93,7 +93,7 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   std::unique_ptr<grpc::ClientContext> context_;
   std::mutex context_mutex_;
 
-  ConnScraper conn_scraper_;
+  std::shared_ptr<IConnScraper> conn_scraper_;
   int scrape_interval_;
   bool turn_off_scraping_;
   bool scrape_listen_endpoints_;

--- a/collector/lib/SignalServiceClient.h
+++ b/collector/lib/SignalServiceClient.h
@@ -68,7 +68,7 @@ class SignalServiceClient {
 
   // This needs to have the same lifetime as the class.
   std::unique_ptr<grpc::ClientContext> context_;
-  std::unique_ptr<DuplexClientWriter<SignalStreamMessage>> writer_;
+  std::unique_ptr<IDuplexClientWriter<SignalStreamMessage>> writer_;
 
   bool first_write_;
 };

--- a/collector/proto/CMakeLists.txt
+++ b/collector/proto/CMakeLists.txt
@@ -30,4 +30,4 @@ target_include_directories(rox-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 get_target_property(grpc_cpp_plugin_location gRPC::grpc_cpp_plugin LOCATION)
 protobuf_generate(TARGET rox-proto LANGUAGE cpp)
-protobuf_generate(TARGET rox-proto LANGUAGE grpc GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc PLUGIN "protoc-gen-grpc=${grpc_cpp_plugin_location}")
+protobuf_generate(TARGET rox-proto LANGUAGE grpc GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc PLUGIN "protoc-gen-grpc=${grpc_cpp_plugin_location}" PLUGIN_OPTIONS generate_mock_code=true)

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -34,7 +34,10 @@ You should have received a copy of the GNU General Public License along with thi
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using namespace collector;
+namespace collector {
+
+namespace {
+
 using grpc_duplex_impl::Result;
 using grpc_duplex_impl::Status;
 using ::testing::Invoke;
@@ -162,3 +165,7 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
 
   SUCCEED();
 }
+
+}  // namespace
+
+}  // namespace collector

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -1,0 +1,164 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include <chrono>
+#include <mutex>
+#include <string>
+
+#include "internalapi/sensor/network_connection_iservice.grpc.pb.h"
+
+#include "CollectorConfig.h"
+#include "DuplexGRPC.h"
+#include "NetworkStatusNotifier.h"
+#include "Utility.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace collector;
+using grpc_duplex_impl::Result;
+using grpc_duplex_impl::Status;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnPointee;
+
+// until we use C++20
+class Semaphore {
+ public:
+  Semaphore(int value = 1) : value_(value) {}
+
+  void release() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    value_++;
+    cond_.notify_one();
+  }
+
+  void acquire() {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    while (value_ <= 0)
+      cond_.wait(lock);
+    value_--;
+  }
+
+  template <class Rep, class Period>
+  bool try_acquire_for(const std::chrono::duration<Rep, Period>& rel_time) {
+    auto deadline = std::chrono::steady_clock::now() + rel_time;
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    while (value_ <= 0)
+      if (cond_.wait_until(lock, deadline) == std::cv_status::timeout)
+        return false;
+    value_--;
+    return true;
+  }
+
+ private:
+  int value_;
+  std::condition_variable cond_;
+  std::mutex mutex_;
+};
+
+class MockConnScraper : public IConnScraper {
+ public:
+  MOCK_METHOD(bool, Scrape, (std::vector<Connection> * connections, std::vector<ContainerEndpoint>* listen_endpoints), (override));
+};
+
+class MockDuplexClientWriter : public IDuplexClientWriter<sensor::NetworkConnectionInfoMessage> {
+ public:
+  MOCK_METHOD(grpc_duplex_impl::Result, Write, (const sensor::NetworkConnectionInfoMessage& obj, const gpr_timespec& deadline), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, WriteAsync, (const sensor::NetworkConnectionInfoMessage& obj), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, WaitUntilStarted, (const gpr_timespec& deadline), (override));
+  MOCK_METHOD(bool, Sleep, (const gpr_timespec& deadline), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, WritesDoneAsync, (), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, WritesDone, (const gpr_timespec& deadline), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, FinishAsync, (), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, WaitUntilFinished, (const gpr_timespec& deadline), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, Finish, (grpc::Status * status, const gpr_timespec& deadline), (override));
+  MOCK_METHOD(grpc::Status, Finish, (const gpr_timespec& deadline), (override));
+  MOCK_METHOD(void, TryCancel, (), (override));
+  MOCK_METHOD(grpc_duplex_impl::Result, Shutdown, (), (override));
+};
+
+class MockNetworkConnectionInfoServiceComm : public INetworkConnectionInfoServiceComm {
+ public:
+  MOCK_METHOD(void, ResetClientContext, (), (override));
+  MOCK_METHOD(bool, WaitForConnectionReady, (const std::function<bool()>& check_interrupted), (override));
+  MOCK_METHOD(void, TryCancel, (), (override));
+  MOCK_METHOD(sensor::NetworkConnectionInfoService::StubInterface*, GetStub, (), (override));
+  MOCK_METHOD(std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>>, PushNetworkConnectionInfoOpenStream, (std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func), (override));
+};
+
+TEST(NetworkStatusNotifier, SimpleStartStop) {
+  bool running = true;
+  CollectorConfig config_(0);
+  std::shared_ptr<MockConnScraper> conn_scraper = std::make_shared<MockConnScraper>();
+  auto conn_tracker = std::make_shared<ConnectionTracker>();
+  auto comm = std::make_shared<MockNetworkConnectionInfoServiceComm>();
+  Semaphore sem(0);  // to wait for the service to accomplish its job.
+
+  EXPECT_CALL(*comm, WaitForConnectionReady).WillRepeatedly(Return(true));
+  // gRPC shuts down the loop, so we will want writer->Sleep to return with false
+  EXPECT_CALL(*comm, TryCancel).Times(1).WillOnce([&running] { running = false; });
+
+  // Create and return a writer object
+  EXPECT_CALL(*comm, PushNetworkConnectionInfoOpenStream).Times(1).WillOnce([&sem, &running](std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) -> std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> {
+    auto duplex_writer = MakeUnique<MockDuplexClientWriter>();
+
+    // the service is sending Sensor a message
+    EXPECT_CALL(*duplex_writer, Write).Times(1).WillOnce([&sem, &running](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
+      for (auto cnx : msg.info().updated_connections()) {
+        std::cout << cnx.container_id() << std::endl;
+      }
+      sem.release();  // notify that the test should end
+      return Result(true);
+    });
+    EXPECT_CALL(*duplex_writer, Sleep).WillRepeatedly(ReturnPointee(&running));
+    EXPECT_CALL(*duplex_writer, WaitUntilStarted).WillRepeatedly(Return(Result(true)));
+
+    return duplex_writer;
+  });
+
+  // Connections/Endpoints returned by the scrapper
+  EXPECT_CALL(*conn_scraper, Scrape).WillRepeatedly([&sem](std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) -> bool {
+    connections->emplace_back("containerId", Endpoint(Address(10, 0, 1, 32), 1024), Endpoint(Address(139, 45, 27, 4), 999), L4Proto::TCP, true);
+    return true;
+  });
+
+  auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
+                                                               config_.ScrapeInterval(), config_.ScrapeListenEndpoints(),
+                                                               config_.TurnOffScrape(),
+                                                               conn_tracker,
+                                                               config_.AfterglowPeriod(), config_.EnableAfterglow(),
+                                                               comm);
+
+  net_status_notifier->Start();
+
+  // we could send probe events using conn_tracker->UpdateConnection
+
+  EXPECT_TRUE(sem.try_acquire_for(std::chrono::seconds(5)));
+
+  running = false;
+  net_status_notifier->Stop();
+
+  SUCCEED();
+}

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -133,10 +133,10 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
         std::cout << cnx.container_id() << std::endl;
       }
       sem.release();  // notify that the test should end
-      return Result(true);
+      return Result(Status::OK);
     });
     EXPECT_CALL(*duplex_writer, Sleep).WillRepeatedly(ReturnPointee(&running));
-    EXPECT_CALL(*duplex_writer, WaitUntilStarted).WillRepeatedly(Return(Result(true)));
+    EXPECT_CALL(*duplex_writer, WaitUntilStarted).WillRepeatedly(Return(Result(Status::OK)));
 
     return duplex_writer;
   });


### PR DESCRIPTION
## Description

In order to test the NetworkConnectionInfoService, we need to mock its dependencies:

* the connection scrapper
* the connection tracker
* the "upstream" channel with Sensor

This first PR is intended to be perfectly isofunctional, and insert those interfaces seamlessly in the call path.

## Checklist
- [x] Investigated and inspected CI test results

