### PR TITLE
Follow up to drivers build

### DIFF
--- a/.openshift-ci/drivers/pre-build.Dockerfile
+++ b/.openshift-ci/drivers/pre-build.Dockerfile
@@ -8,8 +8,9 @@ ENV MAX_PARALLEL_BUILDS=32
 
 COPY --from=replaced-by-osci:scripts /scripts/ /scripts/
 
-RUN dnf -y install jq && \
-    ln -s /go/src/github.com/stackrox/collector/ /collector && \
+USER root
+
+RUN ln -s /go/src/github.com/stackrox/collector/ /collector && \
     git -C /collector fetch --all && \
     . /scripts/pr-checks.sh && \
     /scripts/patch-files.sh $BRANCH $LEGACY_PROBES && \


### PR DESCRIPTION
## Description

The root image on OSCI is currently running with user `circleci` and interfering with the driver's `pre-build` stage, this PR forces the stage to build using the `root` user

## Checklist
- [x] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Rehearsed on openshift/release#29021
