### PR TITLE
Slim down the collector-builder image

### DIFF
--- a/.openshift-ci/build/Dockerfile.build_collector
+++ b/.openshift-ci/build/Dockerfile.build_collector
@@ -2,5 +2,6 @@ FROM will_be_replaced_by_openshift_ci
 
 ENV SRC_ROOT_DIR=/go/src/github.com/stackrox/collector
 WORKDIR $SRC_ROOT_DIR
+COPY / $SRC_ROOT_DIR
 
 RUN ./.openshift-ci/build/build-collector.sh


### PR DESCRIPTION
## Description

This is a sister PR to openshift/release#32169. Changes here are meant to enable a lighter builder image to be built.

## Testing Performed

CI run should be enough
