### PR TITLE
Integration tests retry

### DIFF
--- a/integration-tests/executor.go
+++ b/integration-tests/executor.go
@@ -140,8 +140,11 @@ func NewExecutor() Executor {
 	return &e
 }
 
+// Execute provided command with retries on error.
 func (e *executor) Exec(args ...string) (string, error) {
-	return e.RunCommand(e.builder.ExecCommand(args...))
+	return retry(func() (string, error) {
+		return e.RunCommand(e.builder.ExecCommand(args...))
+	})
 }
 
 func (e *executor) ExecRetry(args ...string) (res string, err error) {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -528,9 +528,10 @@ func (s *RepeatedNetworkFlowTestSuite) TestRepeatedNetworkFlow() {
 func (s *IntegrationTestSuiteBase) launchContainer(args ...string) (string, error) {
 	cmd := []string{"docker", "run", "-d", "--name"}
 	cmd = append(cmd, args...)
-	output, err := s.executor.Exec(cmd...)
-	outLines := strings.Split(output, "\n")
-	return outLines[len(outLines)-1], err
+
+	return retry(func() (string, error) {
+		return s.executor.Exec(cmd...)
+	})
 }
 
 func (s *IntegrationTestSuiteBase) waitForContainerToExit(containerName, containerID string, tickSeconds time.Duration) (bool, error) {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -529,9 +529,12 @@ func (s *IntegrationTestSuiteBase) launchContainer(args ...string) (string, erro
 	cmd := []string{"docker", "run", "-d", "--name"}
 	cmd = append(cmd, args...)
 
-	return retry(func() (string, error) {
+	output, err := retry(func() (string, error) {
 		return s.executor.Exec(cmd...)
 	})
+
+	outLines := strings.Split(output, "\n")
+	return outLines[len(outLines)-1], err
 }
 
 func (s *IntegrationTestSuiteBase) waitForContainerToExit(containerName, containerID string, tickSeconds time.Duration) (bool, error) {

--- a/integration-tests/retry.go
+++ b/integration-tests/retry.go
@@ -1,0 +1,26 @@
+package integrationtests
+
+import (
+	"time"
+)
+
+const (
+	max_retries     = 5
+	retry_wait_time = 3 * time.Second
+)
+
+type retryable = func() (string, error)
+
+// Simple retry in loop for commands produce only one string output and error
+func retry(f retryable) (output string, err error) {
+	for i := 0; i < max_retries; i++ {
+		output, err = f()
+		if err == nil {
+			return output, nil
+		} else {
+			time.Sleep(retry_wait_time)
+		}
+	}
+
+	return output, err
+}

--- a/integration-tests/retry.go
+++ b/integration-tests/retry.go
@@ -17,7 +17,7 @@ func retry(f retryable) (output string, err error) {
 		output, err = f()
 		if err == nil {
 			return output, nil
-		} else {
+		} else if i != max_retries - 1 {
 			time.Sleep(retry_wait_time)
 		}
 	}


### PR DESCRIPTION
## Description

Add a simple retry function, apply it to the command executor and container launcher. The implementation has few quirks:

* It doesn't use routines, but in case of integration tests it doesn't matter if we would block.

* It has two return arguments with fixed type: string and error. The latter one is required for retry logic, the former seem to be rather limited choice. The reason is that without returning any data except an error the scope of the payload function would have to be much bigger (as nothing has to be returned). At the moment it looks like we mostly return strings anyway, so it feels like a good compromise between full-fledged solution and a quick hack.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests

## Testing Performed

TODO