### PR TITLE
ROX-13249 plop: use falco as process info source

### DIFF
--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -43,8 +43,8 @@ int main(int argc, char** argv) {
     proc_dir = argv[1];
   }
 
-  std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(proc_dir);
-  std::shared_ptr<ProcessStore> process_store = std::make_shared<ProcessStore>(process_scraper);
+  ProcessScraper process_scraper(proc_dir);
+  std::shared_ptr<ProcessStore> process_store = std::make_shared<ProcessStore>(&process_scraper);
   ConnScraper scraper(proc_dir, process_store);
   std::vector<Connection> conns;
   std::vector<ContainerEndpoint> endpoints;

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -102,7 +102,6 @@ void CollectorService::RunForever() {
       net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
                                                               conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
                                                               network_connection_info_service_comm);
-      net_status_notifier->Start();
     }
   }
 
@@ -113,6 +112,11 @@ void CollectorService::RunForever() {
 
   sysdig_.Init(config_, conn_tracker);
   sysdig_.Start();
+
+  // Sysdig process list is available, we can start NetworkStatusNotifier
+  if (net_status_notifier) {
+    net_status_notifier->Start();
+  }
 
   ControlValue cv;
   while ((cv = control_->load(std::memory_order_relaxed)) != STOP_COLLECTOR) {

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -90,8 +90,7 @@ void CollectorService::RunForever() {
     if (!config_.DisableNetworkFlows()) {
       std::shared_ptr<ProcessStore> process_store;
       if (config_.IsProcessesListeningOnPortsEnabled()) {
-        std::shared_ptr<ProcessScraper> process_scraper = std::make_shared<ProcessScraper>(config_.HostProc());
-        process_store = std::make_shared<ProcessStore>(process_scraper);
+        process_store = std::make_shared<ProcessStore>(&sysdig_);
       }
       std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
       conn_tracker = std::make_shared<ConnectionTracker>();

--- a/collector/lib/Process.h
+++ b/collector/lib/Process.h
@@ -46,6 +46,7 @@ class Process {
         args_(args),
         pid_(pid) {}
   virtual ~Process() {}
+  Process(uint64_t pid) : pid_(pid) {}
 
   const std::string& container_id() const { return container_id_; }
   const std::string& comm() const { return comm_; }

--- a/collector/lib/Process.h
+++ b/collector/lib/Process.h
@@ -85,7 +85,7 @@ class ProcessStore {
 
   /* The provided process_source is queried when
      a requested PID cannot be found in the store */
-  ProcessStore(std::shared_ptr<ISource> process_source) : process_source_(process_source) {}
+  ProcessStore(ISource* process_source) : process_source_(process_source) {}
 
   /* Get a Process by PID.
      Returns a reference to the cached Process entry, which may have just been created
@@ -103,7 +103,7 @@ class ProcessStore {
     ProcessStore& store_;
   };
 
-  std::shared_ptr<ISource> process_source_;
+  ISource* process_source_;
   std::unordered_map<uint64_t, std::weak_ptr<CachedProcess>> cache_;
 };
 

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -145,7 +145,7 @@ bool SysdigService::FilterEvent(sinsp_evt* event) {
 }
 
 sinsp_evt* SysdigService::GetNext() {
-  std::lock_guard<std::mutex> lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> lock(libsinsp_mutex_);
   sinsp_evt* event;
 
   auto parse_start = NowMicros();
@@ -176,7 +176,7 @@ sinsp_evt* SysdigService::GetNext() {
 }
 
 void SysdigService::Start() {
-  std::lock_guard<std::mutex> sysdig_lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> sysdig_lock(libsinsp_mutex_);
 
   if (!inspector_ || !chisel_) {
     throw CollectorException("Invalid state: SysdigService was not initialized");
@@ -228,7 +228,7 @@ void SysdigService::Run(const std::atomic<ControlValue>& control) {
 }
 
 bool SysdigService::SendExistingProcesses(SignalHandler* handler) {
-  std::lock_guard<std::mutex> lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> lock(libsinsp_mutex_);
 
   if (!inspector_ || !chisel_) {
     throw CollectorException("Invalid state: SysdigService was not initialized");
@@ -254,7 +254,7 @@ bool SysdigService::SendExistingProcesses(SignalHandler* handler) {
 }
 
 void SysdigService::CleanUp() {
-  std::lock_guard<std::mutex> sysdig_lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> sysdig_lock(libsinsp_mutex_);
   std::lock_guard<std::mutex> running_lock(running_mutex_);
   running_ = false;
   inspector_->close();
@@ -271,7 +271,7 @@ void SysdigService::CleanUp() {
 }
 
 bool SysdigService::GetStats(SysdigStats* stats) const {
-  std::lock_guard<std::mutex> sysdig_lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> sysdig_lock(libsinsp_mutex_);
   std::lock_guard<std::mutex> running_lock(running_mutex_);
   if (!running_ || !inspector_) return false;
 
@@ -286,7 +286,7 @@ bool SysdigService::GetStats(SysdigStats* stats) const {
 }
 
 void SysdigService::SetChisel(const std::string& chisel) {
-  std::lock_guard<std::mutex> lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> lock(libsinsp_mutex_);
   CLOG(DEBUG) << "Updating chisel and flushing chisel cache";
   CLOG(DEBUG) << "New chisel: " << chisel;
   chisel_.reset(new_chisel(inspector_.get(), chisel, false));
@@ -324,7 +324,7 @@ void SysdigService::AddSignalHandler(std::unique_ptr<SignalHandler> signal_handl
 }
 
 Process SysdigService::ByPID(uint64_t pid) {
-  std::lock_guard<std::mutex> lock(sysdig_mutex_);
+  std::lock_guard<std::mutex> lock(libsinsp_mutex_);
   threadinfo_map_t::ptr_t th_ref = inspector_->get_thread_ref(pid, true);
   if (th_ref) {
     std::string args;

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -315,4 +315,22 @@ void SysdigService::AddSignalHandler(std::unique_ptr<SignalHandler> signal_handl
   signal_handlers_.emplace_back(std::move(signal_handler), event_filter);
 }
 
+Process SysdigService::ByPID(uint64_t pid) {
+  threadinfo_map_t::ptr_t th_ref = inspector_->get_thread_ref(pid, true);
+  if (th_ref) {
+    std::string args;
+    bool first_arg = true;
+    for (auto arg : th_ref->m_args) {
+      if (first_arg) {
+        first_arg = false;
+      } else {
+        args += " ";
+      }
+      args += arg;
+    }
+    return Process(th_ref->m_container_id, th_ref->get_comm(), th_ref->get_exe(), th_ref->get_exepath(), args, pid);
+  }
+  return Process(pid);
+}
+
 }  // namespace collector

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -145,6 +145,7 @@ bool SysdigService::FilterEvent(sinsp_evt* event) {
 }
 
 sinsp_evt* SysdigService::GetNext() {
+  std::lock_guard<std::mutex> lock(running_mutex_);
   sinsp_evt* event;
 
   auto parse_start = NowMicros();
@@ -316,6 +317,7 @@ void SysdigService::AddSignalHandler(std::unique_ptr<SignalHandler> signal_handl
 }
 
 Process SysdigService::ByPID(uint64_t pid) {
+  std::lock_guard<std::mutex> lock(running_mutex_);
   threadinfo_map_t::ptr_t th_ref = inspector_->get_thread_ref(pid, true);
   if (th_ref) {
     std::string args;

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -93,7 +93,7 @@ class SysdigService : public Sysdig, public ProcessStore::ISource {
 
   void AddSignalHandler(std::unique_ptr<SignalHandler> signal_handler);
 
-  mutable std::mutex sysdig_mutex_;
+  mutable std::mutex libsinsp_mutex_;
   std::unique_ptr<sinsp> inspector_;
   std::unique_ptr<sinsp_chisel> chisel_;
   std::vector<SignalHandlerEntry> signal_handlers_;

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -93,6 +93,7 @@ class SysdigService : public Sysdig, public ProcessStore::ISource {
 
   void AddSignalHandler(std::unique_ptr<SignalHandler> signal_handler);
 
+  mutable std::mutex sysdig_mutex_;
   std::unique_ptr<sinsp> inspector_;
   std::unique_ptr<sinsp_chisel> chisel_;
   std::vector<SignalHandlerEntry> signal_handlers_;

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -37,12 +37,13 @@ You should have received a copy of the GNU General Public License along with thi
 // clang-format on
 
 #include "Control.h"
+#include "Process.h"
 #include "SignalHandler.h"
 #include "Sysdig.h"
 
 namespace collector {
 
-class SysdigService : public Sysdig {
+class SysdigService : public Sysdig, public ProcessStore::ISource {
  public:
   static constexpr char kModulePath[] = "/module/collector.ko";
   static constexpr char kModuleName[] = "collector";
@@ -62,6 +63,9 @@ class SysdigService : public Sysdig {
   bool GetStats(SysdigStats* stats) const override;
 
   bool InitKernel(const CollectorConfig& config) override;
+
+  // implementation of ProcessStore::ISource
+  Process ByPID(uint64_t pid) override;
 
  private:
   enum ChiselCacheStatus : int {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -655,34 +655,29 @@ func (s *ProcfsScraperTestSuite) TearDownSuite() {
 }
 
 func (s *ProcfsScraperTestSuite) TestProcfsScraper() {
-	var imageFamily = os.Getenv("IMAGE_FAMILY")
-	// TODO: These tests fail for rhel-7, ubuntu-pro-1804-lts, sles-12, and sometimes for ubuntu-2204-lts.
-	// Make the tests pass for them and remove this if statement
-	if imageFamily != "rhel-7" && imageFamily != "ubuntu-pro-1804-lts" && imageFamily != "sles-12" && imageFamily!= "ubuntu-2204-lts" {
-		endpoints, err := s.GetEndpoints(s.serverContainer)
-		if (!s.turnOffScrape && s.roxProcessesListeningOnPort) {
-			// If scraping is on and the feature flag is enables we expect to find the nginx endpoint
-			s.Require().NoError(err)
-			assert.Equal(s.T(), 2, len(endpoints))
-			processes, err := s.GetProcesses(s.serverContainer)
-			s.Require().NoError(err)
+	endpoints, err := s.GetEndpoints(s.serverContainer)
+	if (!s.turnOffScrape && s.roxProcessesListeningOnPort) {
+		// If scraping is on and the feature flag is enables we expect to find the nginx endpoint
+		s.Require().NoError(err)
+		assert.Equal(s.T(), 2, len(endpoints))
+		processes, err := s.GetProcesses(s.serverContainer)
+		s.Require().NoError(err)
 
-			assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[0].Protocol)
-			assert.Equal(s.T(), "(timestamp: nil Timestamp)", endpoints[0].CloseTimestamp)
-			assert.Equal(s.T(), endpoints[0].Originator.ProcessName, processes[0].Name)
-			assert.Equal(s.T(), endpoints[0].Originator.ProcessExecFilePath, processes[0].ExePath)
-			assert.Equal(s.T(), endpoints[0].Originator.ProcessArgs, processes[0].Args)
+		assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[0].Protocol)
+		assert.Equal(s.T(), "(timestamp: nil Timestamp)", endpoints[0].CloseTimestamp)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessName, processes[0].Name)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessExecFilePath, processes[0].ExePath)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessArgs, processes[0].Args)
 
-			assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[1].Protocol)
-			assert.NotEqual(s.T(), "(timestamp: nil Timestamp)", endpoints[1].CloseTimestamp)
-			assert.Equal(s.T(), endpoints[1].Originator.ProcessName, processes[0].Name)
-			assert.Equal(s.T(), endpoints[1].Originator.ProcessExecFilePath, processes[0].ExePath)
-			assert.Equal(s.T(), endpoints[1].Originator.ProcessArgs, processes[0].Args)
-		} else {
-			// If scraping is off or the feature flag is disabled
-			// we expect not to find the nginx endpoint and we should get an error
-			s.Require().Error(err)
-		}
+		assert.Equal(s.T(), "L4_PROTOCOL_TCP", endpoints[1].Protocol)
+		assert.NotEqual(s.T(), "(timestamp: nil Timestamp)", endpoints[1].CloseTimestamp)
+		assert.Equal(s.T(), endpoints[1].Originator.ProcessName, processes[0].Name)
+		assert.Equal(s.T(), endpoints[1].Originator.ProcessExecFilePath, processes[0].ExePath)
+		assert.Equal(s.T(), endpoints[1].Originator.ProcessArgs, processes[0].Args)
+	} else {
+		// If scraping is off or the feature flag is disabled
+		// we expect not to find the nginx endpoint and we should get an error
+		s.Require().Error(err)
 	}
 }
 


### PR DESCRIPTION
## Description

Using /proc as the only source of process information exposes us to cmdline being modified by the process (as is the case for nginx). Here, we replace our ProcessStore::ISource by the falco library, which keeps information as seen in the fork syscall.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
  - ~~[ ] Added unit tests~~
  - ~~[ ] Added integration tests~~ Those are already in place and show the issues
  - ~~[ ] Added regression tests~~

## Testing Performed
