### PR TITLE
Build a collector image using the CPaaS drivers

### DIFF
--- a/.openshift-ci/build/Dockerfile.cpaas
+++ b/.openshift-ci/build/Dockerfile.cpaas
@@ -1,0 +1,17 @@
+FROM quay.io/stackrox-io/apollo-ci:collector-0.3.44-1-gb00ffc52af as driver-cache
+
+COPY /kernel-modules/MODULE_VERSION /MODULE_VERSION
+COPY /.openshift-ci/build/build-driver-cache.sh /scripts/build-driver-cache.sh
+
+# Pull the CPaaS built drivers from GCP
+RUN export MODULE_VERSION="$(cat /MODULE_VERSION)" && \
+    mkdir -p "/kernel-modules/${MODULE_VERSION}" && \
+    gsutil -m rsync -r \
+        "gs://collector-modules-osci-public/cpaas//$MODULE_VERSION/" \
+        "/kernel-modules/$MODULE_VERSION/" || true
+
+RUN /scripts/build-driver-cache.sh
+
+FROM quay.io/stackrox-io/collector:3.11.0-slim
+
+COPY --from=driver-cache /driver-cache /kernel-modules

--- a/.openshift-ci/jobs/integration-tests/env.sh
+++ b/.openshift-ci/jobs/integration-tests/env.sh
@@ -31,6 +31,8 @@ fi
 IMAGE_TAG="$(make tag)"
 
 export COLLECTOR_IMAGE
+CPAAS_TEST=${CPAAS_TEST:-0}
+
 if ((CPAAS_TEST)); then
      COLLECTOR_IMAGE="${COLLECTOR_REPO}:cpaas-${IMAGE_TAG}"
 else

--- a/.openshift-ci/jobs/integration-tests/env.sh
+++ b/.openshift-ci/jobs/integration-tests/env.sh
@@ -30,7 +30,12 @@ fi
 
 IMAGE_TAG="$(make tag)"
 
-export COLLECTOR_IMAGE="${COLLECTOR_REPO}:${IMAGE_TAG}"
+export COLLECTOR_IMAGE
+if ((CPAAS_TEST)); then
+     COLLECTOR_IMAGE="${COLLECTOR_REPO}:cpaas-${IMAGE_TAG}"
+else
+     COLLECTOR_IMAGE="${COLLECTOR_REPO}:${IMAGE_TAG}"
+fi
 
 import_creds
 

--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exo pipefail
+set -eo pipefail
 
 CI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 # shellcheck source=SCRIPTDIR/../../scripts/lib.sh

--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -49,6 +49,11 @@ push_images() {
     )
     push_images_to_repos image_repos full_tags collector "${COLLECTOR_FULL}"
 
+    if ((CPAAS_TEST)); then
+        # All done
+        return 0
+    fi
+
     # shellcheck disable=SC2034
     base_tags=(
         "${collector_version}-slim"
@@ -60,6 +65,10 @@ push_images() {
 cd "$PROJECT_DIR"
 
 collector_version="$(make tag)"
+
+if ((CPAAS_TEST)); then
+    collector_version="cpaas-${collector_version}"
+fi
 
 export PUBLIC_REPO=quay.io/stackrox-io
 export QUAY_REPO=quay.io/rhacs-eng
@@ -75,4 +84,10 @@ image_repos=(
 )
 
 push_images
+
+if ((CPAAS_TEST)); then
+    # All done
+    exit 0
+fi
+
 push_builder_image

--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -exo pipefail
 
 CI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 # shellcheck source=SCRIPTDIR/../../scripts/lib.sh

--- a/.openshift-ci/jobs/push-images/push-images.sh
+++ b/.openshift-ci/jobs/push-images/push-images.sh
@@ -65,6 +65,7 @@ push_images() {
 cd "$PROJECT_DIR"
 
 collector_version="$(make tag)"
+CPAAS_TEST=${CPAAS_TEST:-0}
 
 if ((CPAAS_TEST)); then
     collector_version="cpaas-${collector_version}"


### PR DESCRIPTION
## Description

Make some minor changes in order to allow for integration tests to run with CPaaS built drivers. In broad strokes the changes are:
- Create a collector image that holds the CPaaS built drivers.
- Adjust the image used for testing depending on whether we want to test upstream drivers or CPaaS drivers.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Green CI should be enough.
- [x] New jobs rehearsed on openshift/release#32765