### PR TITLE
Jv rox 12855 add pid to endpoint information in connscraper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ endif
 collector: builder
 	make -C collector container/bin/collector
 
+.PHONY: connscrape
+connscrape:
+	make -C collector connscrape ||\
+		( .openshift-ci/slack/notify-if-needed.sh "connscrape" $$? )
+
 .PHONY: unittest
 unittest:
 	make -C collector unittest ||\

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -39,6 +39,7 @@ post-build:
 container/bin/collector: 
 	$(MAKE) pre-build
 	$(MAKE) cmake-build/collector 
+	$(MAKE) post-build
 
 .PHONY: build-connscrape-test
 build-connscrape-test:
@@ -50,7 +51,6 @@ connscrape: build-connscrape-test
 		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		connscrape-test "$(SRC_MOUNT_DIR)/collector/connscrape-test/connscrape-test.sh"
-	$(MAKE) post-build
 
 unittest:
 	docker rm -fv collector_unittest || true

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -39,6 +39,17 @@ post-build:
 container/bin/collector: 
 	$(MAKE) pre-build
 	$(MAKE) cmake-build/collector 
+
+.PHONY: build-connscrape-test
+build-connscrape-test:
+	docker build -f $(CURDIR)/connscrape-test/Dockerfile -t connscrape-test $(CURDIR)/connscrape-test
+
+connscrape: build-connscrape-test
+	docker rm -fv collector_connscrape || true
+	docker run --rm --name collector_connscrape \
+		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
+		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
+		connscrape-test "$(SRC_MOUNT_DIR)/collector/connscrape-test/connscrape-test.sh"
 	$(MAKE) post-build
 
 unittest:

--- a/collector/connscrape-test/Dockerfile
+++ b/collector/connscrape-test/Dockerfile
@@ -1,0 +1,45 @@
+FROM quay.io/centos/centos:stream8
+
+USER root
+
+RUN dnf -y update \
+    && dnf -y install --nobest \
+        autoconf \
+        automake \
+        binutils-devel \
+        bison \
+        ca-certificates \
+        clang \
+        cmake \
+        cracklib-dicts \
+        diffutils \
+        elfutils-libelf-devel \
+        file \
+        flex \
+        gcc \
+        gcc-c++ \
+        gdb \
+        gettext \
+        git \
+        glibc-devel \
+        libasan \
+        libcap-ng-devel \
+        libcurl-devel \
+        libtool \
+        libuuid-devel \
+        make \
+        nc \
+        openssh-server \
+        openssl-devel \
+        patchutils \
+        passwd \
+        pkgconfig \
+        python2 \
+        rsync \
+        tar \
+        unzip \
+        valgrind \
+        wget \
+        which \
+    && dnf clean all
+

--- a/collector/connscrape-test/connscrape-test.sh
+++ b/collector/connscrape-test/connscrape-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+nohup nc -l &
+echo "Pid of nc command is $!"
+/tmp/collector/cmake-build/collector/connscrape

--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -32,7 +32,7 @@ using namespace collector;
 
 namespace {
 
-BoolEnvVar scrape_endpoints("SCRAPE_ENDPOINTS", false);
+BoolEnvVar scrape_endpoints("SCRAPE_ENDPOINTS", true);
 
 }  // namespace
 
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     std::cout << std::endl
               << "Endpoints:" << std::endl;
     for (const auto& ep : endpoints) {
-      std::cout << " " << ep << std::endl;
+      std::cout << " " << ep << " " << ep.pid() << std::endl;
     }
   }
 

--- a/collector/lib/ConnScraper.cpp
+++ b/collector/lib/ConnScraper.cpp
@@ -209,6 +209,7 @@ struct ConnInfo {
 struct EndpointInfo {
   Endpoint endpoint;
   L4Proto l4proto;
+  int pid;
 };
 
 // ParseEndpoint parses an endpoint listed in the `net/tcp[6]` file.
@@ -285,7 +286,7 @@ bool LocalIsServer(const Endpoint& local, const Endpoint& remote, const Unordere
 }
 
 // ReadConnectionsFromFile reads all connections from a `net/tcp[6]` file and stores them by inode in the given map.
-bool ReadConnectionsFromFile(Address::Family family, L4Proto l4proto, std::FILE* f,
+bool ReadConnectionsFromFile(Address::Family family, L4Proto l4proto, int pid, std::FILE* f,
                              UnorderedMap<ino_t, ConnInfo>* connections, UnorderedMap<ino_t, EndpointInfo>* listen_endpoints) {
   char line[512];
 
@@ -302,6 +303,7 @@ bool ReadConnectionsFromFile(Address::Family family, L4Proto l4proto, std::FILE*
         auto& endpoint_info = (*listen_endpoints)[data.inode];
         endpoint_info.endpoint = data.local;
         endpoint_info.l4proto = l4proto;
+        endpoint_info.pid = pid;
       }
       continue;
     }
@@ -324,13 +326,13 @@ bool ReadConnectionsFromFile(Address::Family family, L4Proto l4proto, std::FILE*
 
 // GetConnections reads all active connections (inode -> connection info mapping) for a given network NS, addressed by
 // the dir FD for a proc entry of a process in that network namespace.
-bool GetConnections(int dirfd, UnorderedMap<ino_t, ConnInfo>* connections, UnorderedMap<ino_t, EndpointInfo>* listen_endpoints) {
+bool GetConnections(int dirfd, int pid, UnorderedMap<ino_t, ConnInfo>* connections, UnorderedMap<ino_t, EndpointInfo>* listen_endpoints) {
   bool success = true;
   {
     FDHandle net_tcp_fd = openat(dirfd, "net/tcp", O_RDONLY);
     if (net_tcp_fd.valid()) {
       FileHandle net_tcp(std::move(net_tcp_fd), "r");
-      success = ReadConnectionsFromFile(Address::Family::IPV4, L4Proto::TCP, net_tcp, connections, listen_endpoints) && success;
+      success = ReadConnectionsFromFile(Address::Family::IPV4, L4Proto::TCP, pid, net_tcp, connections, listen_endpoints) && success;
     } else {
       success = false;  // there should always be a net/tcp file
     }
@@ -340,7 +342,7 @@ bool GetConnections(int dirfd, UnorderedMap<ino_t, ConnInfo>* connections, Unord
     FDHandle net_tcp6_fd = openat(dirfd, "net/tcp6", O_RDONLY);
     if (net_tcp6_fd.valid()) {
       FileHandle net_tcp6(std::move(net_tcp6_fd), "r");
-      success = ReadConnectionsFromFile(Address::Family::IPV6, L4Proto::TCP, net_tcp6, connections, listen_endpoints) && success;
+      success = ReadConnectionsFromFile(Address::Family::IPV6, L4Proto::TCP, pid, net_tcp6, connections, listen_endpoints) && success;
     } else {
       success = false;
     }
@@ -377,7 +379,8 @@ void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const C
         } else if (listen_endpoints) {
           if (const auto* ep = Lookup(ns_network_data->listen_endpoints, socket_inode)) {
             if (!IsRelevantEndpoint(ep->endpoint)) continue;
-            listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto);
+            listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto, ep->pid);
+              //listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto);
           }
         }
       }
@@ -400,6 +403,7 @@ bool ReadContainerConnections(const char* proc_path, std::vector<Connection>* co
   // Read all the information from proc.
   while (auto curr = procdir.read()) {
     if (!std::isdigit(curr->d_name[0])) continue;  // only look for <pid> entries
+    int pid = stoi(curr->d_name);
 
     FDHandle dirfd = procdir.openat(curr->d_name, O_RDONLY);
     if (!dirfd.valid()) {
@@ -430,7 +434,7 @@ bool ReadContainerConnections(const char* proc_path, std::vector<Connection>* co
       auto emplace_res = conns_by_ns.emplace(netns_inode, NSNetworkData());
       if (emplace_res.second) {
         auto& ns_network_data = emplace_res.first->second;
-        if (!GetConnections(dirfd, &ns_network_data.connections, listen_endpoints ? &ns_network_data.listen_endpoints : nullptr)) {
+        if (!GetConnections(dirfd, pid, &ns_network_data.connections, listen_endpoints ? &ns_network_data.listen_endpoints : nullptr)) {
           // If there was an error reading connections, that could be due to a number of reasons.
           // We need to differentiate persistent errors (e.g., expected net/tcp6 file not found)
           // from spurious/race condition errors caused by the process disappearing while reading

--- a/collector/lib/ConnScraper.cpp
+++ b/collector/lib/ConnScraper.cpp
@@ -380,7 +380,6 @@ void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const C
           if (const auto* ep = Lookup(ns_network_data->listen_endpoints, socket_inode)) {
             if (!IsRelevantEndpoint(ep->endpoint)) continue;
             listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto, ep->pid);
-              //listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto);
           }
         }
       }

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -141,10 +141,6 @@ class ConnectionTracker {
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
 
- private:
-  // NormalizeConnection transforms a connection into a normalized form.
-  Connection NormalizeConnectionNoLock(const Connection& conn) const;
-
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
   // than the stored one.
   void EmplaceOrUpdateNoLock(const Connection& conn, ConnStatus status);
@@ -152,6 +148,10 @@ class ConnectionTracker {
   // Emplace a listen endpoint into the state ContainerEndpointMap, or update its timestamp if the supplied timestamp is more
   // recent than the stored one.
   void EmplaceOrUpdateNoLock(const ContainerEndpoint& ep, ConnStatus status);
+
+ private:
+  // NormalizeConnection transforms a connection into a normalized form.
+  Connection NormalizeConnectionNoLock(const Connection& conn) const;
 
   IPNet NormalizeAddressNoLock(const Address& address) const;
 

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -347,12 +347,13 @@ size_t Hash(const L4ProtoPortPair& pp);
 
 class ContainerEndpoint {
  public:
-  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto)
-      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto) {}
+  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, int pid = -1)
+      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto), pid_(pid) {}
 
   const std::string& container() const { return container_; }
   const Endpoint& endpoint() const { return endpoint_; }
   const L4Proto l4proto() const { return l4proto_; }
+  const int pid() const { return pid_; }
 
   bool operator==(const ContainerEndpoint& other) const {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_;
@@ -368,6 +369,7 @@ class ContainerEndpoint {
   std::string container_;
   Endpoint endpoint_;
   L4Proto l4proto_;
+  int pid_;
 };
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint);

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -356,7 +356,8 @@ class ContainerEndpoint {
   const int pid() const { return pid_; }
 
   bool operator==(const ContainerEndpoint& other) const {
-    return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_;
+    return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
+           pid_ == other.pid_;
   }
 
   bool operator!=(const ContainerEndpoint& other) const {

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1246,6 +1246,115 @@ TEST(ConnTrackerTest, TestComputeDeltaAfterglowBenchmark2) {
   std::cout << "Time taken by ComputeDeltaAfterglow= " << dur.count() << " ms\n";
 }
 
+TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointDifferentPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, oldConnStatus);
+  connectionTracker.EmplaceOrUpdateNoLock(ce2, newConnStatus);
+
+  ContainerEndpointMap expected_state = {{ce1, oldConnStatus}, {ce2, newConnStatus}};
+  ContainerEndpointMap observed_state = connectionTracker.FetchEndpointState(false, false);
+  EXPECT_THAT(observed_state, expected_state);
+
+  ContainerEndpoint observed_endpoint = observed_state.find(ce2)->first;
+  int observedPid = observed_endpoint.pid();
+
+  EXPECT_THAT(observedPid, 3);
+}
+
+TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointAndPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, oldConnStatus);
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, newConnStatus);
+
+  ContainerEndpointMap expected_state = {{ce1, newConnStatus}};
+  ContainerEndpointMap observed_state = connectionTracker.FetchEndpointState(false, false);
+  EXPECT_THAT(observed_state, expected_state);
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointDifferentPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce2, newConnStatus}};
+
+  ContainerEndpointMap expected_delta = {{ce1, ConnStatus(connection_time1, false)}, {ce2, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, expected_delta);
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointSamePids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce1, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, IsEmpty());
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointDifferentProtocols) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::UDP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce2, newConnStatus}};
+
+  ContainerEndpointMap expected_delta = {{ce1, ConnStatus(connection_time1, false)}, {ce2, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, expected_delta);
+}
+
 }  // namespace
 
 }  // namespace collector


### PR DESCRIPTION
## Description

Connscraper adds the PID of a processes that opened an endpoint to the endpoint. This also adds a make target, connscrape, which runs connscrape in a docker container, which is also running netcat.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly
- [x] Ran connscrape make target

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

See checklist.
