### PR TITLE
ROX-12259 push collector builder images in osci

### DIFF
--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -78,13 +78,5 @@ image_repos=(
     "${PUBLIC_REPO}"
 )
 
-image_name=$1
-
-if [[ "$image_name" == "collector" ]]; then
-    push_images
-elif [[ "$image_name" == "collector-builder" ]]; then
-    push_builder_image
-else
-    echo "Unknown image name $image_name"
-    exit 1
-fi
+push_images
+push_builder_image

--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -2,10 +2,62 @@
 set -eo pipefail
 
 export PROJECT_DIR=/go/src/github.com/stackrox/collector
+# shellcheck source=SCRIPTDIR/../../drivers/scripts/lib.sh
+source "$PROJECT_DIR/.openshift-ci/drivers/scripts/lib.sh"
+
+push_images_to_repos() {
+    local -n local_image_repos=$1
+    local -n local_tags=$2
+    local image_name=$3
+    local osci_image=$4
+
+    for repo in "${local_image_repos[@]}"; do
+        registry_rw_login "$repo"
+
+        for tag in "${local_tags[@]}"; do
+            image="${repo}/${image_name}:${tag}"
+            echo "Pushing image ${image}"
+            oc image mirror "${osci_image}" "${image}"
+        done
+    done
+}
+
+push_builder_image() {
+
+    BRANCH="$(get_branch)"
+    tags=("$collector_version")
+
+    if [[ "$BRANCH" == "master" ]]; then
+        # shellcheck disable=SC2034
+        tags+=("cache")
+    fi
+
+    oc registry login
+
+    push_images_to_repos image_repos tags collector-builder "${COLLECTOR_BUILDER}"
+}
+
+push_images() {
+    oc registry login
+
+    # shellcheck disable=SC2034
+    full_tags=(
+        "${collector_version}"
+        "${collector_version}-latest"
+    )
+    push_images_to_repos image_repos full_tags collector "${COLLECTOR_FULL}"
+
+    # shellcheck disable=SC2034
+    base_tags=(
+        "${collector_version}-slim"
+        "${collector_version}-base"
+    )
+    push_images_to_repos image_repos base_tags collector "${COLLECTOR_SLIM}"
+}
+
 cd "$PROJECT_DIR"
 
 collector_version="$(make tag)"
-export COLLECTOR_VERSION="$collector_version"
 
 export PUBLIC_REPO=quay.io/stackrox-io
 export QUAY_REPO=quay.io/rhacs-eng
@@ -18,34 +70,21 @@ done
 # shellcheck source=SCRIPTDIR/registry_rw_login.sh
 source "${PROJECT_DIR}/.openshift-ci/jobs/push-images/registry_rw_login.sh"
 
+# Note that shellcheck reports unused variable when arrays are passed as reference.
+# See https://github.com/koalaman/shellcheck/issues/1957
+# shellcheck disable=SC2034
 image_repos=(
     "${QUAY_REPO}"
     "${PUBLIC_REPO}"
 )
 
-full_tags=(
-    "${COLLECTOR_VERSION}"
-    "${COLLECTOR_VERSION}-latest"
-)
+image_name=$1
 
-base_tags=(
-    "${COLLECTOR_VERSION}-slim"
-    "${COLLECTOR_VERSION}-base"
-)
-
-oc registry login
-for repo in "${image_repos[@]}"; do
-    registry_rw_login "$repo"
-
-    for tag in "${full_tags[@]}"; do
-        image="${repo}/collector:${tag}"
-        echo "Pushing image ${image}"
-        oc image mirror "${COLLECTOR_FULL}" "${image}"
-    done
-
-    for tag in "${base_tags[@]}"; do
-        image="${repo}/collector:${tag}"
-        echo "Pushing image ${image}"
-        oc image mirror "${COLLECTOR_SLIM}" "${image}"
-    done
-done
+if [[ "$image_name" == "collector" ]]; then
+    push_images
+elif [[ "$image_name" == "collector-builder" ]]; then
+    push_builder_image
+else
+    echo "Unknown image name $image_name"
+    exit 1
+fi


### PR DESCRIPTION
## Description

Add a OSCI job to push collector builder images. See https://github.com/openshift/release/pull/31470

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

- [x] Pulled collector builder image built by OSCI and used it locally
