### PR TITLE
Makes push-drivers use gcloud-init script

### DIFF
--- a/.openshift-ci/drivers/scripts/push-drivers.sh
+++ b/.openshift-ci/drivers/scripts/push-drivers.sh
@@ -16,10 +16,10 @@ upload_drivers() {
     done
 }
 
-GCP_CREDS="$(get_secret_content GOOGLE_CREDENTIALS_KERNEL_CACHE)"
+GCP_CREDS="$(get_secret_file GOOGLE_CREDENTIALS_KERNEL_CACHE)"
 GCP_BASE_BUCKET="gs://collector-modules-osci"
 
-/scripts/setup-gcp-env.sh "${GCP_CREDS}" "${GCP_BASE_BUCKET}"
+/scripts/gcloud-init.sh "${GCP_CREDS}" "${GCP_BASE_BUCKET}"
 
 target="${GCP_BASE_BUCKET}"
 

--- a/.openshift-ci/scripts/gcloud-init.sh
+++ b/.openshift-ci/scripts/gcloud-init.sh
@@ -5,6 +5,9 @@ CI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 # shellcheck source=SCRIPTDIR/lib.sh
 source "${CI_ROOT}/scripts/lib.sh"
 
+CREDS_FILE="${1:-$(get_secret_file GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT)}"
+TEST_BUCKET="${2:-gs://collector-build-cache}"
+
 which gcloud
 which gsutil
 gsutil ver
@@ -12,11 +15,11 @@ gsutil ver -l | grep crcmod
 gcloud version
 cat ~/.boto 2> /dev/null || true
 echo '[Credentials]' > ~/.boto
-echo "gs_service_key_file = $(get_secret_file GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT)" >> ~/.boto
-gcloud auth activate-service-account --key-file "$(get_secret_file GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT)"
+echo "gs_service_key_file = ${CREDS_FILE}" >> ~/.boto
+gcloud auth activate-service-account --key-file "${CREDS_FILE}"
 gcloud config set project stackrox-ci
 gcloud config set compute/region us-central1
 gcloud config set compute/zone us-central1-a
 gcloud config set core/disable_prompts True
 gcloud auth list
-gsutil ls "gs://collector-build-cache" || echo "ERROR: Could not ls bucket"
+gsutil ls "${TEST_BUCKET}" || echo "ERROR: Could not ls ${TEST_BUCKET}"


### PR DESCRIPTION
## Description

The soon to be deleted setup-gcp-env script from circleci is now replaced by the gcloud-init script in .openshift-ci. This script is now more flexible to different credentials as required by the caller. 