### PR TITLE
ROX-13095 endpoint should be reported closed when it is closed by a process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,11 @@ integration-tests-procfsscaper:
 	make -C integration-tests procfsscraper ||\
 		( .openshift-ci/slack/notify-if-needed.sh "procfsscaper" $$? )
 
+.PHONY: integration-tests-process-listening-on-port
+integration-tests-process-listening-on-port:
+	make -C integration-tests process-listening-on-port ||\
+		( .openshift-ci/slack/notify-if-needed.sh "process-listening-on-port" $$? )
+
 .PHONY: integration-tests-report
 integration-tests-report:
 	make -C integration-tests report

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ ci-integration-tests: integration-tests-repeat-network \
 					  integration-tests-missing-proc-scrape \
 					  integration-tests-image-label-json \
 					  integration-tests-procfsscaper \
+					  integration-tests-process-listening-on-ports \
 					  integration-tests-report
 
 .PHONY: ci-benchmarks

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ ci-integration-tests: integration-tests-repeat-network \
 					  integration-tests-missing-proc-scrape \
 					  integration-tests-image-label-json \
 					  integration-tests-procfsscaper \
-					  integration-tests-process-listening-on-ports \
+					  integration-tests-process-listening-on-port \
 					  integration-tests-report
 
 .PHONY: ci-benchmarks

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -68,6 +68,13 @@ procfsscraper: docker-clean
 	go test -timeout 90m -count=1 -v \
 	  -run TestProcfsScraper 2>&1 | tee -a integration-test.log
 
+.PHONY: process-listening-on-port
+process-listening-on-port: docker-clean
+	go version
+	set -o pipefail ; \
+	go test -timeout 90m -count=1 -v \
+	  -run TestProcessListeningOnPort 2>&1 | tee -a integration-test.log
+
 .PHONY: report
 report:
 	go get -u github.com/jstemmer/go-junit-report

--- a/integration-tests/container/processes-listening-on-ports/Dockerfile
+++ b/integration-tests/container/processes-listening-on-ports/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:jammy
+
+COPY process-listening-on-ports.c /process-listening-on-ports.c
+
+RUN apt update -y && apt install gcc lsof -y
+RUN gcc process-listening-on-ports.c -o process-listening-on-ports
+
+EXPOSE 8081 8081
+EXPOSE 9091 9091
+
+ENTRYPOINT /process-listening-on-ports

--- a/integration-tests/container/processes-listening-on-ports/Dockerfile
+++ b/integration-tests/container/processes-listening-on-ports/Dockerfile
@@ -5,7 +5,4 @@ COPY process-listening-on-ports.c /process-listening-on-ports.c
 RUN apt update -y && apt install gcc lsof -y
 RUN gcc process-listening-on-ports.c -o process-listening-on-ports
 
-EXPOSE 8081 8081
-EXPOSE 9091 9091
-
 ENTRYPOINT /process-listening-on-ports

--- a/integration-tests/container/processes-listening-on-ports/Makefile
+++ b/integration-tests/container/processes-listening-on-ports/Makefile
@@ -1,0 +1,17 @@
+.DEFAULT_GOAL = all
+
+COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS := collector-processes-listening-on-ports
+
+COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG=collector-processes-listening-on-ports
+ifneq ($(COLLECTOR_QA_TAG),)
+COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG=collector-processes-listening-on-ports-$(COLLECTOR_QA_TAG)
+endif
+
+.PHONY: all
+all:
+	@docker build -t quay.io/rhacs-eng/qa:$(COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG) .
+
+.PHONY: push
+push:
+	@docker push quay.io/rhacs-eng/qa:$(COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG)
+

--- a/integration-tests/container/processes-listening-on-ports/Makefile
+++ b/integration-tests/container/processes-listening-on-ports/Makefile
@@ -1,8 +1,7 @@
 .DEFAULT_GOAL = all
 
-COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS := collector-processes-listening-on-ports
+COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG := collector-processes-listening-on-ports
 
-COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG=collector-processes-listening-on-ports
 ifneq ($(COLLECTOR_QA_TAG),)
 COLLECTOR_QA_PROCESSES_LISTENING_ON_PORTS_TAG=collector-processes-listening-on-ports-$(COLLECTOR_QA_TAG)
 endif

--- a/integration-tests/container/processes-listening-on-ports/process-listening-on-ports.c
+++ b/integration-tests/container/processes-listening-on-ports/process-listening-on-ports.c
@@ -41,30 +41,12 @@ int openPort(int port) {
 }
 
 void closePort(int server_fd) {
-	shutdown(server_fd, SHUT_RDWR);
+	close(server_fd);
 }
 
-char *readToken(FILE *file)
-{
-    char *code;
-    size_t n = 0;
-    int c;
-
-    code = malloc(1000);
-
-    while ((c = fgetc(file)) != EOF)
-    {
-	if ((char) c == ' ') break;
-        code[n++] = (char) c;
-    }
-
-    code[n] = '\0';
-
-    return code;
-}
-
-char *getActionFromFile(char actionFile[], int *port) {
+int getActionFromFile(char actionFile[], char action[]) {
 	FILE* ptr;
+	int port;
 
 	ptr = fopen(actionFile, "r");
 
@@ -73,29 +55,23 @@ char *getActionFromFile(char actionFile[], int *port) {
 		ptr = fopen(actionFile, "r");
 	}
 
-	char *port_str = malloc(16 * sizeof(char));
-	char *action = malloc(16 * sizeof(char));
-
-	action = readToken(ptr);
-	port_str = readToken(ptr);
-
-	*port = atoi(port_str);
+	fscanf(ptr, "%s %d", action, &port);
 
 	fclose(ptr);
 	remove(actionFile);
 
-	return action;
+	return port;
 }
 
 int main(int argc, char const* argv[])
 {
 	int port;
 	int server_fd[65535];
-	char* action;
+	char *action = malloc(16 * sizeof(char));
 	char* actionFile = "/tmp/action_file.txt";
 
 	while (1) {
-		action = getActionFromFile(actionFile, &port);
+		port = getActionFromFile(actionFile, action);
 		printf("action= %s port= %i\n", action, port);
 		if (strcmp(action, "open") == 0) {
 			server_fd[port] = openPort(port);
@@ -105,7 +81,6 @@ int main(int argc, char const* argv[])
 			printf("Unknown action: %s\n", action);
 		}
 	}
-
 
 	return 0;
 }

--- a/integration-tests/container/processes-listening-on-ports/process-listening-on-ports.c
+++ b/integration-tests/container/processes-listening-on-ports/process-listening-on-ports.c
@@ -1,0 +1,111 @@
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <string.h>
+
+int openPort(int port) {
+	int server_fd;
+	struct sockaddr_in address;
+	int opt = 1;
+
+	if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("socket failed");
+		exit(EXIT_FAILURE);
+	}
+
+	if (setsockopt(server_fd, SOL_SOCKET,
+				SO_REUSEADDR | SO_REUSEPORT, &opt,
+				sizeof(opt))) {
+		perror("setsockopt");
+		exit(EXIT_FAILURE);
+	}
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = INADDR_ANY;
+	address.sin_port = htons(port);
+
+	if (bind(server_fd, (struct sockaddr*)&address,
+			sizeof(address))
+		< 0) {
+		perror("bind failed");
+		exit(EXIT_FAILURE);
+	}
+	if (listen(server_fd, 3) < 0) {
+		perror("listen");
+		exit(EXIT_FAILURE);
+	}
+
+	return server_fd;
+}
+
+void closePort(int server_fd) {
+	shutdown(server_fd, SHUT_RDWR);
+}
+
+char *readToken(FILE *file)
+{
+    char *code;
+    size_t n = 0;
+    int c;
+
+    code = malloc(1000);
+
+    while ((c = fgetc(file)) != EOF)
+    {
+	if ((char) c == ' ') break;
+        code[n++] = (char) c;
+    }
+
+    code[n] = '\0';
+
+    return code;
+}
+
+char *getActionFromFile(char actionFile[], int *port) {
+	FILE* ptr;
+
+	ptr = fopen(actionFile, "r");
+
+	while (ptr == NULL) {
+		sleep(1);
+		ptr = fopen(actionFile, "r");
+	}
+
+	char *port_str = malloc(16 * sizeof(char));
+	char *action = malloc(16 * sizeof(char));
+
+	action = readToken(ptr);
+	port_str = readToken(ptr);
+
+	*port = atoi(port_str);
+
+	fclose(ptr);
+	remove(actionFile);
+
+	return action;
+}
+
+int main(int argc, char const* argv[])
+{
+	int port;
+	int server_fd[65535];
+	char* action;
+	char* actionFile = "/tmp/action_file.txt";
+
+	while (1) {
+		action = getActionFromFile(actionFile, &port);
+		printf("action= %s port= %i\n", action, port);
+		if (strcmp(action, "open") == 0) {
+			server_fd[port] = openPort(port);
+		} else if (strcmp(action, "close") == 0) {
+			closePort(server_fd[port]);
+		} else {
+			printf("Unknown action: %s\n", action);
+		}
+	}
+
+
+	return 0;
+}

--- a/integration-tests/endpoint.go
+++ b/integration-tests/endpoint.go
@@ -7,7 +7,7 @@ import (
 
 type EndpointInfo struct {
 	Protocol string
-	ListenAddress string
+	Address *ListenAddress
 	CloseTimestamp string
 	Originator *ProcessOriginator
 }
@@ -25,9 +25,15 @@ func NewEndpointInfo(line string) (*EndpointInfo, error) {
 		return nil, err
 	}
 
+	listenAddress, err := NewListenAddress(parts[2])
+
+	if err != nil {
+		return nil, err
+	}
+
 	return &EndpointInfo {
 		Protocol: parts[1],
-		ListenAddress: parts[2],
+		Address: listenAddress,
 		CloseTimestamp: parts[3],
 		Originator: originator,
 	}, nil

--- a/integration-tests/listen_address.go
+++ b/integration-tests/listen_address.go
@@ -1,0 +1,35 @@
+package integrationtests
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type ListenAddress struct {
+	AddressData string
+	Port int
+	IpNetwork string
+}
+
+func NewListenAddress(line string) (*ListenAddress, error) {
+	if line == "<nil>" {
+		return nil, fmt.Errorf("ListenAddress is nil")
+	}
+
+	if line == "" {
+		return nil, fmt.Errorf("ListenAddress is empty")
+	}
+
+	r := regexp.MustCompile("address_data:(.*) port:(.*) ip_network:(.*)")
+	listenAddressArr := r.FindStringSubmatch(line)
+	addressData := listenAddressArr[1]
+	port, _ := strconv.Atoi(listenAddressArr[2])
+	ipNetwork := listenAddressArr[3]
+
+	return &ListenAddress {
+		AddressData: addressData,
+		Port: port,
+		IpNetwork: ipNetwork,
+	}, nil
+}


### PR DESCRIPTION
## Description

Adds a program that opens and closes ports that it is told to open and close. The program reads from a file with simple commands such as "open 8080" and "close 9090". Whenever the program reads a command from the file it deletes it and waits for the file to be recreated with new commands. Integration tests issue commands to this program and expected results are compared to actual results.

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
  - [x] Added integration tests

## Testing Performed

CI is sufficient.
