### PR TITLE
rox 13015 collector integration tests should check for process info in endpoints and find it

### DIFF
--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-258-g7ef2173c99",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-281-g25a7abf818",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/collector_manager.go
+++ b/integration-tests/collector_manager.go
@@ -67,7 +67,7 @@ func NewCollectorManager(e Executor, name string) *collectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-129-g8e0c43c17a",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-258-g7ef2173c99",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -13,7 +13,6 @@ type EndpointInfo struct {
 }
 
 func NewEndpointInfo(line string) (*EndpointInfo, error) {
-	fmt.Println(line)
 	parts := strings.Split(line, "|")
 
 	if len(parts) != 5 {

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -19,7 +19,11 @@ func NewEndpointInfo(line string) (*EndpointInfo, error) {
 		return nil, fmt.Errorf("Invalid gRPC string for endpoint info: %s", line)
 	}
 
-	originator, _ := NewProcessOriginator(parts[4])
+	originator, err := NewProcessOriginator(parts[4])
+
+	if err != nil {
+		return nil, err
+	}
 
 	return &EndpointInfo {
 		Protocol: parts[1],

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -9,20 +9,23 @@ type EndpointInfo struct {
 	Protocol string
 	ListenAddress string
 	CloseTimestamp string
-	Originator string
+	Originator *ProcessOriginator
 }
 
 func NewEndpointInfo(line string) (*EndpointInfo, error) {
+	fmt.Println(line)
 	parts := strings.Split(line, "|")
 
 	if len(parts) != 5 {
 		return nil, fmt.Errorf("Invalid gRPC string for endpoint info: %s", line)
 	}
 
+	originator, _ := NewProcessOriginator(parts[4])
+
 	return &EndpointInfo {
 		Protocol: parts[1],
 		ListenAddress: parts[2],
 		CloseTimestamp: parts[3],
-		Originator: parts[4],
+		Originator: originator,
 	}, nil
 }

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -16,7 +16,7 @@ func NewEndpointInfo(line string) (*EndpointInfo, error) {
 	parts := strings.Split(line, "|")
 
 	if len(parts) != 5 {
-		return nil, fmt.Errorf("invalid gRPC string for endpoint info: %s", line)
+		return nil, fmt.Errorf("Invalid gRPC string for endpoint info: %s", line)
 	}
 
 	return &EndpointInfo {

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -9,12 +9,13 @@ type EndpointInfo struct {
 	Protocol string
 	ListenAddress string
 	CloseTimestamp string
+	Originator string
 }
 
 func NewEndpointInfo(line string) (*EndpointInfo, error) {
 	parts := strings.Split(line, "|")
 
-	if len(parts) != 4 {
+	if len(parts) != 5 {
 		return nil, fmt.Errorf("invalid gRPC string for endpoint info: %s", line)
 	}
 
@@ -22,5 +23,6 @@ func NewEndpointInfo(line string) (*EndpointInfo, error) {
 		Protocol: parts[1],
 		ListenAddress: parts[2],
 		CloseTimestamp: parts[3],
+		Originator: parts[4],
 	}, nil
 }

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -108,12 +108,26 @@ func TestRepeatedNetworkFlowThreeCurlsNoAfterglow(t *testing.T) {
 // in which scraping is turned off and we expect that we will not see
 // endpoint opened before collector is turned on.
 func TestConnScraper(t *testing.T) {
-	connScraperTestSuite := &ConnScraperTestSuite{turnOffScrape:	false}
+	connScraperTestSuite := &ConnScraperTestSuite{
+		turnOffScrape:	false
+		roxProcessesListeningOnPort: true
+	}
 	suite.Run(t, connScraperTestSuite)
 }
 
 func TestConnScraperNoScrape(t *testing.T) {
-	connScraperTestSuite := &ConnScraperTestSuite{turnOffScrape:	true}
+	connScraperTestSuite := &ConnScraperTestSuite{
+		turnOffScrape:	true,
+		roxProcessesListeningOnPort: true,
+	}
+	suite.Run(t, connScraperTestSuite)
+}
+
+func TestConnScraperDisableFeatureFlag(t *testing.T) {
+	connScraperTestSuite := &ConnScraperTestSuite{
+		turnOffScrape:	false,
+		roxProcessesListeningOnPort: false,
+	}
 	suite.Run(t, connScraperTestSuite)
 }
 
@@ -183,10 +197,9 @@ type ImageLabelJSONTestSuite struct {
 
 type ConnScraperTestSuite struct {
 	IntegrationTestSuiteBase
-	logLines		[]string
-	serverContainer		string
-	turnOffScrape		bool
-	expectedResult		bool
+	serverContainer			string
+	turnOffScrape			bool
+	roxProcessesListeningOnPort	bool
 }
 
 func (s *ImageLabelJSONTestSuite) SetupSuite() {
@@ -562,6 +575,7 @@ func (s *ConnScraperTestSuite) SetupSuite() {
 	s.collector = NewCollectorManager(s.executor, s.T().Name())
 
 	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":` + strconv.FormatBool(s.turnOffScrape) + `,"scrapeInterval":2}`
+	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = s.RoxProcessesListeningOnPort
 
 	s.launchNginx()
 
@@ -602,7 +616,7 @@ func (s *ConnScraperTestSuite) TearDownSuite() {
 
 func (s *ConnScraperTestSuite) TestConnScraper() {
 	endpoints, err := s.GetEndpoints(s.serverContainer)
-	if (!s.turnOffScrape) {
+	if (!s.turnOffScrape && ) {
 		// If scraping is on we expect to find the nginx endpoint
 		s.Require().NoError(err)
 		assert.Equal(s.T(), 1, len(endpoints))

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -109,8 +109,8 @@ func TestRepeatedNetworkFlowThreeCurlsNoAfterglow(t *testing.T) {
 // endpoint opened before collector is turned on.
 func TestConnScraper(t *testing.T) {
 	connScraperTestSuite := &ConnScraperTestSuite{
-		turnOffScrape:	false
-		roxProcessesListeningOnPort: true
+		turnOffScrape:	false,
+		roxProcessesListeningOnPort: true,
 	}
 	suite.Run(t, connScraperTestSuite)
 }
@@ -575,7 +575,7 @@ func (s *ConnScraperTestSuite) SetupSuite() {
 	s.collector = NewCollectorManager(s.executor, s.T().Name())
 
 	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":` + strconv.FormatBool(s.turnOffScrape) + `,"scrapeInterval":2}`
-	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = s.RoxProcessesListeningOnPort
+	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = strconv.FormatBool(s.roxProcessesListeningOnPort)
 
 	s.launchNginx()
 
@@ -616,7 +616,7 @@ func (s *ConnScraperTestSuite) TearDownSuite() {
 
 func (s *ConnScraperTestSuite) TestConnScraper() {
 	endpoints, err := s.GetEndpoints(s.serverContainer)
-	if (!s.turnOffScrape && ) {
+	if (!s.turnOffScrape && s.roxProcessesListeningOnPort) {
 		// If scraping is on we expect to find the nginx endpoint
 		s.Require().NoError(err)
 		assert.Equal(s.T(), 1, len(endpoints))

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -601,7 +601,6 @@ func (s *ConnScraperTestSuite) TearDownSuite() {
 }
 
 func (s *ConnScraperTestSuite) TestConnScraper() {
-	fmt.Println(s.serverContainer)
 	endpoints, err := s.GetEndpoints(s.serverContainer)
 	if (!s.turnOffScrape) {
 		// If scraping is on we expect to find the nginx endpoint
@@ -741,7 +740,7 @@ func (s *IntegrationTestSuiteBase) GetProcesses(containerID string) ([]ProcessIn
 			return fmt.Errorf("Container bucket %s not found!", containerID)
 		}
 
-		container.ForEach(func(k, v []byte) error {
+		return container.ForEach(func(k, v []byte) error {
 			pinfo, err := NewProcessInfo(string(v))
 			if err != nil {
 				return err
@@ -766,7 +765,6 @@ func (s *IntegrationTestSuiteBase) GetProcesses(containerID string) ([]ProcessIn
 			processes = append(processes, *pinfo)
 			return nil
 		})
-		return nil
 	})
 
 	if err != nil {
@@ -792,7 +790,7 @@ func (s *IntegrationTestSuiteBase) GetEndpoints(containerID string) ([]EndpointI
 			return fmt.Errorf("Container bucket %s not found!", containerID)
 		}
 
-		container.ForEach(func(k, v []byte) error {
+		return container.ForEach(func(k, v []byte) error {
 			einfo, err := NewEndpointInfo(string(v))
 			if err != nil {
 				return err
@@ -801,7 +799,6 @@ func (s *IntegrationTestSuiteBase) GetEndpoints(containerID string) ([]EndpointI
 			endpoints = append(endpoints, *einfo)
 			return nil
 		})
-		return nil
 	})
 
 	if err != nil {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -608,7 +608,6 @@ func (s *ConnScraperTestSuite) TestConnScraper() {
 		assert.Equal(s.T(), 1, len(endpoints))
 		assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[0].Protocol)
 		assert.Equal(s.T(), "(timestamp: nil Timestamp)", endpoints[0].CloseTimestamp)
-		assert.Equal(s.T(), "process_name:nginx process_exec_file_path:/usr/bin/nginx process_args:\n", endpoints[0].Originator)
 
 		processes, err := s.GetProcesses(s.serverContainer)
 		s.Require().NoError(err)

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -609,6 +609,12 @@ func (s *ConnScraperTestSuite) TestConnScraper() {
 		assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[0].Protocol)
 		assert.Equal(s.T(), "(timestamp: nil Timestamp)", endpoints[0].CloseTimestamp)
 		assert.Equal(s.T(), "process_name:nginx process_exec_file_path:/usr/bin/nginx process_args:\n", endpoints[0].Originator)
+
+		processes, err := s.GetProcesses(s.serverContainer)
+		s.Require().NoError(err)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessName, processes[0].Name)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessExecFilePath, processes[0].ExePath)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessArgs, processes[0].Args)
 	} else {
 		// If scraping is off we expect not to find the nginx endpoint and we should get an error
 		s.Require().Error(err)

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -601,14 +601,15 @@ func (s *ConnScraperTestSuite) TearDownSuite() {
 }
 
 func (s *ConnScraperTestSuite) TestConnScraper() {
+	fmt.Println(s.serverContainer)
 	endpoints, err := s.GetEndpoints(s.serverContainer)
 	if (!s.turnOffScrape) {
 		// If scraping is on we expect to find the nginx endpoint
 		s.Require().NoError(err)
-		assert.Equal(s.T(), len(endpoints), 1)
-		assert.Equal(s.T(), endpoints[0].Protocol, "L4_PROTOCOL_TCP")
-		assert.Equal(s.T(), endpoints[0].CloseTimestamp, "(timestamp: nil Timestamp)\n")
-
+		assert.Equal(s.T(), 1, len(endpoints))
+		assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[0].Protocol)
+		assert.Equal(s.T(), "(timestamp: nil Timestamp)", endpoints[0].CloseTimestamp)
+		assert.Equal(s.T(), "process_name:nginx process_exec_file_path:/usr/bin/nginx process_args:\n", endpoints[0].Originator)
 	} else {
 		// If scraping is off we expect not to find the nginx endpoint and we should get an error
 		s.Require().Error(err)

--- a/integration-tests/process_originator.go
+++ b/integration-tests/process_originator.go
@@ -28,32 +28,20 @@ func NewProcessOriginator(line string) (*ProcessOriginator, error) {
 		return nil, fmt.Errorf("ProcessOriginator is nil")
 	}
 
-	r := regexp.MustCompile("process_name:(.*)process_exec_file_path:")
-	processNameArr := r.FindStringSubmatch(line)
-	if len(processNameArr) !=2 {
-		return nil, fmt.Errorf("Could not find process_name in %s", line)
-	}
-	processName := removeQuotesAndWhiteSpace(processNameArr[1])
-
-	r = regexp.MustCompile("process_exec_file_path:(.*)process_args:")
-	processExecFilePathArr := r.FindStringSubmatch(line)
-	if len(processExecFilePathArr) !=2 {
-		r = regexp.MustCompile("process_exec_file_path:(.*)\n$")
-		processExecFilePathArr = r.FindStringSubmatch(line)
-		if len(processExecFilePathArr) !=2 {
-			return nil, fmt.Errorf("Could not find process_exec_file_path in %s", line)
-		}
-	}
-	processExecFilePath := removeQuotesAndWhiteSpace(processExecFilePathArr[1])
-
-	r = regexp.MustCompile("process_args:(.*)\n$")
-	processArgsArr := r.FindStringSubmatch(line)
 	var processArgs string
-	if len(processArgsArr) !=2 {
-		processArgs = ""
+	r := regexp.MustCompile("process_name:(.*)process_exec_file_path:(.*)process_args(.*)\n$")
+	processArr := r.FindStringSubmatch(line)
+	if len(processArr) !=4 {
+		r := regexp.MustCompile("process_name:(.*)process_exec_file_path:(.*)\n$")
+		processArr := r.FindStringSubmatch(line)
+		if len(processArr) !=3 {
+			return nil, fmt.Errorf("Could not parse process originator %s", line)
+		}
 	} else {
-		processArgs = removeQuotesAndWhiteSpace(processArgsArr[1])
+		processArgs = removeQuotesAndWhiteSpace(processArr[3])
 	}
+	processName := removeQuotesAndWhiteSpace(processArr[1])
+	processExecFilePath := removeQuotesAndWhiteSpace(processArr[2])
 
 	return &ProcessOriginator {
 		ProcessName: processName,

--- a/integration-tests/process_originator.go
+++ b/integration-tests/process_originator.go
@@ -1,0 +1,50 @@
+package integrationtests
+
+import (
+	//"strings"
+	"fmt"
+	"regexp"
+)
+
+type ProcessOriginator struct {
+	ProcessName string
+	ProcessExecFilePath string
+	ProcessArgs string
+}
+
+func NewProcessOriginator(line string) (*ProcessOriginator, error) {
+	if line == "<nil>\n" {
+		return nil, fmt.Errorf("ProcessOriginator is nil")
+	}
+
+	r := regexp.MustCompile("process_name:(.*)process_exec_file_path:")
+	processNameArr := r.FindStringSubmatch(line)
+	if len(processNameArr) !=2 {
+		return nil, fmt.Errorf("Could not find process_name in %s", line)
+	}
+	processName := processNameArr[1]
+	fmt.Println("processName= " + processName)
+
+	r = regexp.MustCompile("process_exec_file_path:(.*)process_args:")
+	processExecFilePathArr := r.FindStringSubmatch(line)
+	if len(processExecFilePathArr) !=2 {
+		return nil, fmt.Errorf("Could not find process_exec_file_path in %s", line)
+	}
+	processExecFilePath := processExecFilePathArr[1]
+	fmt.Println("processExecFilePath= " + processExecFilePath)
+
+	r = regexp.MustCompile("process_args:(.*)$")
+	processArgsArr := r.FindStringSubmatch(line)
+	if len(processArgsArr) !=2 {
+		return nil, fmt.Errorf("Could not find process_args in %s", line)
+	}
+	processArgs := processArgsArr[1]
+	fmt.Println("processArgs= " + processArgs)
+
+
+	return &ProcessOriginator {
+		ProcessName: processName,
+		ProcessExecFilePath: processExecFilePath,
+		ProcessArgs: processArgs,
+	}, nil
+}

--- a/integration-tests/process_originator.go
+++ b/integration-tests/process_originator.go
@@ -1,7 +1,7 @@
 package integrationtests
 
 import (
-	//"strings"
+	"strings"
 	"fmt"
 	"regexp"
 )
@@ -10,6 +10,17 @@ type ProcessOriginator struct {
 	ProcessName string
 	ProcessExecFilePath string
 	ProcessArgs string
+}
+
+func removeQuotesAndWhiteSpace(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 func NewProcessOriginator(line string) (*ProcessOriginator, error) {
@@ -22,25 +33,27 @@ func NewProcessOriginator(line string) (*ProcessOriginator, error) {
 	if len(processNameArr) !=2 {
 		return nil, fmt.Errorf("Could not find process_name in %s", line)
 	}
-	processName := processNameArr[1]
-	fmt.Println("processName= " + processName)
+	processName := removeQuotesAndWhiteSpace(processNameArr[1])
 
 	r = regexp.MustCompile("process_exec_file_path:(.*)process_args:")
 	processExecFilePathArr := r.FindStringSubmatch(line)
 	if len(processExecFilePathArr) !=2 {
-		return nil, fmt.Errorf("Could not find process_exec_file_path in %s", line)
+		r = regexp.MustCompile("process_exec_file_path:(.*)\n$")
+		processExecFilePathArr = r.FindStringSubmatch(line)
+		if len(processExecFilePathArr) !=2 {
+			return nil, fmt.Errorf("Could not find process_exec_file_path in %s", line)
+		}
 	}
-	processExecFilePath := processExecFilePathArr[1]
-	fmt.Println("processExecFilePath= " + processExecFilePath)
+	processExecFilePath := removeQuotesAndWhiteSpace(processExecFilePathArr[1])
 
-	r = regexp.MustCompile("process_args:(.*)$")
+	r = regexp.MustCompile("process_args:(.*)\n$")
 	processArgsArr := r.FindStringSubmatch(line)
+	var processArgs string
 	if len(processArgsArr) !=2 {
-		return nil, fmt.Errorf("Could not find process_args in %s", line)
+		processArgs = ""
+	} else {
+		processArgs = removeQuotesAndWhiteSpace(processArgsArr[1])
 	}
-	processArgs := processArgsArr[1]
-	fmt.Println("processArgs= " + processArgs)
-
 
 	return &ProcessOriginator {
 		ProcessName: processName,

--- a/integration-tests/process_originator.go
+++ b/integration-tests/process_originator.go
@@ -33,8 +33,8 @@ func NewProcessOriginator(line string) (*ProcessOriginator, error) {
 	processArr := r.FindStringSubmatch(line)
 	if len(processArr) !=4 {
 		r := regexp.MustCompile("process_name:(.*)process_exec_file_path:(.*)\n$")
-		processArr := r.FindStringSubmatch(line)
-		if len(processArr) !=3 {
+		processArr = r.FindStringSubmatch(line)
+		if len(processArr) != 3 {
 			return nil, fmt.Errorf("Could not parse process originator %s", line)
 		}
 	} else {


### PR DESCRIPTION
## Description

The ConnScraper integration test which checks endpoint information sent by collector will now check that the endpoint information includes the process originator. This PR is related to https://github.com/stackrox/collector/pull/868

The difference between the two PRs is that this one will pass once Collector reports process data in the endpoints and the one linked to will pass if Collector doesn't report process data. This means that integration tests here will fail. See "Testing Performed" to see how to test this locally.

## Checklist
- [ ] Investigated and inspected CI test results

**Automated testing**
  - [x] Added integration tests

## Testing Performed

git checkout ovalenti/ROX-12803-add-process-info-to-network-endpoints
make clean
make
git checkout jv-rox-13015-collector-integration-tests-should-check-for-process-info-in-endpoints-and-find-it
make
make integration-tests-connscraper

Checking out the first branch and building the collector there make it so that the tests are run using the branch that adds process information to endpoints.