### PR TITLE
Debug build type for PRs

### DIFF
--- a/.openshift-ci/build/build-collector.sh
+++ b/.openshift-ci/build/build-collector.sh
@@ -6,10 +6,8 @@ export CMAKE_BUILD_DIR="$SRC_ROOT_DIR/cmake-build"
 export COLLECTOR_APPEND_CID=true
 
 # For all PRs build in debug mode, unless requested otherwise via labels.
-if is_in_PR_context; then
-    if ! pr_has_label "release-build-type"; then
-        export CMAKE_BUILD_TYPE="Debug"
-    fi
+if is_in_PR_context && ! pr_has_label "release-build-type"; then
+    export CMAKE_BUILD_TYPE="Debug"
 fi
 
 make -C "$SRC_ROOT_DIR/collector" pre-build

--- a/.openshift-ci/build/build-collector.sh
+++ b/.openshift-ci/build/build-collector.sh
@@ -5,6 +5,13 @@ export DISABLE_PROFILING="true"
 export CMAKE_BUILD_DIR="$SRC_ROOT_DIR/cmake-build"
 export COLLECTOR_APPEND_CID=true
 
+# For all PRs build in debug mode, unless requested otherwise via labels.
+if is_in_PR_context; then
+    if ! pr_has_label "release-build-type"; then
+        export CMAKE_BUILD_TYPE="Debug"
+    fi
+fi
+
 make -C "$SRC_ROOT_DIR/collector" pre-build
 "$SRC_ROOT_DIR/builder/build/build-collector.sh"
 make -C "$SRC_ROOT_DIR/collector" post-build


### PR DESCRIPTION
## Description

Build Collector in the debug mode for PRs, which will make testing
and benchmarking easier. Do not switch for main/release branches or if
the release build is requested via labels.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly