### PR TITLE
Add a function for propagating CI environment in integration tests

### DIFF
--- a/.openshift-ci/jobs/integration-tests/run-integration-tests.sh
+++ b/.openshift-ci/jobs/integration-tests/run-integration-tests.sh
@@ -60,6 +60,16 @@ function save_artifacts() {
     fi
 }
 
+function propagate_ci_env() {
+    echo "${OFFLINE}"
+
+    if [[ "${OFFLINE,,}" != "false" ]]; then
+        export COLLECTOR_OFFLINE_MODE="true"
+    fi
+}
+
+propagate_ci_env
+
 exit_code=0
 
 if [[ $REMOTE_HOST_TYPE != "local" ]]; then

--- a/.openshift-ci/jobs/integration-tests/run-integration-tests.sh
+++ b/.openshift-ci/jobs/integration-tests/run-integration-tests.sh
@@ -61,8 +61,6 @@ function save_artifacts() {
 }
 
 function propagate_ci_env() {
-    echo "${OFFLINE}"
-
     if [[ "${OFFLINE,,}" != "false" ]]; then
         export COLLECTOR_OFFLINE_MODE="true"
     fi


### PR DESCRIPTION
## Description

A function has been added to the `run-integration-tests.sh` script for CI environment to be propagated into the tests by exporting environment variables.

The only variable being propagated right now is OFFLINE so that integration tests can be run in offline mode, this function could be extended to other environment variables or PR labels in the future.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Green CI
- [ ] Rehearse on openshift/release#32765 which needs this working.