### PR TITLE
Simplifies get_secret_file implementation

### DIFF
--- a/.openshift-ci/scripts/lib.sh
+++ b/.openshift-ci/scripts/lib.sh
@@ -187,7 +187,7 @@ get_secret_file() {
     local secret_name="$1"
 
     for cred in /tmp/secrets/**/[A-Z]*; do
-        if [[ "$cred" =~ "${secret_name}"\$ ]]; then
+        if [[ "$(basename "$cred")" == "${secret_name}" ]]; then
             echo "${cred}"
             return
         fi


### PR DESCRIPTION
## Description

Fixes an issue in secret name identification when attempting to retrieve the secret file from /tmp/secret. This fix simplifies the process a little.  See openshift/release#32025 for the tests/checks


## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
 ~- [ ] Added unit tests~
 ~- [ ] Added integration tests~
 ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Relying primarily on OSCI
