### PR TITLE
Adds RHEL SAP support to integration tests

### DIFF
--- a/.openshift-ci/jobs/integration-tests/envbuilder.sh
+++ b/.openshift-ci/jobs/integration-tests/envbuilder.sh
@@ -269,7 +269,7 @@ setupGCPVM() {
 
     if [[ "$GCP_VM_TYPE" =~ ^ubuntu-os ]]; then
         installDockerOnUbuntuViaGCPSSH "$GCP_VM_USER" "$GCP_VM_NAME" "$GCP_SSH_KEY_FILE"
-    elif test "$GCP_VM_TYPE" = "rhel"; then
+    elif [[ "$GCP_VM_TYPE" =~ ^rhel ]]; then
         installDockerOnRHELViaGCPSSH "$GCP_VM_USER" "$GCP_VM_NAME" "$GCP_IMAGE_FAMILY" "$GCP_SSH_KEY_FILE"
     elif [[ "$GCP_VM_TYPE" =~ "suse" ]]; then
         setupDockerOnSUSEViaGCPSSH "$GCP_VM_USER" "$GCP_VM_NAME" "$GCP_SSH_KEY_FILE"

--- a/.openshift-ci/jobs/integration-tests/envbuilder.sh
+++ b/.openshift-ci/jobs/integration-tests/envbuilder.sh
@@ -241,7 +241,7 @@ setupGCPVM() {
     local GDOCKER_PASS="$1"
     shift
 
-    if [[ ! "$GCP_VM_TYPE" =~ ^(coreos|cos|rhel|suse|suse-sap|ubuntu-os-pro|ubuntu-os|flatcar|fedora-coreos|garden-linux)$ ]]; then
+    if [[ ! "$GCP_VM_TYPE" =~ ^(coreos|cos|rhel|rhel-sap|suse|suse-sap|ubuntu-os-pro|ubuntu-os|flatcar|fedora-coreos|garden-linux)$ ]]; then
         echo "Unsupported GCP_VM_TYPE: $GCP_VM_TYPE"
         exit 1
     fi

--- a/.openshift-ci/jobs/integration-tests/envbuilder.sh
+++ b/.openshift-ci/jobs/integration-tests/envbuilder.sh
@@ -169,9 +169,14 @@ installDockerOnRHELViaGCPSSH() {
     local GCP_SSH_KEY_FILE="$1"
     shift
 
+    local rhel_release="${GCP_IMAGE_FAMILY: -1}"
+    if [[ "$GCP_IMAGE_FAMILY" =~ "sap" ]]; then
+        rhel_release="8"
+    fi
+
     gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo yum install -y yum-utils device-mapper-persistent-data lvm2"
     gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
-    gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo yum-config-manager --setopt=\"docker-ce-stable.baseurl=https://download.docker.com/linux/centos/${GCP_IMAGE_FAMILY: -1}/x86_64/stable\" --save"
+    gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo yum-config-manager --setopt=\"docker-ce-stable.baseurl=https://download.docker.com/linux/centos/${rhel_release}/x86_64/stable\" --save"
     gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo yum install -y docker-ce docker-ce-cli containerd.io"
     gcloud compute ssh --ssh-key-file="${GCP_SSH_KEY_FILE}" "$GCP_VM_USER@$GCP_VM_NAME" --command "sudo systemctl start docker"
 }


### PR DESCRIPTION
## Description

Adjusts the VM builder in  envbuilder.sh to support RHEL SAP VMs. This is associated with the openshift/release PR https://github.com/openshift/release/pull/31801 

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
~- [ ] Added unit tests~
  - [x] Added integration tests
~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Tested with a pj-rehearse on openshift/release in the PR linked above.
