### PR TITLE
ROX-11447: refactor kernel driver start up

### DIFF
--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -28,20 +28,20 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include "CollectorConfig.h"
 #include "CollectorStats.h"
+#include "Control.h"
+#include "SysdigService.h"
 
 namespace collector {
 
+class SysdigService;
+
 class CollectorService {
  public:
-  enum ControlValue {
-    RUN = 0,           // Keep running
-    INTERRUPT_SYSDIG,  // Stop running sysdig, but resume collector operation (e.g., for chisel update)
-    STOP_COLLECTOR,    // Stop the collector (e.g., SIGINT or SIGTERM received).
-  };
-
   CollectorService(const CollectorConfig& config, std::atomic<ControlValue>* control, const std::atomic<int>* signum);
 
   void RunForever();
+
+  bool InitKernel();
 
  private:
   void OnChiselReceived(const std::string& chisel);
@@ -55,6 +55,8 @@ class CollectorService {
 
   std::atomic<ControlValue>* control_;
   const std::atomic<int>& signum_;
+
+  SysdigService sysdig_;
 };
 
 }  // namespace collector

--- a/collector/lib/Control.h
+++ b/collector/lib/Control.h
@@ -1,0 +1,14 @@
+#ifndef COLLECTOR_CONTROL_H
+#define COLLECTOR_CONTROL_H
+
+namespace collector {
+
+enum ControlValue {
+  RUN = 0,           // Keep running
+  INTERRUPT_SYSDIG,  // Stop running sysdig, but resume collector operation (e.g., for chisel update)
+  STOP_COLLECTOR,    // Stop the collector (e.g., SIGINT or SIGTERM received).
+};
+
+}
+
+#endif

--- a/collector/lib/KernelDriver.cpp
+++ b/collector/lib/KernelDriver.cpp
@@ -34,7 +34,7 @@ std::string constructArgsStr(std::unordered_map<std::string, std::string>& args)
   return stream.str();
 }
 
-int doInsertModule(std::vector<char>& image, std::unordered_map<std::string, std::string>& args) {
+int insertModule(std::vector<char>& image, std::unordered_map<std::string, std::string>& args) {
   std::string args_str = constructArgsStr(args);
   CLOG(DEBUG) << "Kernel module arguments: " << args_str;
 
@@ -115,7 +115,7 @@ bool KernelDriverModule::insert(const std::vector<std::string>& syscalls, std::s
 
   // Attempt to insert the module. If it is already inserted then remove it and
   // try again
-  int result = doInsertModule(image, module_args);
+  int result = insertModule(image, module_args);
   while (result != 0) {
     if (errno == EEXIST) {
       // note that we forcefully remove the kernel module whether or not it has a non-zero
@@ -128,7 +128,7 @@ bool KernelDriverModule::insert(const std::vector<std::string>& syscalls, std::s
                   << ". Aborting...";
       return false;
     }
-    result = doInsertModule(image, module_args);
+    result = insertModule(image, module_args);
   }
 
   CLOG(INFO) << "Successfully inserted kernel module " << path << ".";

--- a/collector/lib/KernelDriver.cpp
+++ b/collector/lib/KernelDriver.cpp
@@ -1,0 +1,162 @@
+#include "KernelDriver.h"
+
+#include "FileSystem.h"
+#include "SysdigService.h"
+#include "Utility.h"
+
+extern "C" {
+#include <sys/stat.h>
+}
+
+#define init_module(module_image, len, param_values) syscall(__NR_init_module, module_image, len, param_values)
+#define delete_module(name, flags) syscall(__NR_delete_module, name, flags)
+
+namespace collector {
+
+namespace {
+
+int read_module(int fd, void* buf, int buflen) {
+  unsigned char* p = static_cast<unsigned char*>(buf);
+  int n, i = 0;
+  while (i < buflen) {
+    n = read(fd, p + i, buflen - i);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      else
+        return n;
+    } else if (n == 0) {
+      return i;
+    } else {
+      i += n;
+    }
+  }
+  return i;
+}
+
+std::string constructArgsStr(std::unordered_map<std::string, std::string>& args) {
+  bool first = true;
+  std::stringstream stream;
+
+  for (auto& entry : args) {
+    if (first) {
+      first = false;
+    } else {
+      stream << " ";
+    }
+    stream << entry.first << "=" << entry.second;
+  }
+
+  return stream.str();
+}
+
+int doInsertModule(int fd, std::unordered_map<std::string, std::string>& args) {
+  std::string args_str = constructArgsStr(args);
+  CLOG(DEBUG) << "Kernel module arguments: " << args_str;
+
+  struct stat st;
+  int res = fstat(fd, &st);
+  if (res != 0) {
+    CLOG(ERROR) << "Could not stat kernel module: " << StrError();
+    errno = EINVAL;
+    return -1;
+  }
+  size_t image_size = st.st_size;
+  void* image = malloc(image_size);
+  if (!image) {
+    CLOG(ERROR) << "Could not allocate memory for kernel module: " << StrError();
+    errno = EINVAL;
+    return -1;
+  }
+  lseek(fd, 0, SEEK_SET);
+  size_t read_image_size = read_module(fd, image, image_size);
+  if (read_image_size != image_size) {
+    CLOG(ERROR) << "Could not read kernel module: " << StrError() << ".  Mismatch with number of bytes read and kernel module size.";
+    errno = EINVAL;
+    return -1;
+  }
+
+  int res = init_module(fd, args_str.c_str(), 0);
+  if (res != 0) {
+    return res;
+  }
+
+  std::string param_dir = GetHostPath(
+      std::string("/sys/module/") + SysdigService::kModuleName + "/parameters");
+
+  if (stat(param_dir.c_str(), &st) != 0) {
+    // This is not optimal, but don't fail hard on systems where
+    // for whatever reason the above directory does not exist.
+    CLOG(WARNING) << "Could not stat " << param_dir << ": " << StrError()
+                  << ". No parameter verification can be performed.";
+    return 0;
+  }
+
+  for (const auto& entry : args) {
+    std::string param_file = param_dir + entry.first;
+
+    if (stat(param_file.c_str(), &st) != 0) {
+      CLOG(ERROR) << "Could not stat " << param_file << ": " << StrError()
+                  << ". Parameter " << entry.first
+                  << " is unsupported, suspecting module version mismatch.";
+      errno = EINVAL;
+      return -1;
+    }
+  }
+  return 0;
+}
+
+}  // namespace
+
+bool KernelDriverModule::insert(const std::vector<std::string>& syscalls, std::string path) {
+  std::unordered_map<std::string, std::string> module_args;
+  std::stringstream syscall_ids;
+
+  // Iterate over the syscalls that we want and pull each of their ids.
+  // These are stashed into a string that will get passed to init_module
+  // to insert the kernel module
+  const EventNames& event_names = EventNames::GetInstance();
+  for (const auto& syscall : syscalls) {
+    for (ppm_event_type id : event_names.GetEventIDs(syscall)) {
+      syscall_ids << id << ",";
+    }
+  }
+  syscall_ids << "-1";
+
+  module_args["s_syscallIds"] = syscall_ids.str();
+  module_args["exclude_initns"] = "1";
+  module_args["exclude_selfns"] = "1";
+  module_args["verbose"] = "0";
+
+  FDHandle fd = FDHandle(open(path.c_str(), O_RDONLY));
+  if (!fd.valid()) {
+    CLOG(ERROR) << "Cannot open kernel module: " << path << ". Aborting...";
+    return false;
+  }
+
+  CLOG(INFO) << "Inserting kernel module " << SysdigService::kModulePath
+             << " with indefinite removal and retry if required.";
+
+  // Attempt to insert the module. If it is already inserted then remove it and
+  // try again
+  int result = doInsertModule(fd.get(), module_args);
+  while (result != 0) {
+    if (errno == EEXIST) {
+      // note that we forcefully remove the kernel module whether or not it has a non-zero
+      // reference count. There is only one container that is ever expected to be using
+      // this kernel module and that is us
+      delete_module(SysdigService::kModuleName, O_NONBLOCK | O_TRUNC);
+      sleep(2);  // wait for 2s before trying again
+    } else {
+      CLOG(ERROR) << "Error inserting kernel module: " << path << ": " << StrError()
+                  << ". Aborting...";
+      return false;
+    }
+    result = doInsertModule(fd.get(), module_args);
+  }
+
+  CLOG(INFO) << "Successfully inserted kernel module " << path << ".";
+  return true;
+}
+
+}  // namespace collector

--- a/collector/lib/KernelDriver.cpp
+++ b/collector/lib/KernelDriver.cpp
@@ -44,7 +44,7 @@ int doInsertModule(std::vector<char>& image, std::unordered_map<std::string, std
   }
 
   std::string param_dir = GetHostPath(
-      std::string("/sys/module/") + SysdigService::kModuleName + "/parameters");
+      std::string("/sys/module/") + SysdigService::kModuleName + "/parameters/");
 
   struct stat st;
   if (stat(param_dir.c_str(), &st) != 0) {

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -27,7 +27,7 @@ class IKernelDriver {
 
 class KernelDriverModule : public IKernelDriver {
  public:
-  bool Setup(const CollectorConfig& config, std::string path) {
+  bool Setup(const CollectorConfig& config, std::string path) override {
     // First action: drop all capabilities except for:
     // SYS_MODULE (inserting the module),
     // SYS_PTRACE (reading from /proc),
@@ -72,7 +72,7 @@ class KernelDriverModule : public IKernelDriver {
 
 class KernelDriverEBPF : public IKernelDriver {
  public:
-  bool Setup(const CollectorConfig& config, std::string path) {
+  bool Setup(const CollectorConfig& config, std::string path) override {
     FDHandle fd = FDHandle(open(path.c_str(), O_RDONLY));
     if (!fd.valid()) {
       CLOG(ERROR) << "Cannot open eBPF probe at " << path;

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -1,0 +1,107 @@
+#ifndef COLLECTOR_KERNEL_DRIVER_H
+#define COLLECTOR_KERNEL_DRIVER_H
+
+#include <string>
+
+extern "C" {
+#include <cap-ng.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+}
+
+#include "CollectorConfig.h"
+#include "EventNames.h"
+#include "FileSystem.h"
+#include "Logging.h"
+#include "Utility.h"
+
+extern unsigned char g_bpf_drop_syscalls[];
+
+namespace collector {
+
+class IKernelDriver {
+ public:
+  virtual bool Setup(const CollectorConfig& config, std::string path) = 0;
+};
+
+class KernelDriverModule : public IKernelDriver {
+ public:
+  bool Setup(const CollectorConfig& config, std::string path) {
+    // First action: drop all capabilities except for:
+    // SYS_MODULE (inserting the module),
+    // SYS_PTRACE (reading from /proc),
+    // DAC_OVERRIDE (opening the device files with
+    //               O_RDWR regardless of actual permissions).
+    capng_clear(CAPNG_SELECT_BOTH);
+    capng_updatev(
+        CAPNG_ADD,
+        static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED),
+        CAP_SYS_MODULE,
+        CAP_DAC_OVERRIDE,
+        CAP_SYS_PTRACE,
+        -1);
+
+    if (capng_apply(CAPNG_SELECT_BOTH) != 0) {
+      CLOG(WARNING) << "Failed to drop capabilities: " << StrError();
+    }
+
+    if (!insert(config.Syscalls(), path)) {
+      CLOG(ERROR) << "Failed to insert kernel module";
+      return false;
+    }
+
+    // if we've successfully inserted, drop SYS_MODULE capability
+    capng_updatev(
+        CAPNG_DROP,
+        static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED),
+        CAP_SYS_MODULE,
+        -1);
+
+    if (capng_apply(CAPNG_SELECT_BOTH) != 0) {
+      // not a fatal error, as we can continue, but needs to be reported.
+      CLOG(WARNING) << "Failed to drop SYS_MODULE capability: " << StrError();
+    }
+
+    return true;
+  }
+
+ private:
+  bool insert(const std::vector<std::string>& syscalls, std::string path);
+};
+
+class KernelDriverEBPF : public IKernelDriver {
+ public:
+  bool Setup(const CollectorConfig& config, std::string path) {
+    FDHandle fd = FDHandle(open(path.c_str(), O_RDONLY));
+    if (!fd.valid()) {
+      CLOG(ERROR) << "Cannot open eBPF probe at " << path;
+      return false;
+    }
+    setDropSyscalls(config.Syscalls());
+    return true;
+  }
+
+ private:
+  void setDropSyscalls(const std::vector<std::string>& syscalls) {
+    // Initialize bpf syscall drop table to drop all
+    for (int i = 0; i < SYSCALL_TABLE_SIZE; i++) {
+      g_bpf_drop_syscalls[i] = 1;
+    }
+    // Do not drop syscalls from given list
+    const EventNames& event_names = EventNames::GetInstance();
+    for (const auto& syscall_str : syscalls) {
+      for (ppm_event_type event_id : event_names.GetEventIDs(syscall_str)) {
+        uint16_t syscall_id = event_names.GetEventSyscallID(event_id);
+        if (!syscall_id) {
+          continue;
+        }
+        g_bpf_drop_syscalls[syscall_id] = 0;
+      }
+    }
+  }
+};
+
+}  // namespace collector
+
+#endif

--- a/collector/lib/NRadix.cpp
+++ b/collector/lib/NRadix.cpp
@@ -73,8 +73,8 @@ bool NRadixTree::Insert(const IPNet& network) const {
       // Reset and move to lower part.
       bit = 0x8000000000000000ULL;
       if (network.bits() >= 64) {
-        *addr_p++;
-        *net_mask_p++;
+        addr_p++;
+        net_mask_p++;
       }
     }
   }
@@ -109,8 +109,8 @@ bool NRadixTree::Insert(const IPNet& network) const {
 
       bit = 0x8000000000000000ULL;
       if (network.bits() >= 64) {
-        *addr_p++;
-        *net_mask_p++;
+        addr_p++;
+        net_mask_p++;
       }
     }
   }
@@ -163,8 +163,8 @@ IPNet NRadixTree::Find(const IPNet& network) const {
 
       bit = 0x8000000000000000ULL;
       if (network.bits() >= 64) {
-        *addr_p++;
-        *net_mask_p++;
+        addr_p++;
+        net_mask_p++;
       }
     }
   }

--- a/collector/lib/Sysdig.h
+++ b/collector/lib/Sysdig.h
@@ -28,8 +28,9 @@ You should have received a copy of the GNU General Public License along with thi
 #include <cstdint>
 #include <string>
 
-#include "CollectorService.h"
+#include "CollectorConfig.h"
 #include "ConnTracker.h"
+#include "Control.h"
 #include "ppm_events_public.h"
 
 namespace collector {
@@ -66,8 +67,9 @@ class Sysdig {
   virtual ~Sysdig() = default;
 
   virtual void Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) = 0;
+  virtual bool InitKernel(const CollectorConfig& config) = 0;
   virtual void Start() = 0;
-  virtual void Run(const std::atomic<CollectorService::ControlValue>& control) = 0;
+  virtual void Run(const std::atomic<ControlValue>& control) = 0;
   virtual void CleanUp() = 0;
 
   virtual bool GetStats(SysdigStats* stats) const = 0;

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -47,7 +47,7 @@ constexpr char SysdigService::kProbePath[];
 constexpr char SysdigService::kProbeName[];
 
 void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) {
-  if (inspector_ || chisel_) {
+  if (chisel_) {
     throw CollectorException("Invalid state: SysdigService was already initialized");
   }
 
@@ -69,6 +69,10 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
 }
 
 bool SysdigService::InitKernel(const CollectorConfig& config) {
+  if (inspector_) {
+    throw CollectorException("Invalid state: SysdigService kernel components are already initialized");
+  }
+
   inspector_.reset(new_inspector());
   inspector_->set_snaplen(config.SnapLen());
 

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -36,7 +36,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include "chisel.h"
 // clang-format on
 
-#include "CollectorService.h"
+#include "Control.h"
 #include "SignalHandler.h"
 #include "Sysdig.h"
 
@@ -55,11 +55,13 @@ class SysdigService : public Sysdig {
 
   void Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) override;
   void Start() override;
-  void Run(const std::atomic<CollectorService::ControlValue>& control) override;
+  void Run(const std::atomic<ControlValue>& control) override;
   void SetChisel(const std::string& new_chisel);
   void CleanUp() override;
 
   bool GetStats(SysdigStats* stats) const override;
+
+  bool InitKernel(const CollectorConfig& config) override;
 
  private:
   enum ChiselCacheStatus : int {

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -100,7 +100,7 @@ class SysdigService : public Sysdig {
 
   mutable std::mutex running_mutex_;
   bool running_ = false;
-  bool useEbpf = false;
+  bool useEbpf_ = false;
 };
 
 }  // namespace collector


### PR DESCRIPTION
## Description

Refactors SysdigService and CollectorService to centralise the kernel driver insertion logic to better inform start up diagnostics. This also decouples some components within CollectorService.

The kernel driver setup logic is now in a set of classes of its own, and then initialised by the SysdigService. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Some local testing, but CI should uncover any significant problems with this refactor.
