### PR TITLE
ROX-11725 update googletest for ubi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,4 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,6 @@
 	path = collector/proto/third_party/stackrox
 	url = https://github.com/stackrox/stackrox
 	branch = master
+[submodule "third_party/googletest"]
+	path = third_party/googletest
+	url = https://github.com/google/googletest.git

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifdef BUILD_BUILDER_IMAGE
 		--cache-from quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
 		-t quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
 		-f "$(CURDIR)/builder/Dockerfile" \
-		builder
+		.
 else
 	docker pull quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)
 endif

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,11 +2,8 @@ FROM quay.io/centos/centos:stream8
 
 ARG NPROCS=6
 ENV NPROCS=$NPROCS
-ARG BUILDER_ROOT_DIR=.
-ENV BUILDER_ROOT_DIR=$BUILDER_ROOT_DIR
 
-COPY . /go/src/github.com/stackrox/collector
-WORKDIR /go/src/github.com/stackrox/collector
+ARG BUILD_DIR=/install-tmp
 
 USER root
 
@@ -50,13 +47,15 @@ RUN dnf -y update \
         which \
     && dnf clean all
 
-# We want to fail if the destination directory is there, hence mkdir (not -p).
-RUN mkdir /install-tmp
-
-RUN cp -r "${BUILDER_ROOT_DIR}"/install/*.sh "/install-tmp"
-
 # Build dependencies from source
-RUN "/install-tmp/install.sh"
+WORKDIR ${BUILD_DIR}
+
+COPY builder builder
+COPY third_party third_party
+
+RUN "builder/install/install-dependencies.sh"
+
+RUN rm -rf ${BUILD_DIR}
 
 RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 

--- a/builder/build/build-ubi-dependencies.sh
+++ b/builder/build/build-ubi-dependencies.sh
@@ -15,6 +15,7 @@ mkdir -p "${LICENSE_DIR}"
 
 ### Dependencies
 cd third_party
+../builder/install/20-googletest.sh
 ../builder/install/40-grpc.sh
 ../builder/install/50-libb64.sh
 ../builder/install/50-luajit.sh

--- a/builder/build/build-ubi-dependencies.sh
+++ b/builder/build/build-ubi-dependencies.sh
@@ -14,8 +14,8 @@ export LICENSE_DIR="/THIRD_PARTY_NOTICES"
 mkdir -p "${LICENSE_DIR}"
 
 ### Dependencies
+builder/install/20-googletest.sh
 cd third_party
-../builder/install/20-googletest.sh
 ../builder/install/40-grpc.sh
 ../builder/install/50-libb64.sh
 ../builder/install/50-luajit.sh

--- a/builder/install/20-googletest.sh
+++ b/builder/install/20-googletest.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-git clone https://github.com/google/googletest.git -b "$GOOGLETEST_REVISION" --depth 1
-cd googletest
+cd third_party/googletest
 cp LICENSE "${LICENSE_DIR}/googletest-${GOOGLETEST_REVISION}"
 mkdir cmake-build
 cd cmake-build
 cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j "${NPROCS:-2}"
-make install
+cmake --build . --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/install-dependencies.sh
+++ b/builder/install/install-dependencies.sh
@@ -5,10 +5,9 @@ set -e
 export LICENSE_DIR="/THIRD_PARTY_NOTICES"
 
 mkdir -p "${LICENSE_DIR}"
-cd /install-tmp/
+
 # shellcheck source=SCRIPTDIR/versions.sh
-source ./versions.sh
-for f in [0-9][0-9]-*.sh; do
+source builder/install/versions.sh
+for f in builder/install/[0-9][0-9]-*.sh; do
     ./"$f"
 done
-cd && rm -rf /install-tmp

--- a/collector/container/Dockerfile.ubi
+++ b/collector/container/Dockerfile.ubi
@@ -39,9 +39,6 @@ RUN dnf -y update && \
         elfutils-libelf-devel \
         tbb-devel \
         c-ares-devel && \
-    dnf -y --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install \
-        gmock-devel \
-        gtest-devel && \
     dnf -y --enablerepo amq-clients-2-for-rhel-8-x86_64-rpms install \
         jsoncpp-devel && \
     dnf -y --enablerepo rhocp-4.6-for-rhel-8-x86_64-rpms install \


### PR DESCRIPTION
## Description

The UBI image used to depend on the gmock RPM for building tests.
This one is rather old and has only deprecated MOCK_METHODx macros.
We update the build to use a newer gtest from a submodule.
 
## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
