### PR TITLE
collector: force ebpf if SecureBoot undetermined only on x86_64

### DIFF
--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -140,11 +140,13 @@ class SecureBootHeuristic : public Heuristic {
       hconfig->SetCollectionMethod("ebpf");
     }
 
+#ifdef __x86_64__
     if (sb_status == SecureBootStatus::NOT_DETERMINED) {
       CLOG(WARNING) << "SecureBoot status could not be determined. "
                     << "Switching to eBPF based collection.";
       hconfig->SetCollectionMethod("ebpf");
     }
+#endif
   }
 };
 


### PR DESCRIPTION
## Description

Although I wonder if this block shouldn't be removed entirely (after all, why assume Secure Boot if none of the signs thereof could be detected?), at a minimum, this logic should not be applied to other architectures.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

