### PR TITLE
Hacks to build Collector on M1 Macs

### DIFF
--- a/kernel-modules/build/Dockerfile
+++ b/kernel-modules/build/Dockerfile
@@ -18,18 +18,18 @@ RUN apt-get update \
       pkg-config \
  ;
 
-RUN sed s_stretch_jessie_g < /etc/apt/sources.list > /etc/apt/sources.list.d/jessie.list && \
-    apt-get update && apt-get install --no-install-recommends -y \
-      gcc-4.9 \
-;
+#RUN sed s_stretch_jessie_g < /etc/apt/sources.list > /etc/apt/sources.list.d/jessie.list && \
+#    apt-get update && apt-get install --no-install-recommends -y \
+#      gcc-4.9 \
+#;
 
 # Since our base Debian image ships with GCC 6 which breaks older kernels, revert the
 # default to gcc-4.9
-RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc
-RUN rm -rf /usr/bin/clang \
- && rm -rf /usr/bin/llc \
- && ln -s /usr/bin/clang-7 /usr/bin/clang \
- && ln -s /usr/bin/llc-7 /usr/bin/llc
+#RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-4.9 /usr/bin/gcc
+#RUN rm -rf /usr/bin/clang \
+# && rm -rf /usr/bin/llc \
+# && ln -s /usr/bin/clang-7 /usr/bin/clang \
+# && ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN apt-get autoremove -y
 


### PR DESCRIPTION
## Description

Trying to get Collector to compile and run on M1 Macs.

To build run:
`BUILD_BUILDER_IMAGE=true make image`

Then before deploying using the `deploy-local.sh` script, tag the Collector image so that it gets picked up instead of being pulled from the registry.

Using this approach, Collector should compile and run, but then fails like this (on colima):

```
[W 20220811 163720 collector.cpp:343] Error getting kernel object: collector-ebpf-5.10.109-0-virt.o
[I 20220811 163720 collector.cpp:215] gRPC server=sensor.stackrox.svc:443
[I 20220811 163720 collector.cpp:357] Attempting to connect to GRPC server
[E 20220811 163720 collector.cpp:359] Unable to connect to the GRPC server.
[F 20220811 163720 collector.cpp:368] No suitable kernel object downloaded
```

A follow-up step could be installing the kernel source files in the build container, and see if it builds the driver, using
`BUILD_BUILDER_IMAGE=true make image-dev-full`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

