### PR TITLE
Fix bucket used for cpaas images

### DIFF
--- a/.openshift-ci/build/Dockerfile.cpaas
+++ b/.openshift-ci/build/Dockerfile.cpaas
@@ -7,7 +7,7 @@ COPY /.openshift-ci/build/build-driver-cache.sh /scripts/build-driver-cache.sh
 RUN export MODULE_VERSION="$(cat /MODULE_VERSION)" && \
     mkdir -p "/kernel-modules/${MODULE_VERSION}" && \
     gsutil -m rsync -r \
-        "gs://collector-modules-osci-public/cpaas//$MODULE_VERSION/" \
+        "gs://collector-modules-osci-public/cpaas/$MODULE_VERSION/" \
         "/kernel-modules/$MODULE_VERSION/" || true
 
 RUN /scripts/build-driver-cache.sh


### PR DESCRIPTION
## Description

The additional `/` in the bucket name makes it so `gsutil` fails to properly download drivers into the image.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] rehearsed on openshift/release#32765
