### PR TITLE
Use the OSCI built bundles

### DIFF
--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -19,7 +19,9 @@ download_bundle() {
 
     rm -rf "/bundles/${CURRENT_SHARD}"/* 2> /dev/null || true
     mkdir -p "/bundles/${CURRENT_SHARD}"
-    gsutil -m cp "gs://collector-kernel-bundles-public/bundle-${kernel_version}.tgz" "/bundles/${CURRENT_SHARD}/bundle-${kernel_version}.tgz"
+    gsutil -m cp \
+        "gs://stackrox-kernel-bundles-staging/copy/bundle-${kernel_version}.tgz" \
+        "/bundles/${CURRENT_SHARD}/bundle-${kernel_version}.tgz"
 }
 
 osci_handle_bundle() {

--- a/kernel-modules/build/build-wrapper.sh
+++ b/kernel-modules/build/build-wrapper.sh
@@ -20,7 +20,7 @@ download_bundle() {
     rm -rf "/bundles/${CURRENT_SHARD}"/* 2> /dev/null || true
     mkdir -p "/bundles/${CURRENT_SHARD}"
     gsutil -m cp \
-        "gs://stackrox-kernel-bundles-staging/copy/bundle-${kernel_version}.tgz" \
+        "gs://collector-kernel-bundles-public/bundle-${kernel_version}.tgz" \
         "/bundles/${CURRENT_SHARD}/bundle-${kernel_version}.tgz"
 }
 


### PR DESCRIPTION
## Description

This PR changes the bucket being used to pull kernel bundles during driver builds. The new bucket is populated by the OSCI crawler.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Green-ish CI should be enough