### PR TITLE
Only append CID on PR builds

### DIFF
--- a/.openshift-ci/build/build-collector.sh
+++ b/.openshift-ci/build/build-collector.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+CI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+# shellcheck source=SCRIPTDIR/../../scripts/lib.sh
+source "${CI_ROOT}/scripts/lib.sh"
+
 export DISABLE_PROFILING="true"
 export CMAKE_BUILD_DIR="$SRC_ROOT_DIR/cmake-build"
-export COLLECTOR_APPEND_CID=true
+
+if ! is_in_PR_context; then
+    export COLLECTOR_APPEND_CID=true
+fi
 
 make -C "$SRC_ROOT_DIR/collector" pre-build
 "$SRC_ROOT_DIR/builder/build/build-collector.sh"

--- a/.openshift-ci/build/build-collector.sh
+++ b/.openshift-ci/build/build-collector.sh
@@ -9,7 +9,7 @@ source "${CI_ROOT}/scripts/lib.sh"
 export DISABLE_PROFILING="true"
 export CMAKE_BUILD_DIR="$SRC_ROOT_DIR/cmake-build"
 
-if ! is_in_PR_context; then
+if is_in_PR_context; then
     export COLLECTOR_APPEND_CID=true
 fi
 

--- a/.openshift-ci/build/build-collector.sh
+++ b/.openshift-ci/build/build-collector.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 CI_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
-# shellcheck source=SCRIPTDIR/../../scripts/lib.sh
+# shellcheck source=SCRIPTDIR/../scripts/lib.sh
 source "${CI_ROOT}/scripts/lib.sh"
 
 export DISABLE_PROFILING="true"

--- a/.openshift-ci/scripts/lib.sh
+++ b/.openshift-ci/scripts/lib.sh
@@ -237,6 +237,8 @@ registry_rw_login() {
 if [[ "${CI_DATA:-}" == "" ]]; then
     export CI_DATA="available"
 
-    # shellcheck source=/dev/null
-    source /ci-data/dump.sh
+    if [[ -f /ci-data/dump.sh ]]; then
+        # shellcheck source=/dev/null
+        source /ci-data/dump.sh
+    fi
 fi


### PR DESCRIPTION
## Description

When running from PRs, the URL used for driver download gets a `cid=collector` parameter appended to it, this is done for some internal filtering. When we migrated to OSCI, this extra parameter has been added to all versions of collector, it has no functional impact on it, but we should still only add it when it is actually needed.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

If any of these don't apply, please comment below.

## Testing Performed
Testing will need to happen once we merge to master or by removing the `export COLLECTOR_APPEND_CID=true` line altogether.