### PR TITLE
Jv rox 12845 integration tests for connscraper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ ci-integration-tests: integration-tests-repeat-network \
 					  integration-tests-process-network \
 					  integration-tests-missing-proc-scrape \
 					  integration-tests-image-label-json \
+					  integations-tests-connscraper \
 					  integration-tests-report
 
 .PHONY: ci-benchmarks

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,11 @@ integration-tests-image-label-json:
 	make -C integration-tests image-label-json ||\
 		( .openshift-ci/slack/notify-if-needed.sh "image-label-json" $$? )
 
+.PHONY: integration-tests-connscraper
+integration-tests-connscraper:
+	make -C integration-tests connscraper ||\
+		( .openshift-ci/slack/notify-if-needed.sh "connscraper" $$? )
+
 .PHONY: integration-tests-report
 integration-tests-report:
 	make -C integration-tests report

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ ci-integration-tests: integration-tests-repeat-network \
 					  integration-tests-process-network \
 					  integration-tests-missing-proc-scrape \
 					  integration-tests-image-label-json \
-					  integations-tests-connscraper \
+					  integration-tests-connscraper \
 					  integration-tests-report
 
 .PHONY: ci-benchmarks

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -61,6 +61,13 @@ repeat-network: docker-clean
 	go test -timeout 90m -count=1 -v \
 	  -run TestRepeatedNetworkFlow 2>&1 | tee -a integration-test.log
 
+.PHONY: connscraper
+connscraper: docker-clean
+	go version
+	set -o pipefail ; \
+	go test -timeout 90m -count=1 -v \
+	  -run TestConnScraper 2>&1 | tee -a integration-test.log
+
 .PHONY: report
 report:
 	go get -u github.com/jstemmer/go-junit-report

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-129-g8e0c43c17a",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-239-g0e734983a3-dirty",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,
@@ -86,7 +86,7 @@ func (c *collectorManager) Setup() error {
 		}
 
 		// remove previous db file
-		if _, err := c.executor.Exec("rm", "-fv", c.DBPath); err != nil {
+		if _, err := c.executor.Exec("sudo", "rm", "-fv", c.DBPath); err != nil {
 			return err
 		}
 	}

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.70.x-468-g5d733366eb",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-124-g11b8a742b7",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-127-g4740f123bf",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-129-g8e0c43c17a",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-239-g0e734983a3-dirty",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-129-g8e0c43c17a",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-124-g11b8a742b7",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-126-g9cd70f6bf6-dirty",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -86,7 +86,9 @@ func (c *collectorManager) Setup() error {
 		}
 
 		// remove previous db file
-		c.executor.Exec("rm", "-fv", c.DBPath)
+		if _, err := c.executor.Exec("rm", "-fv", c.DBPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-126-g9cd70f6bf6-dirty",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-127-g4740f123bf",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -1,0 +1,26 @@
+package integrationtests
+
+import (
+	"strings"
+	"fmt"
+)
+
+type EndpointInfo struct {
+	Protocol string
+	ListenAddress string
+	CloseTimestamp string
+}
+
+func NewEndpointInfo(line string) (*EndpointInfo, error) {
+	parts := strings.Split(line, "|")
+
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid gRPC string for endpoint info: %s", line)
+	}
+
+	return &EndpointInfo {
+		Protocol: parts[1],
+		ListenAddress: parts[2],
+		CloseTimestamp: parts[3],
+	}, nil
+}

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -551,7 +551,7 @@ func (s *RepeatedNetworkFlowTestSuite) TestRepeatedNetworkFlow() {
 // Launches nginx container
 // Launches gRPC server in insecure mode
 // Launches collector
-// Note it is important to launch the nginx container before collector, which is the opposite of 
+// Note it is important to launch the nginx container before collector, which is the opposite of
 // other tests. The purpose is that we want ConnScraper to see the nginx endpoint and we do not want
 // NetworkSignalHandler to see the nginx endpoint.
 func (s *ConnScraperTestSuite) SetupSuite() {
@@ -613,22 +613,6 @@ func (s *ConnScraperTestSuite) TestConnScraper() {
 		// If scraping is off we expect not to find the nginx endpoint and we should get an error
 		s.Require().Error(err)
 	}
-
-	//val, err := s.Get(s.serverContainer, endpointBucket)
-	//actualValues := strings.Split(string(val), "|")
-	//if (!s.turnOffScrape) {
-	//	// If scraping is on we expect to find the nginx endpoint
-	//	s.Require().NoError(err)
-	//	assert.Equal(s.T(), len(actualValues), 4)
-	//	assert.Equal(s.T(), actualValues[0], "EndpointInfo: SOCKET_FAMILY_IPV4")
-	//	assert.Equal(s.T(), actualValues[1], "L4_PROTOCOL_TCP")
-	//	// Formating issues prevented me from having a test for the address here
-	//	assert.Equal(s.T(), actualValues[3], "(timestamp: nil Timestamp)\n")
-
-	//} else {
-	//	// If scraping is off we expect not to find the nginx endpoint and we should get an error
-	//	s.Require().Error(err)
-	//}
 }
 
 func (s *IntegrationTestSuiteBase) launchContainer(args ...string) (string, error) {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -617,6 +617,7 @@ func (s *ConnScraperTestSuite) TestConnScraper() {
 		match, _ := regexp.MatchString(pattern, logLine)
 		if match {
 			found = true
+			break
 		}
 	}
 	assert.Equal(s.T(), s.expectedResult, found)


### PR DESCRIPTION
## Description

We need integration tests for ConnScraper as we are about to modify it for the "Processes listening on ports" MVP. ConnScraper is able to find open endpoints when Collector starts up (and thus knows about endpoints that were opened before Collector started up), whereas NetworkSignalHandler only knows about endpoints that open after Collector starts up. To test ConnScraper we start an nginx container before launching Collector, and test that we can find the nginx endpoint when scraping is on and that we cannot find the nginx endpoint when scraping is off.

Related to this PR is a change for the mock grpc server. See https://github.com/stackrox/stackrox/pull/3215

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Performed integration tests locally

**Automated testing**
  - [x] Added integration tests

## Testing Performed

Go into the stackrox repo root directory and run the following commands

Checkout the branch of the stackrox PR listed above
make mock-grpc-server-build
cp bin/linux_amd64/mock-grpc-server integration-tests/mock-grpc-server/image/bin/ // You may need to adjust the path at linux_amd64
make mock-grpc-server-image

Go int the collector repo root directory
make
make integration-tests-connscraper