### PR TITLE
Fix support packages

### DIFF
--- a/.openshift-ci/jobs/update-support-packages/run.sh
+++ b/.openshift-ci/jobs/update-support-packages/run.sh
@@ -33,12 +33,6 @@ source "${WORKDIR}/.openshift-ci/jobs/update-support-packages/env.sh"
 
 env
 
-gcloud_command "git clone https://github.com/stackrox/collector.git"
-gcloud_command "cd $SOURCE_ROOT; git checkout $BRANCH"
-
-gcloud_command "sudo apt install zip -y"
-gcloud_command "$SUPPORT_PKG_SRC_ROOT/run-all.sh $SOURCE_ROOT $SUPPORT_PKG_SRC_ROOT"
-
 RELATIVE_PATH="collector/support-packages"
 GCLOUD_BUCKET="gs://sr-roxc"
 PUBLIC_GCLOUD_BUCKET="gs://collector-support-public"
@@ -50,6 +44,15 @@ relative_path="$RELATIVE_PATH"
 if [[ "$BRANCH" != "master" ]]; then
     relative_path="${relative_path}/.test-${JOB_ID}"
 fi
+
+DOWNLOAD_BASE_URL="https://install.stackrox.io"
+BASE_URL="${DOWNLOAD_BASE_URL}/${relative_path}"
+
+gcloud_command "git clone https://github.com/stackrox/collector.git"
+gcloud_command "cd $SOURCE_ROOT; git checkout $BRANCH"
+
+gcloud_command "sudo apt install zip -y"
+gcloud_command "$SUPPORT_PKG_SRC_ROOT/run-all.sh $SOURCE_ROOT $SUPPORT_PKG_SRC_ROOT $BASE_URL"
 
 GCLOUD_TARGET="${GCLOUD_BUCKET}/${relative_path}"
 

--- a/.openshift-ci/jobs/update-support-packages/run.sh
+++ b/.openshift-ci/jobs/update-support-packages/run.sh
@@ -23,7 +23,9 @@ BRANCH="$(get_branch)"
 source "${WORKDIR}/.openshift-ci/drivers/scripts/lib.sh"
 
 if ! pr_has_label "test-support-packages"; then
+    echo "Does not have test-support-packages label"
     if [ "${BRANCH}" != "master" ]; then
+        echo "Not running master branch. Not running update support packages"
         exit 0
     fi
 fi

--- a/kernel-modules/support-packages/run-all.sh
+++ b/kernel-modules/support-packages/run-all.sh
@@ -3,8 +3,11 @@ set -eo pipefail
 
 SOURCE_ROOT=$1
 SUPPORT_PKG_SRC_ROOT=$2
-COLLECTOR_MODULES_BUCKET=${3:-"gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656"}
-LICENSE_FILE=${4:-"${SOURCE_ROOT}/collector/LICENSE-kernel-modules.txt"}
+base_url=$3
+COLLECTOR_MODULES_BUCKET=${4:-"gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656"}
+LICENSE_FILE=${5:-"${SOURCE_ROOT}/collector/LICENSE-kernel-modules.txt"}
+
+export BASE_URL="$base_url"
 
 "${SUPPORT_PKG_SRC_ROOT}/01-collector-to-rox-version-map.py" \
         "${SOURCE_ROOT}/RELEASED_VERSIONS" \


### PR DESCRIPTION
## Description

The link to download support packages is broken. Here is the ticket for that problem https://access.redhat.com/support/cases/#/case/03317606. This fixes that. The problem resulted from the BASE_URL environment variable not being set in VM where the update support packages script is run. This PR sets the value for BASE_URL and passes it to the VM.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Able to download support packages


## Testing Performed

See above.
