### PR TITLE
ROX-11447: write fatal log messages to termination log

### DIFF
--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -76,7 +76,7 @@ class CosHeuristic : public Heuristic {
                       << "collector.collectionMethod=EBPF to remove this message";
         hconfig->SetCollectionMethod("ebpf");
       } else {
-        CLOG(FATAL) << "Unable to switch to eBPF collection on this host";
+        CLOG(FATAL) << "Unable to switch to eBPF collection on " << host.GetDistro();
       }
     }
   }

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -26,6 +26,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <fstream>
 #include <string>
 #include <unordered_map>
 
@@ -125,6 +126,17 @@ const char* GetGlobalLogPrefix() {
 
 void SetGlobalLogPrefix(const char* prefix) {
   g_log_prefix.store(prefix, std::memory_order_relaxed);
+}
+
+void WriteTerminationLog(std::string message) {
+  std::ofstream tlog(TerminationLog);
+
+  // If the termination log does not exist it is likely that
+  // we're not running in k8s so otherwise do nothing. This
+  // diagnostic measure does not work in openshift.
+  if (tlog.is_open()) {
+    tlog.write(message.c_str(), message.size());
+  }
 }
 
 }  // namespace logging

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -36,6 +36,8 @@ namespace logging {
 
 namespace {
 
+const char* TerminationLog = "/dev/termination-log";
+
 std::atomic<uint32_t> g_level(static_cast<uint32_t>(LogLevel::INFO));
 std::atomic<const char*> g_log_prefix("");
 

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -55,7 +55,10 @@ bool ParseLogLevelName(std::string name, LogLevel* level);
 const char* GetGlobalLogPrefix();
 void SetGlobalLogPrefix(const char* prefix);
 
+void WriteTerminationLog(std::string message);
+
 const size_t LevelPaddingWidth = 7;
+const std::string TerminationLog = "/dev/termination-log";
 
 class LogMessage {
  public:
@@ -93,6 +96,7 @@ class LogMessage {
               << std::endl;
 
     if (level_ == LogLevel::FATAL) {
+      WriteTerminationLog(buf_.str());
       exit(1);
     }
   }

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -58,7 +58,6 @@ void SetGlobalLogPrefix(const char* prefix);
 void WriteTerminationLog(std::string message);
 
 const size_t LevelPaddingWidth = 7;
-const std::string TerminationLog = "/dev/termination-log";
 
 class LogMessage {
  public:

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -60,7 +60,7 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
   }
 
   if (signal_handlers_.empty()) {
-    CLOG(FATAL) << "There are no signal handlers";
+    CLOG(FATAL) << "Internal error: There are no signal handlers.";
   }
 
   SetChisel(config.Chisel());


### PR DESCRIPTION
## Description

Writes all `FATAL` log messages to [/dev/termination-log](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/) if that device exists. In k8s, it is used to enrich container status information, and allows us to report better errors through k8s APIs for diagnostics of Collector startup. 

Commands for getting this enriched information:

```bash
$ kubectl describe pod -n stackrox collector-cr2mf
# ...
    Last State:     Terminated
      Reason:       Error
      Message:      No suitable kernel object downloaded
      Exit Code:    1
      Started:      Fri, 21 Oct 2022 11:50:56 +0100
      Finished:     Fri, 21 Oct 2022 11:51:25 +0100
# ...

$ kubectl get pods -n stackrox collector-cr2mf -o jsonpath='{.status.containerStatuses[].lastState}' | jq .
{
  "terminated": {
    "containerID": "docker://33abaef2f6b18e06e4c8ac8dbb7c3195355faa34b288731203fcbdde7b3a1920",
    "exitCode": 1,
    "finishedAt": "2022-10-21T10:57:09Z",
    "message": "No suitable kernel object downloaded",
    "reason": "Error",
    "startedAt": "2022-10-21T10:56:30Z"
  }
}
```

This also includes some improvements to `FATAL` log messages.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally on k8s running in Colima (which has the added advantaged of using a kernel for which we don't have a kernel driver for, so collector always hits a `FATAL` error)
