### PR TITLE
ROX-17097 Tests to exercise NetworkStatusNotifier at gRPC level.

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -105,7 +105,7 @@ end
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
- private:
+ protected:
   bool use_chisel_cache_;
   int scrape_interval_;
   int snap_len_;

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -278,8 +278,6 @@ TEST(NetworkStatusNotifier, UpdateIPnoAfterglow) {
   // the same server connection normalized and grouped in a known subnet
   Connection conn3("containerId", Endpoint(Address(), 1024), Endpoint(IPNet(Address(139, 45, 0, 0), 16), 0), L4Proto::TCP, true);
 
-  UnorderedMap<Address::Family, std::vector<IPNet>> known_networks = {{Address::Family::IPV4, {IPNet(Address(139, 45, 0, 0), 16)}}};
-
   config.DisableAfterglow();
 
   // the connection is always ready

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -25,6 +25,8 @@ You should have received a copy of the GNU General Public License along with thi
 #include <mutex>
 #include <string>
 
+#include <google/protobuf/util/time_util.h>
+
 #include "internalapi/sensor/network_connection_iservice.grpc.pb.h"
 
 #include "CollectorConfig.h"
@@ -43,6 +45,7 @@ using grpc_duplex_impl::Status;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnPointee;
+using ::testing::UnorderedElementsAre;
 
 // until we use C++20
 class Semaphore {
@@ -81,6 +84,15 @@ class Semaphore {
   std::mutex mutex_;
 };
 
+class MockCollectorConfig : public collector::CollectorConfig {
+ public:
+  MockCollectorConfig() : collector::CollectorConfig(0) {}
+
+  void DisableAfterglow() {
+    enable_afterglow_ = false;
+  }
+};
+
 class MockConnScraper : public IConnScraper {
  public:
   MOCK_METHOD(bool, Scrape, (std::vector<Connection> * connections, std::vector<ContainerEndpoint>* listen_endpoints), (override));
@@ -111,6 +123,76 @@ class MockNetworkConnectionInfoServiceComm : public INetworkConnectionInfoServic
   MOCK_METHOD(std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>>, PushNetworkConnectionInfoOpenStream, (std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func), (override));
 };
 
+class NetworkConnectionInfoMessageParser {
+ public:
+  NetworkConnectionInfoMessageParser(const sensor::NetworkConnectionInfoMessage& msg) {
+    for (auto conn : msg.info().updated_connections()) {
+      updated_connections_.emplace(
+          Connection(
+              conn.container_id(),
+              Endpoint(IPNetFromProto(conn.local_address()), conn.local_address().port()),
+              Endpoint(IPNetFromProto(conn.remote_address()), conn.remote_address().port()),
+              L4ProtocolFromProto(conn.protocol()),
+              conn.role() == sensor::ROLE_SERVER),
+          !conn.has_close_timestamp());
+    }
+  }
+
+  const std::unordered_map<Connection, bool, Hasher>& get_updated_connections() const { return updated_connections_; }
+
+ private:
+  std::unordered_map<Connection, bool, Hasher> updated_connections_;
+
+  static IPNet IPNetFromProto(const sensor::NetworkAddress& na) {
+    Address addr;
+    const bool is_net = (na.ip_network().length() != 0);
+
+    const std::string& bytes_stream = is_net ? na.ip_network() : na.address_data();
+
+    switch (bytes_stream.length()) {
+      case 0:
+        return IPNet();
+      case 4:
+      case 5: {
+        uint32_t ip;
+        memcpy((void*)&ip, bytes_stream.c_str(), 4);
+        addr = Address(ip);
+        break;
+      }
+      case 16:
+      case 17: {
+        uint32_t ip[4];
+        memcpy((void*)ip, bytes_stream.c_str(), 16);
+        addr = Address(ip);
+        break;
+      }
+      default:
+        throw std::runtime_error("Invalid address length");
+    }
+
+    if (is_net) {
+      const char* prefix_len = bytes_stream.c_str() + (bytes_stream.length() - 1);
+
+      return IPNet(addr, *prefix_len);
+    } else {
+      return IPNet(addr);
+    }
+  }
+
+  static L4Proto L4ProtocolFromProto(storage::L4Protocol proto) {
+    switch (proto) {
+      case storage::L4_PROTOCOL_TCP:
+        return L4Proto::TCP;
+      case storage::L4_PROTOCOL_UDP:
+        return L4Proto::UDP;
+      case storage::L4_PROTOCOL_ICMP:
+        return L4Proto::ICMP;
+      default:
+        return L4Proto::UNKNOWN;
+    }
+  }
+};
+
 TEST(NetworkStatusNotifier, SimpleStartStop) {
   bool running = true;
   CollectorConfig config_(0);
@@ -128,7 +210,7 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
     auto duplex_writer = MakeUnique<MockDuplexClientWriter>();
 
     // the service is sending Sensor a message
-    EXPECT_CALL(*duplex_writer, Write).Times(1).WillOnce([&sem, &running](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
+    EXPECT_CALL(*duplex_writer, Write).WillRepeatedly([&sem, &running](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
       for (auto cnx : msg.info().updated_connections()) {
         std::cout << cnx.container_id() << std::endl;
       }
@@ -156,14 +238,93 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
 
   net_status_notifier->Start();
 
-  // we could send probe events using conn_tracker->UpdateConnection
-
   EXPECT_TRUE(sem.try_acquire_for(std::chrono::seconds(5)));
 
-  running = false;
   net_status_notifier->Stop();
+}
 
-  SUCCEED();
+TEST(NetworkStatusNotifier, UpdateIPnoAfterglow) {
+  bool running = true;
+  MockCollectorConfig config;
+  std::shared_ptr<MockConnScraper> conn_scraper = std::make_shared<MockConnScraper>();
+  auto conn_tracker = std::make_shared<ConnectionTracker>();
+  auto comm = std::make_shared<MockNetworkConnectionInfoServiceComm>();
+  std::function<void(const sensor::NetworkFlowsControlMessage*)> network_flows_callback;
+  Semaphore sem(0);  // to wait for the service to accomplish its job.
+
+  // the connection as scrapped (public)
+  Connection conn1("containerId", Endpoint(Address(10, 0, 1, 32), 1024), Endpoint(Address(139, 45, 27, 4), 999), L4Proto::TCP, true);
+  // the same server connection normalized
+  Connection conn2("containerId", Endpoint(Address(), 1024), Endpoint(Address(255, 255, 255, 255), 0), L4Proto::TCP, true);
+  // the same server connection normalized and grouped in a known subnet
+  Connection conn3("containerId", Endpoint(Address(), 1024), Endpoint(IPNet(Address(139, 45, 0, 0), 16), 0), L4Proto::TCP, true);
+
+  UnorderedMap<Address::Family, std::vector<IPNet>> known_networks = {{Address::Family::IPV4, {IPNet(Address(139, 45, 0, 0), 16)}}};
+
+  config.DisableAfterglow();
+
+  EXPECT_CALL(*comm, WaitForConnectionReady).WillRepeatedly(Return(true));
+  // gRPC shuts down the loop, so we will want writer->Sleep to return with false
+  EXPECT_CALL(*comm, TryCancel).Times(1).WillOnce([&running] { running = false; });
+
+  // Create and return a writer object
+  EXPECT_CALL(*comm, PushNetworkConnectionInfoOpenStream).Times(1).WillOnce([&sem, &running, &conn2, &conn3, &network_flows_callback](std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) -> std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> {
+    auto duplex_writer = MakeUnique<MockDuplexClientWriter>();
+    network_flows_callback = receive_func;
+
+    // the service is sending Sensor a message
+    EXPECT_CALL(*duplex_writer, Write).WillOnce([&conn2, &sem](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
+                                        EXPECT_THAT(NetworkConnectionInfoMessageParser(msg).get_updated_connections(), UnorderedElementsAre(std::make_pair(conn2, true)));
+                                        return Result(true);
+                                      })
+        .WillOnce([&conn2, &conn3, &sem](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
+          // conn3 appears and conn2 is destroyed
+          EXPECT_THAT(NetworkConnectionInfoMessageParser(msg).get_updated_connections(), UnorderedElementsAre(std::make_pair(conn3, true), std::make_pair(conn2, false)));
+
+          // Done
+          sem.release();
+
+          return Result(true);
+        })
+        .WillRepeatedly(Return(Result(true)));
+
+    EXPECT_CALL(*duplex_writer, Sleep).WillOnce(ReturnPointee(&running)).WillOnce([&running, &network_flows_callback](const gpr_timespec& deadline) {
+                                                                          sensor::NetworkFlowsControlMessage msg;
+                                                                          unsigned char content[] = {139, 45, 0, 0, 16};  // address in network order, plus prefix length
+                                                                          std::string network((char*)content, sizeof(content));
+
+                                                                          auto ip_networks = msg.mutable_ip_networks();
+                                                                          ip_networks->set_ipv4_networks(network);
+
+                                                                          network_flows_callback(&msg);
+                                                                          return running;
+                                                                        })
+        .WillRepeatedly(ReturnPointee(&running));
+
+    EXPECT_CALL(*duplex_writer, WaitUntilStarted).WillRepeatedly(Return(Result(true)));
+
+    return duplex_writer;
+  });
+
+  // Connections/Endpoints returned by the scrapper
+  EXPECT_CALL(*conn_scraper, Scrape).WillRepeatedly([&conn1](std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) -> bool {
+    connections->emplace_back(conn1);
+    return true;
+  });
+
+  auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
+                                                               config.ScrapeInterval(), config.ScrapeListenEndpoints(),
+                                                               config.TurnOffScrape(),
+                                                               conn_tracker,
+                                                               config.AfterglowPeriod(), config.EnableAfterglow(),
+                                                               comm);
+
+  net_status_notifier->Start();
+
+  // Wait for the first scrape to occur
+  EXPECT_TRUE(sem.try_acquire_for(std::chrono::seconds(5)));
+
+  net_status_notifier->Stop();
 }
 
 }  // namespace

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -144,6 +144,8 @@ class NetworkConnectionInfoMessageParser {
     }
   }
 
+  /* our internal model for connection life-cycle events uses the Connection object as the key for a hashmap.
+     The value in the hashmap describes the kind of event: true stands for a creation, false for a deletion. */
   const std::unordered_map<Connection, bool, Hasher>& get_updated_connections() const { return updated_connections_; }
 
  private:


### PR DESCRIPTION
## Description

We want to minimize the risk of regression with the ongoing changes on the collector reporting algorithm.
These tests are able to mock the connection with Sensor down to the level of proto gRPC objects.