### PR TITLE
Jv integration tests for networksignalhandler endpoints

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -367,6 +367,11 @@ func (s *ProcessNetworkTestSuite) TestProcessLineageInfo() {
 func (s *ProcessNetworkTestSuite) TestNetworkFlows() {
 
 	// Server side checks
+
+	// NetworkSignalHandler does not currently report endpoints
+	_, err := s.GetEndpoints(s.serverContainer)
+	s.Require().Error(err)
+
 	val, err := s.Get(s.serverContainer, networkBucket)
 	s.Require().NoError(err)
 	actualValues := strings.Split(string(val), "|")
@@ -385,6 +390,11 @@ func (s *ProcessNetworkTestSuite) TestNetworkFlows() {
 	fmt.Printf("ServerDetails from test: %s %s, Port: %s\n", s.serverContainer, s.serverIP, s.serverPort)
 
 	// client side checks
+
+	// NetworkSignalHandler does not currently report endpoints
+	_, err = s.GetEndpoints(s.clientContainer)
+	s.Require().Error(err)
+
 	val, err = s.Get(s.clientContainer, networkBucket)
 	s.Require().NoError(err)
 	actualValues = strings.Split(string(val), "|")

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -368,7 +368,13 @@ func (s *ProcessNetworkTestSuite) TestNetworkFlows() {
 
 	// Server side checks
 
-	// NetworkSignalHandler does not currently report endpoints
+	// NetworkSignalHandler does not currently report endpoints.
+	// ConnScraper, which scrapes networking information from /proc reports endpoints and connections
+	// However NetworkSignalHandler, which gets networking information from Falco only reports connections.
+	// At some point in the future NetworkSignalHandler will report endpoints and connections.
+	// At that time this test and the similar test for the client container will need to be changed.
+	// The requirement should be NoError, instead of Error and there should be multiple asserts to
+	// check that the endpoints are what we expect them to be.
 	_, err := s.GetEndpoints(s.serverContainer)
 	s.Require().Error(err)
 
@@ -391,7 +397,8 @@ func (s *ProcessNetworkTestSuite) TestNetworkFlows() {
 
 	// client side checks
 
-	// NetworkSignalHandler does not currently report endpoints
+	// NetworkSignalHandler does not currently report endpoints.
+	// See the comment above for the server container endpoint test for more info.
 	_, err = s.GetEndpoints(s.clientContainer)
 	s.Require().Error(err)
 


### PR DESCRIPTION
## Description

Makes it so that TestNetworkFlows checks for endpoints as well as connections. Right now NetworkSignalHandler does not report endpoints, and TestNetworkFlows only checks for connections. Probably someday NetworkSignalHandler will report endpoints. 

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
  - [x] Added integration tests

## Testing Performed

See above