### PR TITLE
Small fix on the prepare-src script

### DIFF
--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 die() {
-    echo >&2 "$1"
+    echo >&2 "$@"
     exit 1
 }
 

--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -2,10 +2,15 @@
 
 set -eo pipefail
 
-[[ -n "$SCRATCH_DIR" && -n "$DRIVER_DIR" && -n "$OUTPUT_DIR" && -n "$LEGACY_DIR" ]] || {
-    echo >&2 "SCRATCH_DIR, DRIVER_DIR and OUTPUT_DIR all need to be set"
+die() {
+    echo >&2 "$1"
     exit 1
 }
+
+[[ -n "$SCRATCH_DIR" ]] || die "SCRATCH_DIR is not set"
+[[ -n "$DRIVER_DIR" ]] || die "DRIVER_DIR is not set"
+[[ -n "$OUTPUT_DIR" ]] || die "OUTPUT_DIR is not set"
+[[ -n "$LEGACY_DIR" ]] || die "LEGACY_DIR is not set"
 
 DOCKERIZED=${DOCKERIZED:-0}
 DRIVER_SCRATCH="${SCRATCH_DIR}/src"


### PR DESCRIPTION
## Description

This patch started by adding a missing variable name to an error message, but I also took the liberty of refactoring the check so that is properly prints the variable that caused the error.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
The change itself should be pretty transparent, only the prepare sources step will be affected.

- [x] Run CI with `build-legacy-probes` for a more thorough check.