### PR TITLE
Removes the CircleCI pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,6 @@ repos:
         args:
           - -d
       - id: shellcheck
-      
-  - repo: git@github.com:zahorniak/pre-commit-circleci.git
-    rev: "v0.4"
-    hooks:
-      - id: circleci_validate
-        args:
-          - --org-slug gh/stackrox
 
   - repo: git@github.com:pycqa/flake8.git
     rev: "4.0.1"

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,6 @@ $(eval $(call linter,flake8))
 $(eval $(call linter,clang-format))
 $(eval $(call linter,shellcheck))
 $(eval $(call linter,shfmt))
-$(eval $(call linter,circleci_validate))
 
 .PHONY: linters
 linters:


### PR DESCRIPTION
## Description

This is no longer needed, since we stopped using CircleCI.

## Testing Performed

Not much to test, other than the CircleCI pre-commit hook no longer showing up when creating a new commit.
