### PR TITLE
Adds all-integration-tests label support

### DIFF
--- a/.openshift-ci/jobs/integration-tests/env.sh
+++ b/.openshift-ci/jobs/integration-tests/env.sh
@@ -39,17 +39,17 @@ for cred in /tmp/secret/**/[A-Z]*; do
     export "$(basename "$cred")"="$(cat "$cred")"
 done
 
+if pr_has_label "skip-integration-tests"; then
+    echo "Skipping integration tests for ${VM_CONFIG}"
+    exit 0
+fi
+
 # only run all integration tests on master, or when the all-integration-tests
 # label is added. This is checked in this common env script because it allows
 # us to skip pre- and post- steps as well (which source this file)
-if ! pr_has_label "all-integration-tests" && is_in_PR_context; then
+if is_in_PR_context && ! pr_has_label "all-integration-tests"; then
     if [[ ! "$IMAGE_FAMILY" =~ (rhel-(7|8)|ubuntu-) ]]; then
         echo "Not running integration tests for ${VM_CONFIG}"
         exit 0
     fi
-fi
-
-if pr_has_label "skip-integration-tests"; then
-    echo "Skipping integration tests for ${VM_CONFIG}"
-    exit 0
 fi


### PR DESCRIPTION
## Description

Adds support for all-integration-tests label. Runs rhel-7, rhel-8 and all ubuntu tests on PRs by default. If the label is provided, all the other platforms are tested. On master, all platforms are tested.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
