### PR TITLE
Allow specifying instruction set

### DIFF
--- a/kernel-modules/probe/Makefile
+++ b/kernel-modules/probe/Makefile
@@ -9,6 +9,7 @@ always = $(always-y)
 
 LLC ?= llc
 CLANG ?= clang
+BPF_ISA ?= probe
 
 KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
@@ -59,4 +60,9 @@ $(obj)/probe.o: $(src)/collector_probe.c
 		-fno-stack-protector \
 		-Wno-tautological-compare \
 		-O2 $(BPF_DEBUG_SYMBOLS) -emit-llvm -c $< -o $(patsubst %.o,%.ll,$@)
-	$(LLC) -march=bpf -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
+	$(LLC) \
+		-march=bpf \
+		-mcpu=$(BPF_ISA) \
+		-mattr=+alu32 \
+		-filetype=obj \
+		-o $@ $(patsubst %.o,%.ll,$@)


### PR DESCRIPTION
## Description

Kernel supports few instruction sets [[1]], and the default one (which is
apparently being used at the moment in falco) is going to be the
`generic` or `v1`, which has certain limitations and requires
workarounds. It's possible to instruct `llc` to search the latest
supported instruction set via `-mcpu` parameter, which generally
speaking should result in more compact and potentially more performant
generated instructions for the same code. For the support table see
great blog post [[2]] about the topic. The gist for the support is:

v2: Linux v4.14 [[3]], LLVM v6.0 [[4]]
v3: Linux v5.1 [[5]], LLVM [[6]]

Probing is working via performing bpf syscall with various instruction
sets and figuring out maximum supported version based on the results.
Which means it would work only for the build host, so we need to allow
pinning it precisely if needed.

[1]: https://www.kernel.org/doc/html/latest/bpf/bpf_devel_QA.html#q-new-bpf-instruction-for-kernel-and-llvm
[2]: https://pchaigno.github.io/bpf/2021/10/20/ebpf-instruction-sets.html
[3]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=92b31a9af73b3a3fc801899335d6c47966351830
[4]: https://reviews.llvm.org/rL311522
[5]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=092ed0968bb648cd18e8a0430cd0a8a71727315c
[6]: https://reviews.llvm.org/rL353384

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Local testing with instruction set v2.