### PR TITLE
Add s390x support--allow socketcall and inserting kernel fix

### DIFF
--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -111,6 +111,7 @@ int InsertModule(int fd, const std::unordered_map<std::string, std::string>& arg
   fstat(fd, &st);
   size_t image_size = st.st_size;
   void* image = malloc(image_size);
+  lseek(fd, 0, SEEK_SET);
   read(fd, image, image_size);
   int res = init_module(image, image_size, args_str.c_str());
   free(image);

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -110,7 +110,7 @@ int InsertModule(int fd, const std::unordered_map<std::string, std::string>& arg
   struct stat st;
   fstat(fd, &st);
   size_t image_size = st.st_size;
-  void *image = malloc(image_size);
+  void* image = malloc(image_size);
   read(fd, image, image_size);
   int res = init_module(image, image_size, args_str.c_str());
   free(image);

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -96,7 +96,7 @@ static void AbortHandler(int signum) {
   raise(signum);
 }
 
-static int __read(int fd, void* buf, int buflen) {
+static int read_module(int fd, void* buf, int buflen) {
   unsigned char* p = static_cast<unsigned char*>(buf);
   int n, i = 0;
   while (i < buflen) {
@@ -141,7 +141,7 @@ int InsertModule(int fd, const std::unordered_map<std::string, std::string>& arg
       return -1;
   }
   lseek(fd, 0, SEEK_SET);
-  size_t read_image_size = __read(fd, image, image_size);
+  size_t read_image_size = read_module(fd, image, image_size);
   if (read_image_size != image_size) {
       CLOG(ERROR) << "Could not read kernel module: " << StrError() << ".  Mismatch with number of bytes read and kernel module size.";
       errno = EINVAL;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -60,6 +60,9 @@ class CollectorConfig {
       "setuid",
       "shutdown",
       "socket",
+#ifdef __s390x__
+      "syscall",
+#endif
       "vfork",
   };
   static constexpr char kChisel[] = R"(


### PR DESCRIPTION
## Description

On s390x we are relegated to socketcall wrapping various system calls until we have glibc support--[details](https://sourceware.org/pipermail/libc-alpha/2022-September/142108.html).  We will not filter syscall type so we can receive these syscalls.

Also included patch to read kernel module into memory and insert from there instead of finit_module.

## Testing Performed

Ran unit and integration tests on s390x and x86

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
