### PR TITLE
Get webhook env directly

### DIFF
--- a/.openshift-ci/slack/notify.sh
+++ b/.openshift-ci/slack/notify.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
-source .openshift-ci/env.sh
+shopt -s nullglob
+for cred in /tmp/secret/**/[A-Z]*; do
+    export "$(basename "$cred")"="$(cat "$cred")"
+done
 
 WEBHOOK_URL=$SLACK_WEBHOOK_ONCALL
 JOB_URL="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/${JOB_NAME}/${BUILD_ID}"


### PR DESCRIPTION
## Description

env.sh doesn't exist, pull webhook env directly from the notify script.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Testing is possible via CI logs.