### PR TITLE
Add an extra layer for kernels to the collector full image

### DIFF
--- a/kernel-modules/container/Dockerfile
+++ b/kernel-modules/container/Dockerfile
@@ -7,7 +7,7 @@ ARG max_layer_size=xxx
 ARG max_layer_depth=xxx
 
 # Increase the value in this check if additional hardcoded layers are added below.
-RUN test "${max_layer_depth}" -le 8
+RUN test "${max_layer_depth}" -le 9
 
 COPY kernel-modules/ /kernel-modules
 COPY partition-probes.py /
@@ -42,3 +42,6 @@ COPY --from=kernel-modules /kernel-modules/6 /kernel-modules/
 
 FROM probe-layer-7 AS probe-layer-8
 COPY --from=kernel-modules /kernel-modules/7 /kernel-modules/
+
+FROM probe-layer-8 AS probe-layer-9
+COPY --from=kernel-modules /kernel-modules/8 /kernel-modules/


### PR DESCRIPTION
## Description

Adds an extra layer for the kernel drivers in the collector full image.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
