### PR TITLE
Add OSCI rehearsal labels and option to use same cache across PR builds

### DIFF
--- a/.openshift-ci/drivers/scripts/env.sh
+++ b/.openshift-ci/drivers/scripts/env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export MAIN_DRIVER_CACHE="gs://collector-modules-osci-public/"
+export BRANCH_DRIVER_CACHE="gs://stackrox-collector-modules-staging/pr-builds"
+export GCP_BASE_BUCKET="gs://collector-modules-osci"

--- a/.openshift-ci/drivers/scripts/lib.sh
+++ b/.openshift-ci/drivers/scripts/lib.sh
@@ -7,6 +7,31 @@ die() {
     exit 1
 }
 
+get_repo_full_name() {
+    if [[ -n "${REPO_OWNER:-}" ]]; then
+        # presubmit, postsubmit and batch runs
+        # (ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables)
+        [[ -n "${REPO_NAME:-}" ]] || die "expect: REPO_NAME"
+        echo "${REPO_OWNER}/${REPO_NAME}"
+    elif [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
+        # periodics - CLONEREFS_OPTIONS exists in binary_build_commands and images.
+        local org
+        local repo
+        org="$(jq -r '.refs[0].org' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS yaml"
+        repo="$(jq -r '.refs[0].repo' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS yaml"
+        if [[ "$org" == "null" ]] || [[ "$repo" == "null" ]]; then
+            die "expect: org and repo in CLONEREFS_OPTIONS.refs[0]"
+        fi
+        echo "${org}/${repo}"
+    else
+        die "Expect REPO_OWNER/NAME or CLONEREFS_OPTIONS"
+    fi
+}
+
+is_openshift_CI_rehearse_PR() {
+    [[ "$(get_repo_full_name)" == "openshift/release" ]]
+}
+
 pr_has_label() {
     if [[ -z "${1:-}" ]]; then
         die "usage: pr_has_label <expected label> [<pr details>]"
@@ -18,9 +43,25 @@ pr_has_label() {
     pr_details="${2:-$(get_pr_details)}" || exitstatus="$?"
     if [[ "$exitstatus" != "0" ]]; then
         info "Warning: checking for a label in a non PR context"
-        false
+        return 1
     fi
-    jq '([.labels | .[].name]  // []) | .[]' -r <<< "$pr_details" | grep -qx "${expected_label}"
+
+    if is_openshift_CI_rehearse_PR; then
+        pr_has_label_in_body "${expected_label}" "$pr_details"
+    else
+        jq '([.labels | .[].name]  // []) | .[]' -r <<< "$pr_details" | grep -qx "${expected_label}"
+    fi
+}
+
+pr_has_label_in_body() {
+    if [[ "$#" -ne 2 ]]; then
+        die "usage: pr_has_label_in_body <expected label> <pr details>"
+    fi
+
+    local expected_label="$1"
+    local pr_details="$2"
+
+    [[ "$(jq -r '.body' <<< "$pr_details")" =~ \/label:[[:space:]]*$expected_label ]]
 }
 
 is_in_PR_context() {
@@ -44,7 +85,11 @@ get_branch() {
     # ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
     if [[ -n "${CLONEREFS_OPTIONS}" ]]; then
         local base_ref
-        base_ref="$(jq -r '.refs[0].base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        if is_openshift_CI_rehearse_PR; then
+            base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        else
+            base_ref="$(jq -r '.refs[0].base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        fi
         if [[ "$base_ref" == "null" ]]; then
             die "expect: base_ref in CLONEREFS_OPTIONS.refs[0]"
         fi

--- a/.openshift-ci/drivers/scripts/lib.sh
+++ b/.openshift-ci/drivers/scripts/lib.sh
@@ -82,11 +82,7 @@ is_openshift_CI_rehearse_PR() {
 }
 
 get_branch() {
-    if [[ -n "${PULL_BASE_REF:-}" ]]; then
-        # presubmit, postsubmit and batch runs
-        # (ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables)
-        echo "${PULL_BASE_REF}"
-    elif [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
+    if [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
         # periodics - CLONEREFS_OPTIONS exists in binary_build_commands and images.
         local base_ref
         base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
@@ -94,6 +90,10 @@ get_branch() {
             die "expect: base_ref in CLONEREFS_OPTIONS.refs[0]"
         fi
         echo "${base_ref}"
+    elif [[ -n "${PULL_BASE_REF:-}" ]]; then
+        # presubmit, postsubmit and batch runs
+        # (ref: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables)
+        echo "${PULL_BASE_REF}"
     else
         die "Expect PULL_BASE_REF or CLONEREFS_OPTIONS"
     fi

--- a/.openshift-ci/drivers/scripts/lib.sh
+++ b/.openshift-ci/drivers/scripts/lib.sh
@@ -85,7 +85,11 @@ get_branch() {
     if [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
         # periodics - CLONEREFS_OPTIONS exists in binary_build_commands and images.
         local base_ref
-        base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        if is_openshift_CI_rehearse_PR; then
+            base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        else
+            base_ref="$(jq -r '.refs[0].base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
+        fi
         if [[ "$base_ref" == "null" ]]; then
             die "expect: base_ref in CLONEREFS_OPTIONS.refs[0]"
         fi

--- a/.openshift-ci/drivers/scripts/lib.sh
+++ b/.openshift-ci/drivers/scripts/lib.sh
@@ -89,11 +89,7 @@ get_branch() {
     elif [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
         # periodics - CLONEREFS_OPTIONS exists in binary_build_commands and images.
         local base_ref
-        if is_openshift_CI_rehearse_PR; then
-            base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
-        else
-            base_ref="$(jq -r '.refs[0].base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
-        fi
+        base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
         if [[ "$base_ref" == "null" ]]; then
             die "expect: base_ref in CLONEREFS_OPTIONS.refs[0]"
         fi

--- a/.openshift-ci/drivers/scripts/lib.sh
+++ b/.openshift-ci/drivers/scripts/lib.sh
@@ -82,16 +82,16 @@ is_openshift_CI_rehearse_PR() {
 }
 
 get_branch() {
-    if [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
+    if is_in_PR_context; then
+        pr_details="$(get_pr_details)"
+        head_ref="$(jq -r '.head.ref' <<< "$pr_details")"
+        echo "${head_ref}"
+    elif [[ -n "${CLONEREFS_OPTIONS:-}" ]]; then
         # periodics - CLONEREFS_OPTIONS exists in binary_build_commands and images.
         local base_ref
-        if is_openshift_CI_rehearse_PR; then
-            base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
-        else
-            base_ref="$(jq -r '.refs[0].base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
-        fi
+        base_ref="$(jq -r '.refs[] | select(.repo=="collector") | .base_ref' <<< "${CLONEREFS_OPTIONS}")" || die "invalid CLONEREFS_OPTIONS json"
         if [[ "$base_ref" == "null" ]]; then
-            die "expect: base_ref in CLONEREFS_OPTIONS.refs[0]"
+            die "expect: base_ref in CLONEREFS_OPTIONS.refs[collector]"
         fi
         echo "${base_ref}"
     elif [[ -n "${PULL_BASE_REF:-}" ]]; then

--- a/.openshift-ci/drivers/scripts/pr-checks.sh
+++ b/.openshift-ci/drivers/scripts/pr-checks.sh
@@ -13,9 +13,11 @@ BRANCH="$(get_branch)"
 
 export LEGACY_PROBES
 export NO_CACHE
+export PER_BRANCH_CACHE
 
 LEGACY_PROBES="true"
 NO_CACHE=0
+PER_BRANCH_CACHE=0
 
 if is_in_PR_context; then
     if ! pr_has_label "build-legacy-probes"; then
@@ -24,5 +26,9 @@ if is_in_PR_context; then
 
     if pr_has_label "no-cache"; then
         NO_CACHE=1
+    fi
+
+    if pr_has_label "per-branch-cache"; then
+        PER_BRANCH_CACHE=1
     fi
 fi

--- a/.openshift-ci/drivers/scripts/process-kernels.sh
+++ b/.openshift-ci/drivers/scripts/process-kernels.sh
@@ -1,22 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=SCRIPTDIR/env.sh
+source /scripts/env.sh
+# shellcheck source=SCRIPTDIR/lib.sh
+source /scripts/lib.sh
+
 # Download all cached driver for every version being built
-build_cache() {
+build_cache_from_gcs() {
+    cache_bucket=$1
     for module_version_dir in /kobuild-tmp/versions-src/*; do
         module_version="$(basename "${module_version_dir}")"
         mkdir -p "/kernel-modules/$module_version/"
 
         gsutil -m rsync -r \
-            "gs://collector-modules-osci-public/$module_version/" \
+            "$cache_bucket/$module_version/" \
             "/kernel-modules/$module_version/" || true
     done
 
     /scripts/sanitize-drivers.py
 }
 
+build_cache_from_branch() {
+    branch_name="$(get_branch)"
+    cache="$BRANCH_DRIVER_CACHE/${branch_name}"
+    if is_openshift_CI_rehearse_PR; then
+        cache="${cache}/rehearsal"
+    fi
+    echo "building cache from ${cache}/branch"
+    build_cache_from_gcs "${cache}/branch"
+}
+
+build_cache_from_main() {
+    echo "building cache from $MAIN_DRIVER_CACHE"
+    build_cache_from_gcs "$MAIN_DRIVER_CACHE"
+}
+
 mkdir -p "/kernel-modules"
-((NO_CACHE)) || build_cache
+((NO_CACHE)) || build_cache_from_main
+((PER_BRANCH_CACHE)) && build_cache_from_branch
 
 # Create the tasks file
 KERNELS_FILE=/kernels/all /scripts/get-build-tasks.sh

--- a/.openshift-ci/drivers/scripts/push-drivers.sh
+++ b/.openshift-ci/drivers/scripts/push-drivers.sh
@@ -2,8 +2,12 @@
 
 set -eo pipefail
 
+# shellcheck source=SCRIPTDIR/env.sh
+source /scripts/env.sh
 # shellcheck source=SCRIPTDIR/lib.sh
 source /scripts/lib.sh
+# shellcheck source=SCRIPTDIR/pr-checks.sh
+source /scripts/pr-checks.sh
 
 upload_drivers() {
     local drivers_dir=$1
@@ -17,16 +21,23 @@ upload_drivers() {
 }
 
 GCP_CREDS="$(cat /tmp/secrets/GOOGLE_CREDENTIALS_KERNEL_CACHE)"
-GCP_BASE_BUCKET="gs://collector-modules-osci"
 
 /scripts/setup-gcp-env.sh "${GCP_CREDS}" "${GCP_BASE_BUCKET}"
 
 target="${GCP_BASE_BUCKET}"
 
 if is_in_PR_context; then
-    BRANCH="$(get_branch)"
-    target="gs://stackrox-collector-modules-staging/pr-builds/${BRANCH}/${BUILD_ID}"
+    target_base="${BRANCH_DRIVER_CACHE}/${BRANCH}"
+    if is_openshift_CI_rehearse_PR; then
+        target_base="${target_base}/rehearsal"
+    fi
+    if ((PER_BRANCH_CACHE)); then
+        target="${target_base}/branch"
+    else
+        target="${target_base}/${BUILD_ID}"
+    fi
 fi
+echo "uploading built-drivers to ${target}"
 
 shopt -s nullglob
 shopt -s dotglob


### PR DESCRIPTION
## Description

Support usage of labels on rehearsals in openshift/release using mechanism from stackrox/stackrox.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
