### PR TITLE
Remove -g from bpf compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
 
   kernels:
     <<: *defaultMachine
-    parallelism: 8
+    parallelism: 32
     environment:
     - BUILD_CONTAINER_TAG: quay.io/rhacs-eng/collector-builder:kobuilder-cache
     - BUILD_CONTAINER_CACHE_IMAGES: quay.io/rhacs-eng/collector-builder:kobuilder-cache


### PR DESCRIPTION
## Description

Update falco libs to remove debug symbols from ebpf bytecode. ebpf probes are ~67% smaller.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Updated documentation accordingly~

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] validate no performance impacts
- [ ] ci passes