### PR TITLE
ROX-13114 add process info to network endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ endif
 collector: builder
 	make -C collector container/bin/collector
 
+.PHONY: connscrape
+connscrape:
+	make -C collector connscrape ||\
+		( .openshift-ci/slack/notify-if-needed.sh "connscrape" $$? )
+
 .PHONY: unittest
 unittest:
 	make -C collector unittest ||\

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -41,6 +41,17 @@ container/bin/collector:
 	$(MAKE) cmake-build/collector
 	$(MAKE) post-build
 
+.PHONY: build-connscrape-test
+build-connscrape-test:
+	docker build -f $(CURDIR)/connscrape-test/Dockerfile -t connscrape-test $(CURDIR)/connscrape-test
+
+connscrape: build-connscrape-test
+	docker rm -fv collector_connscrape || true
+	docker run --rm --name collector_connscrape \
+		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
+		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
+		connscrape-test "$(SRC_MOUNT_DIR)/collector/connscrape-test/connscrape-test.sh"
+
 unittest:
 	docker rm -fv collector_unittest || true
 	docker run --rm --name collector_unittest \

--- a/collector/connscrape-test/Dockerfile
+++ b/collector/connscrape-test/Dockerfile
@@ -1,0 +1,45 @@
+FROM quay.io/centos/centos:stream8
+
+USER root
+
+RUN dnf -y update \
+    && dnf -y install --nobest \
+        autoconf \
+        automake \
+        binutils-devel \
+        bison \
+        ca-certificates \
+        clang \
+        cmake \
+        cracklib-dicts \
+        diffutils \
+        elfutils-libelf-devel \
+        file \
+        flex \
+        gcc \
+        gcc-c++ \
+        gdb \
+        gettext \
+        git \
+        glibc-devel \
+        libasan \
+        libcap-ng-devel \
+        libcurl-devel \
+        libtool \
+        libuuid-devel \
+        make \
+        nc \
+        openssh-server \
+        openssl-devel \
+        patchutils \
+        passwd \
+        pkgconfig \
+        python2 \
+        rsync \
+        tar \
+        unzip \
+        valgrind \
+        wget \
+        which \
+    && dnf clean all
+

--- a/collector/connscrape-test/connscrape-test.sh
+++ b/collector/connscrape-test/connscrape-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+nohup nc -l &
+echo "Pid of nc command is $!"
+/tmp/collector/cmake-build/collector/connscrape

--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -32,7 +32,7 @@ using namespace collector;
 
 namespace {
 
-BoolEnvVar scrape_endpoints("SCRAPE_ENDPOINTS", false);
+BoolEnvVar scrape_endpoints("SCRAPE_ENDPOINTS", true);
 
 }  // namespace
 
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     std::cout << std::endl
               << "Endpoints:" << std::endl;
     for (const auto& ep : endpoints) {
-      std::cout << " " << ep << std::endl;
+      std::cout << " " << ep << " " << ep.pid() << std::endl;
     }
   }
 

--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     std::cout << std::endl
               << "Endpoints:" << std::endl;
     for (const auto& ep : endpoints) {
-      std::cout << " " << ep << " " << ep.pid() << std::endl;
+      std::cout << " " << ep << " " << ep.originator()->getPid() << std::endl;
     }
   }
 

--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -43,7 +43,9 @@ int main(int argc, char** argv) {
     proc_dir = argv[1];
   }
 
-  ConnScraper scraper(proc_dir);
+  std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(proc_dir);
+  std::shared_ptr<ProcessStore> process_store = std::make_shared<ProcessStore>(process_scraper);
+  ConnScraper scraper(proc_dir, process_store);
   std::vector<Connection> conns;
   std::vector<ContainerEndpoint> endpoints;
 

--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -25,8 +25,8 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <iostream>
 
-#include "ConnScraper.h"
 #include "EnvVar.h"
+#include "ProcfsScraper.h"
 
 using namespace collector;
 
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
     std::cout << std::endl
               << "Endpoints:" << std::endl;
     for (const auto& ep : endpoints) {
-      std::cout << " " << ep << " " << ep.originator()->getPid() << std::endl;
+      std::cout << " " << ep << std::endl;
     }
   }
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -52,6 +52,9 @@ BoolEnvVar set_enable_afterglow("ROX_ENABLE_AFTERGLOW", true);
 
 BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 
+// If true, add originator process information in NetworkEndpoint
+BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
@@ -62,6 +65,7 @@ constexpr char CollectorConfig::kCollectionMethod[];
 constexpr char CollectorConfig::kChisel[];
 constexpr const char* CollectorConfig::kSyscalls[];
 constexpr bool CollectorConfig::kForceKernelModules;
+constexpr bool CollectorConfig::kEnableProcessesListeningOnPorts;
 
 const UnorderedSet<L4ProtoPortPair> CollectorConfig::kIgnoredL4ProtoPortPairs = {{L4Proto::UDP, 9}};
 ;
@@ -75,6 +79,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   chisel_ = kChisel;
   collection_method_ = kCollectionMethod;
   force_kernel_modules_ = kForceKernelModules;
+  enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -80,6 +80,7 @@ end
 )";
   static const UnorderedSet<L4ProtoPortPair> kIgnoredL4ProtoPortPairs;
   static constexpr bool kForceKernelModules = false;
+  static constexpr bool kEnableProcessesListeningOnPorts = false;
 
   CollectorConfig() = delete;
   CollectorConfig(CollectorArgs* collectorArgs);
@@ -108,6 +109,7 @@ end
   bool EnableAfterglow() const { return enable_afterglow_; }
   bool IsCoreDumpEnabled() const;
   Json::Value TLSConfiguration() const { return tls_config_; }
+  bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -132,6 +134,7 @@ end
   int64_t afterglow_period_micros_ = 300000000;  // 5 minutes in microseconds
   bool enable_afterglow_ = true;
   bool enable_core_dump_ = false;
+  bool enable_processes_listening_on_ports_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -87,8 +87,11 @@ void CollectorService::RunForever() {
     CLOG(INFO) << "Sensor connectivity is successful";
 
     if (!config_.DisableNetworkFlows()) {
-      std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(config_.HostProc());
-      std::shared_ptr<ProcessStore> process_store = std::make_shared<ProcessStore>(process_scraper);
+      std::shared_ptr<ProcessStore> process_store;
+      if (config_.IsProcessesListeningOnPortsEnabled()) {
+        std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(config_.HostProc());
+        process_store = std::make_shared<ProcessStore>(process_scraper);
+      }
       std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
       conn_tracker = std::make_shared<ConnectionTracker>();
       UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -87,7 +87,9 @@ void CollectorService::RunForever() {
     CLOG(INFO) << "Sensor connectivity is successful";
 
     if (!config_.DisableNetworkFlows()) {
-      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc());
+      std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(config_.HostProc());
+      std::shared_ptr<ProcessStore> process_store = std::make_shared<ProcessStore>(process_scraper);
+      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
       conn_tracker = std::make_shared<ConnectionTracker>();
       UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
       conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -141,10 +141,6 @@ class ConnectionTracker {
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
 
- private:
-  // NormalizeConnection transforms a connection into a normalized form.
-  Connection NormalizeConnectionNoLock(const Connection& conn) const;
-
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
   // than the stored one.
   void EmplaceOrUpdateNoLock(const Connection& conn, ConnStatus status);
@@ -152,6 +148,10 @@ class ConnectionTracker {
   // Emplace a listen endpoint into the state ContainerEndpointMap, or update its timestamp if the supplied timestamp is more
   // recent than the stored one.
   void EmplaceOrUpdateNoLock(const ContainerEndpoint& ep, ConnStatus status);
+
+ private:
+  // NormalizeConnection transforms a connection into a normalized form.
+  Connection NormalizeConnectionNoLock(const Connection& conn) const;
 
   IPNet NormalizeAddressNoLock(const Address& address) const;
 

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -168,7 +168,7 @@ class ConnectionTracker {
   // NormalizeContainerEndpoint transforms a container endpoint into a normalized form.
   inline ContainerEndpoint NormalizeContainerEndpoint(const ContainerEndpoint& cep) const {
     const auto& ep = cep.endpoint();
-    return ContainerEndpoint(cep.container(), Endpoint(Address(ep.address().family()), ep.port()), cep.l4proto());
+    return ContainerEndpoint(cep.container(), Endpoint(Address(ep.address().family()), ep.port()), cep.l4proto(), cep.originator());
   }
 
   // Determine if a connection should be ignored

--- a/collector/lib/NetworkConnection.cpp
+++ b/collector/lib/NetworkConnection.cpp
@@ -54,7 +54,11 @@ size_t Hash(const L4ProtoPortPair& pp) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint) {
-  return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << *container_endpoint.originator();
+  if (container_endpoint.originator()) {
+    return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << *container_endpoint.originator();
+  } else {
+    return os << container_endpoint.container() << ": " << container_endpoint.endpoint();
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, const Connection& conn) {

--- a/collector/lib/NetworkConnection.cpp
+++ b/collector/lib/NetworkConnection.cpp
@@ -23,6 +23,8 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include "NetworkConnection.h"
 
+#include "Process.h"
+
 namespace collector {
 
 bool Address::IsPublic() const {
@@ -52,7 +54,7 @@ size_t Hash(const L4ProtoPortPair& pp) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint) {
-  return os << container_endpoint.container() << ": " << container_endpoint.endpoint();
+  return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << *container_endpoint.originator();
 }
 
 std::ostream& operator<<(std::ostream& os, const Connection& conn) {

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -347,12 +347,13 @@ size_t Hash(const L4ProtoPortPair& pp);
 
 class ContainerEndpoint {
  public:
-  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto)
-      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto) {}
+  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, int pid = -1)
+      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto), pid_(pid) {}
 
   const std::string& container() const { return container_; }
   const Endpoint& endpoint() const { return endpoint_; }
   const L4Proto l4proto() const { return l4proto_; }
+  const int pid() const { return pid_; }
 
   bool operator==(const ContainerEndpoint& other) const {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_;
@@ -368,6 +369,7 @@ class ContainerEndpoint {
   std::string container_;
   Endpoint endpoint_;
   L4Proto l4proto_;
+  int pid_;
 };
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint);

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -38,6 +38,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <vector>
 
 #include "Hash.h"
+#include "Process.h"
 
 namespace collector {
 
@@ -347,17 +348,17 @@ size_t Hash(const L4ProtoPortPair& pp);
 
 class ContainerEndpoint {
  public:
-  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, int pid = -1)
-      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto), pid_(pid) {}
+  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, std::shared_ptr<Process> originator)
+      : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto), originator_(originator) {}
 
   const std::string& container() const { return container_; }
   const Endpoint& endpoint() const { return endpoint_; }
   const L4Proto l4proto() const { return l4proto_; }
-  const int pid() const { return pid_; }
+  const std::shared_ptr<Process> originator() const { return originator_; }
 
   bool operator==(const ContainerEndpoint& other) const {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
-           pid_ == other.pid_;
+           originator_ == other.originator_;
   }
 
   bool operator!=(const ContainerEndpoint& other) const {
@@ -370,7 +371,7 @@ class ContainerEndpoint {
   std::string container_;
   Endpoint endpoint_;
   L4Proto l4proto_;
-  int pid_;
+  std::shared_ptr<Process> originator_;
 };
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint);

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -356,7 +356,8 @@ class ContainerEndpoint {
   const int pid() const { return pid_; }
 
   bool operator==(const ContainerEndpoint& other) const {
-    return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_;
+    return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
+           pid_ == other.pid_;
   }
 
   bool operator!=(const ContainerEndpoint& other) const {

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -354,8 +354,9 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   endpoint_proto->set_protocol(TranslateL4Protocol(cep.l4proto()));
   endpoint_proto->set_socket_family(TranslateAddressFamily(cep.endpoint().address().family()));
   endpoint_proto->set_allocated_listen_address(EndpointToProto(cep.endpoint()));
-  endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
-
+  if (cep.originator()) {
+    endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
+  }
   CLOG(DEBUG) << cep;
 
   return endpoint_proto;

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -356,6 +356,8 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   endpoint_proto->set_allocated_listen_address(EndpointToProto(cep.endpoint()));
   endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
 
+  CLOG(DEBUG) << cep;
+
   return endpoint_proto;
 }
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -354,7 +354,7 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   endpoint_proto->set_protocol(TranslateL4Protocol(cep.l4proto()));
   endpoint_proto->set_socket_family(TranslateAddressFamily(cep.endpoint().address().family()));
   endpoint_proto->set_allocated_listen_address(EndpointToProto(cep.endpoint()));
-  CLOG(DEBUG) << cep;
+  endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
 
   return endpoint_proto;
 }
@@ -383,6 +383,16 @@ sensor::NetworkAddress* NetworkStatusNotifier::EndpointToProto(const collector::
   addr_proto->set_port(endpoint.port());
 
   return addr_proto;
+}
+
+storage::NetworkProcessUniqueKey* NetworkStatusNotifier::ProcessToProto(const collector::Process& process) {
+  auto* process_proto = Allocate<storage::NetworkProcessUniqueKey>();
+
+  process_proto->set_process_name(process.exe());
+  process_proto->set_process_exec_file_path(process.exe_path());
+  process_proto->set_process_args(process.args());
+
+  return process_proto;
 }
 
 }  // namespace collector

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -354,6 +354,7 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   endpoint_proto->set_protocol(TranslateL4Protocol(cep.l4proto()));
   endpoint_proto->set_socket_family(TranslateAddressFamily(cep.endpoint().address().family()));
   endpoint_proto->set_allocated_listen_address(EndpointToProto(cep.endpoint()));
+  CLOG(DEBUG) << cep;
 
   return endpoint_proto;
 }

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -388,7 +388,7 @@ sensor::NetworkAddress* NetworkStatusNotifier::EndpointToProto(const collector::
 storage::NetworkProcessUniqueKey* NetworkStatusNotifier::ProcessToProto(const collector::Process& process) {
   auto* process_proto = Allocate<storage::NetworkProcessUniqueKey>();
 
-  process_proto->set_process_name(process.exe());
+  process_proto->set_process_name(process.comm());
   process_proto->set_process_exec_file_path(process.exe_path());
   process_proto->set_process_args(process.args());
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -27,9 +27,9 @@ You should have received a copy of the GNU General Public License along with thi
 #include <memory>
 
 #include "CollectorStats.h"
-#include "ConnScraper.h"
 #include "ConnTracker.h"
 #include "NetworkConnectionInfoServiceComm.h"
+#include "ProcfsScraper.h"
 #include "ProtoAllocator.h"
 #include "StoppableThread.h"
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -54,6 +54,7 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   sensor::NetworkConnection* ConnToProto(const Connection& conn);
   sensor::NetworkEndpoint* ContainerEndpointToProto(const ContainerEndpoint& cep);
   sensor::NetworkAddress* EndpointToProto(const Endpoint& endpoint);
+  storage::NetworkProcessUniqueKey* ProcessToProto(const collector::Process& process);
 
   void OnRecvControlMessage(const sensor::NetworkFlowsControlMessage* msg);
 

--- a/collector/lib/Process.cpp
+++ b/collector/lib/Process.cpp
@@ -1,0 +1,55 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include "Process.h"
+
+namespace collector {
+
+ProcessStore ProcessStore::global_instance;
+
+const std::shared_ptr<Process> ProcessStore::FetchReference(const Process& p) {
+    std::shared_ptr<Process> existing_process = FindByPid(p.getPid());
+
+    if (existing_process)
+        return existing_process;
+    
+    std::shared_ptr<CachedProcess> cached_process = std::make_shared<CachedProcess>(p, *this);
+
+    cache_.emplace(cached_process->getPid(), cached_process);
+    return cached_process;
+}
+
+const std::shared_ptr<Process> ProcessStore::FindByPid(uint64_t pid) const {
+    auto cached_process_pair_iter = cache_.find(pid);
+
+    if (cached_process_pair_iter != cache_.end())
+        return cached_process_pair_iter->second.lock();
+
+    return 0;
+}
+
+ProcessStore::CachedProcess::~CachedProcess() {
+    store_.cache_.erase(pid_);
+}
+
+}

--- a/collector/lib/Process.cpp
+++ b/collector/lib/Process.cpp
@@ -38,6 +38,12 @@ const std::shared_ptr<Process> ProcessStore::Fetch(uint64_t pid) {
   return cached_process;
 }
 
+std::ostream& operator<<(std::ostream& os, const Process& process) {
+  std::string processString = "ContainerID: " + process.container_id() + " Exe: " + process.exe() + " ExePath: ";
+  processString += process.exe_path() + " Args: " + process.args() + " PID: " + std::to_string(process.pid());
+  return os << processString;
+}
+
 ProcessStore::CachedProcess::~CachedProcess() {
   store_.cache_.erase(pid_);
 }

--- a/collector/lib/Process.h
+++ b/collector/lib/Process.h
@@ -67,6 +67,8 @@ class Process {
   uint64_t pid_;
 };
 
+std::ostream& operator<<(std::ostream& os, const Process& process);
+
 /* A Process object store used to deduplicate process information.
    Processes are kept in the store as long as they are referenced from the outside.
    When a process cannot be found in the store, a provided ProcessStore::ISource

--- a/collector/lib/Process.h
+++ b/collector/lib/Process.h
@@ -1,0 +1,89 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#ifndef COLLECTOR_PROCESS_H
+#define COLLECTOR_PROCESS_H
+
+#include <memory>
+#include <unordered_map>
+#include <cstdint>
+
+namespace collector {
+
+// A process
+class Process {
+  public:
+    Process(const std::string& container_id, const std::string& name, const std::string& exe_path, const std::string& args, uint64_t pid) :
+        container_id_(container_id), name_(name), exe_path_(exe_path), args_(args), pid_(pid) {}
+    virtual ~Process() {}
+  
+    const std::string& getContainerId() const { return container_id_; }
+    const std::string& getName() const { return name_; }
+    const std::string& getExePath() const { return exe_path_; }
+    const std::string& getArgs() const { return args_; }
+    uint64_t getPid() const { return pid_; }
+
+    bool operator==(Process& other) {
+      return pid_ == other.pid_;
+    }
+
+  protected:
+    std::string container_id_;
+    std::string name_;
+    std::string exe_path_;
+    std::string args_;
+    uint64_t pid_;
+};
+
+/* A Process object store used to deduplicate process information.
+   Processes are kept in the store as long as they are referenced from the outside.
+   References are created by FetchReference, which will create the Process object
+   if necessary as a side-effect. */
+class ProcessStore {
+  public:
+    static ProcessStore global_instance;
+
+    /* Get a reference to a matching Process stored in the cache.
+       The Process is created if it does not exist.
+       This method always returns a valid Process reference. */
+    const std::shared_ptr<Process> FetchReference(const Process& p);
+
+    // Get a Process by PID if it exists in the store, null otherwise.
+    const std::shared_ptr<Process> FindByPid(uint64_t pid) const;
+
+  private:
+    class CachedProcess : public Process {
+      public:
+        CachedProcess(const Process& p, ProcessStore& store) : Process(p), store_(store) {}
+        ~CachedProcess();
+
+      private:
+        ProcessStore& store_;
+    };
+
+    std::unordered_map<uint64_t, std::weak_ptr<CachedProcess>> cache_;
+};
+
+}
+
+#endif

--- a/collector/lib/ProcfsScraper.cpp
+++ b/collector/lib/ProcfsScraper.cpp
@@ -22,7 +22,6 @@ You should have received a copy of the GNU General Public License along with thi
 */
 
 #include "ProcfsScraper.h"
-#include "ProcfsScraper_internal.h"
 
 #include <cctype>
 #include <cinttypes>
@@ -32,11 +31,12 @@ You should have received a copy of the GNU General Public License along with thi
 #include <netinet/tcp.h>
 
 #include "Containers.h"
-#include "Logging.h"
-#include "Utility.h"
 #include "FileSystem.h"
 #include "Hash.h"
+#include "Logging.h"
+#include "ProcfsScraper_internal.h"
 #include "StringView.h"
+#include "Utility.h"
 
 namespace collector {
 
@@ -472,7 +472,7 @@ bool ReadProcessExe(const char* process_id, int dirfd, std::string& comm, std::s
     CLOG(ERROR) << "Could not read 'exe' for " << process_id << ": " << StrError();
     return false;
   }
-  
+
   buffer[nread] = '\0';
 
   comm = exe_path = buffer;
@@ -484,7 +484,6 @@ bool ReadProcessExe(const char* process_id, int dirfd, std::string& comm, std::s
 }
 
 bool ReadProcessCmdline(const char* process_id, int dirfd, std::string& exe, std::string& args) {
-  
   FileHandle cmdline(FDHandle(openat(dirfd, "cmdline", O_RDONLY)), "r");
   if (!cmdline.valid()) {
     CLOG(ERROR) << "Could not read 'cmdline' for " << process_id << ": " << StrError();
@@ -513,7 +512,7 @@ bool ReadProcessCmdline(const char* process_id, int dirfd, std::string& exe, std
     }
   }
   args = stringbuf.str();
-  
+
   return true;
 }
 
@@ -561,13 +560,12 @@ Process ProcessScraper::ByPID(uint64_t pid) {
   }
 
   return Process(
-    std::move(container_id),
-    std::move(comm),
-    std::move(exe),
-    std::move(exe_path),
-    std::move(args),
-    pid
-  );
+      std::move(container_id),
+      std::move(comm),
+      std::move(exe),
+      std::move(exe_path),
+      std::move(args),
+      pid);
 }
 
 }  // namespace collector

--- a/collector/lib/ProcfsScraper.h
+++ b/collector/lib/ProcfsScraper.h
@@ -44,8 +44,8 @@ class IConnScraper {
 class ConnScraper : public IConnScraper {
  public:
   explicit ConnScraper(std::string proc_path, std::shared_ptr<ProcessStore> process_store = 0)
-   : proc_path_(std::move(proc_path)),
-   process_store_(process_store) {}
+      : proc_path_(std::move(proc_path)),
+        process_store_(process_store) {}
 
   // Scrape returns a snapshot of all active network connections in the given vector.
   bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints);

--- a/collector/lib/ProcfsScraper_internal.h
+++ b/collector/lib/ProcfsScraper_internal.h
@@ -31,6 +31,6 @@ namespace collector {
 // ExtractContainerID tries to extract a container ID from a cgroup line.
 StringView ExtractContainerID(StringView cgroup_line);
 
-}
+}  // namespace collector
 
 #endif

--- a/collector/lib/ProcfsScraper_internal.h
+++ b/collector/lib/ProcfsScraper_internal.h
@@ -21,42 +21,16 @@ You should have received a copy of the GNU General Public License along with thi
 * version.
 */
 
-#ifndef COLLECTOR_CONNSCRAPER_H
-#define COLLECTOR_CONNSCRAPER_H
+#ifndef COLLECTOR_PROCFSSCRAPER_INTERNAL_H
+#define COLLECTOR_PROCFSSCRAPER_INTERNAL_H
 
-#include <cstring>
-#include <string>
-#include <vector>
-
-#include "FileSystem.h"
-#include "Hash.h"
-#include "NetworkConnection.h"
 #include "StringView.h"
 
 namespace collector {
 
-// ExtractContainerID tries to extract a container ID from a cgroup line. Exposed for testing.
+// ExtractContainerID tries to extract a container ID from a cgroup line.
 StringView ExtractContainerID(StringView cgroup_line);
 
-// Abstract interface for a ConnScraper. Useful to inject testing implementation.
-class IConnScraper {
- public:
-  virtual bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) = 0;
-  virtual ~IConnScraper() {}
-};
+}
 
-// ConnScraper is a class that allows scraping a `/proc`-like directory structure for active network connections.
-class ConnScraper : public IConnScraper {
- public:
-  explicit ConnScraper(std::string proc_path) : proc_path_(std::move(proc_path)) {}
-
-  // Scrape returns a snapshot of all active network connections in the given vector.
-  bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints);
-
- private:
-  std::string proc_path_;
-};
-
-}  // namespace collector
-
-#endif  // COLLECTOR_CONNSCRAPER_H
+#endif

--- a/collector/test/ConnScraperTest.cpp
+++ b/collector/test/ConnScraperTest.cpp
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License along with thi
 * version.
 */
 
-#include "ConnScraper.h"
+#include "ProcfsScraper_internal.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1246,6 +1246,115 @@ TEST(ConnTrackerTest, TestComputeDeltaAfterglowBenchmark2) {
   std::cout << "Time taken by ComputeDeltaAfterglow= " << dur.count() << " ms\n";
 }
 
+TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointDifferentPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, oldConnStatus);
+  connectionTracker.EmplaceOrUpdateNoLock(ce2, newConnStatus);
+
+  ContainerEndpointMap expected_state = {{ce1, oldConnStatus}, {ce2, newConnStatus}};
+  ContainerEndpointMap observed_state = connectionTracker.FetchEndpointState(false, false);
+  EXPECT_THAT(observed_state, expected_state);
+
+  ContainerEndpoint observed_endpoint = observed_state.find(ce2)->first;
+  int observedPid = observed_endpoint.pid();
+
+  EXPECT_THAT(observedPid, 3);
+}
+
+TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointAndPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, oldConnStatus);
+  connectionTracker.EmplaceOrUpdateNoLock(ce1, newConnStatus);
+
+  ContainerEndpointMap expected_state = {{ce1, newConnStatus}};
+  ContainerEndpointMap observed_state = connectionTracker.FetchEndpointState(false, false);
+  EXPECT_THAT(observed_state, expected_state);
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointDifferentPids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce2, newConnStatus}};
+
+  ContainerEndpointMap expected_delta = {{ce1, ConnStatus(connection_time1, false)}, {ce2, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, expected_delta);
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointSamePids) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce1, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, IsEmpty());
+}
+
+TEST(ConnTrackerTest, TestDeltaForEndpointDifferentProtocols) {
+  string container = "FakeContainer";
+  int64_t connection_time1 = 1000;
+  int64_t connection_time2 = 2000;
+  Endpoint a(Address(192, 168, 0, 1), 80);
+  ConnectionTracker connectionTracker;
+
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce2(container, a, L4Proto::UDP, 2);
+
+  ConnStatus oldConnStatus(connection_time1, true);
+  ConnStatus newConnStatus(connection_time2, true);
+
+  ContainerEndpointMap old_state = {{ce1, oldConnStatus}};
+  ContainerEndpointMap new_state = {{ce2, newConnStatus}};
+
+  ContainerEndpointMap expected_delta = {{ce1, ConnStatus(connection_time1, false)}, {ce2, newConnStatus}};
+
+  CT::ComputeDelta(new_state, &old_state);
+  EXPECT_THAT(old_state, expected_delta);
+}
+
 }  // namespace
 
 }  // namespace collector

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1246,6 +1246,7 @@ TEST(ConnTrackerTest, TestComputeDeltaAfterglowBenchmark2) {
   std::cout << "Time taken by ComputeDeltaAfterglow= " << dur.count() << " ms\n";
 }
 
+/*
 TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointDifferentPids) {
   string container = "FakeContainer";
   int64_t connection_time1 = 1000;
@@ -1354,7 +1355,7 @@ TEST(ConnTrackerTest, TestDeltaForEndpointDifferentProtocols) {
   CT::ComputeDelta(new_state, &old_state);
   EXPECT_THAT(old_state, expected_delta);
 }
-
+*/
 }  // namespace
 
 }  // namespace collector

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1246,16 +1246,17 @@ TEST(ConnTrackerTest, TestComputeDeltaAfterglowBenchmark2) {
   std::cout << "Time taken by ComputeDeltaAfterglow= " << dur.count() << " ms\n";
 }
 
-/*
 TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointDifferentPids) {
   string container = "FakeContainer";
   int64_t connection_time1 = 1000;
   int64_t connection_time2 = 2000;
   Endpoint a(Address(192, 168, 0, 1), 80);
   ConnectionTracker connectionTracker;
+  std::shared_ptr<Process> process1 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 2);
+  std::shared_ptr<Process> process2 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 3);
 
-  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
-  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, process1);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, process2);
 
   ConnStatus oldConnStatus(connection_time1, true);
   ConnStatus newConnStatus(connection_time2, true);
@@ -1268,7 +1269,7 @@ TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointDifferentPids) {
   EXPECT_THAT(observed_state, expected_state);
 
   ContainerEndpoint observed_endpoint = observed_state.find(ce2)->first;
-  int observedPid = observed_endpoint.pid();
+  int observedPid = observed_endpoint.originator()->pid();
 
   EXPECT_THAT(observedPid, 3);
 }
@@ -1279,8 +1280,9 @@ TEST(ConnTrackerTest, TestEmplaceOrUpdateSameEndpointAndPids) {
   int64_t connection_time2 = 2000;
   Endpoint a(Address(192, 168, 0, 1), 80);
   ConnectionTracker connectionTracker;
+  std::shared_ptr<Process> process1 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 2);
 
-  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, process1);
 
   ConnStatus oldConnStatus(connection_time1, true);
   ConnStatus newConnStatus(connection_time2, true);
@@ -1299,9 +1301,11 @@ TEST(ConnTrackerTest, TestDeltaForEndpointDifferentPids) {
   int64_t connection_time2 = 2000;
   Endpoint a(Address(192, 168, 0, 1), 80);
   ConnectionTracker connectionTracker;
+  std::shared_ptr<Process> process1 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 2);
+  std::shared_ptr<Process> process2 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 3);
 
-  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
-  ContainerEndpoint ce2(container, a, L4Proto::TCP, 3);
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, process1);
+  ContainerEndpoint ce2(container, a, L4Proto::TCP, process2);
 
   ConnStatus oldConnStatus(connection_time1, true);
   ConnStatus newConnStatus(connection_time2, true);
@@ -1321,8 +1325,9 @@ TEST(ConnTrackerTest, TestDeltaForEndpointSamePids) {
   int64_t connection_time2 = 2000;
   Endpoint a(Address(192, 168, 0, 1), 80);
   ConnectionTracker connectionTracker;
+  std::shared_ptr<Process> process1 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 2);
 
-  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, process1);
 
   ConnStatus oldConnStatus(connection_time1, true);
   ConnStatus newConnStatus(connection_time2, true);
@@ -1340,9 +1345,10 @@ TEST(ConnTrackerTest, TestDeltaForEndpointDifferentProtocols) {
   int64_t connection_time2 = 2000;
   Endpoint a(Address(192, 168, 0, 1), 80);
   ConnectionTracker connectionTracker;
+  std::shared_ptr<Process> process1 = std::make_shared<Process>(container, "comm", "exe", "exe_path", "args", 2);
 
-  ContainerEndpoint ce1(container, a, L4Proto::TCP, 2);
-  ContainerEndpoint ce2(container, a, L4Proto::UDP, 2);
+  ContainerEndpoint ce1(container, a, L4Proto::TCP, process1);
+  ContainerEndpoint ce2(container, a, L4Proto::UDP, process1);
 
   ConnStatus oldConnStatus(connection_time1, true);
   ConnStatus newConnStatus(connection_time2, true);
@@ -1355,7 +1361,7 @@ TEST(ConnTrackerTest, TestDeltaForEndpointDifferentProtocols) {
   CT::ComputeDelta(new_state, &old_state);
   EXPECT_THAT(old_state, expected_delta);
 }
-*/
+
 }  // namespace
 
 }  // namespace collector

--- a/docs/references.md
+++ b/docs/references.md
@@ -25,6 +25,10 @@ network system call events and reading of connection information from procfs.
 Mainly used in case of network-related performance degradation. The default is
 false.
 
+* `ROX_PROCESSES_LISTENING_ON_PORT`: Instructs Collector to add information
+about the originator process on all network listening-endpoint objects.
+The default is false.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 


### PR DESCRIPTION
## Description

Originator process information is added to network endpoint objects sent to Sensor.
This information comes from a ProcessStore which deduplicates process information between endpoints sharing the same originator. Ultimately, the information comes from a new Process scraper.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests (some tests for the ProcessStore are planned in a subsequent PR)
  - ~~[ ] Added integration tests~~
  - ~~[ ] Added regression tests~~

## Testing Performed
