### PR TITLE
disable ebpf on s390x

### DIFF
--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -112,7 +112,11 @@ struct KernelVersion {
     if (kernel < 4 || (kernel == 4 && major < 14)) {
       return false;
     }
+#ifdef __s390x__
+    return false;
+#else
     return true;
+#endif
   }
 
   // Whether or not the kernel has secure_boot option present in boot_params.

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -109,12 +109,14 @@ struct KernelVersion {
   // Whether or not the kernel has built-in eBPF support
   // Anything before 4.14 doesn't have support, anything newer does.
   bool HasEBPFSupport() const {
+#ifdef __s390x__
+    // TODO: only kernel module will ship with s390x until socketcall is handled in ebpf probe.
+    //       back out github.com/stackrox/collector/pull/855 when ebpf is ready to ship.
+    return false;
+#else
     if (kernel < 4 || (kernel == 4 && major < 14)) {
       return false;
     }
-#ifdef __s390x__
-    return false;
-#else
     return true;
 #endif
   }

--- a/collector/test/HostInfoTest.cpp
+++ b/collector/test/HostInfoTest.cpp
@@ -120,7 +120,11 @@ TEST(KernelVersionTest, TestVersionStringPopulated) {
 
 TEST(KernelVersionTest, TestHasEBPFSupport) {
   KernelVersion new_kernel("5.10.0", "");
+#ifdef __s390x__
+  EXPECT_EQ(false, new_kernel.HasEBPFSupport());
+#else
   EXPECT_EQ(true, new_kernel.HasEBPFSupport());
+#endif
 
   KernelVersion old_kernel("2.6.0", "");
   EXPECT_EQ(false, old_kernel.HasEBPFSupport());
@@ -129,7 +133,11 @@ TEST(KernelVersionTest, TestHasEBPFSupport) {
   EXPECT_EQ(false, old_four_kernel.HasEBPFSupport());
 
   KernelVersion new_four_kernel("4.20.0", "");
+#ifdef __s390x__
+  EXPECT_EQ(false, new_four_kernel.HasEBPFSupport());
+#else
   EXPECT_EQ(true, new_four_kernel.HasEBPFSupport());
+#endif
 }
 
 TEST(HostInfoTest, TestIsRHEL76) {
@@ -153,7 +161,11 @@ TEST(HostInfoTest, TestHasEBPFSupport) {
   EXPECT_FALSE(hasEBPFSupport(kernel, os_id));
 
   kernel = KernelVersion("5.10.0", "");
+#ifdef __s390x__
+  EXPECT_FALSE(hasEBPFSupport(kernel, os_id));
+#else
   EXPECT_TRUE(hasEBPFSupport(kernel, os_id));
+#endif
 }
 
 TEST(HostInfoTest, TestHostInfoGetDistro) {


### PR DESCRIPTION
## Description

Disable ebpf probe on s390x until its ready for production use.

## Testing Performed

ran unit and integration tests

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
