### PR TITLE
Catch integration test failures and fail after all variations are done

### DIFF
--- a/ansible/run-integration-tests.yml
+++ b/ansible/run-integration-tests.yml
@@ -21,6 +21,10 @@
         cmd: "docker login -u {{ quay_username }} --password-stdin quay.io"
         stdin: "{{ quay_password }}"
 
+    - name: Set tests as successful
+      set_fact:
+        success: true
+
     #
     # Separation of collection method is only possible with a separate
     # task file, because we need to loop over a set of tasks to ensure
@@ -35,3 +39,7 @@
         - ebpf
         - kernel_module
 
+    - name: Check results
+      ansible.builtin.fail:
+        msg: Tests failed
+      when: success == false

--- a/ansible/run-integration-tests.yml
+++ b/ansible/run-integration-tests.yml
@@ -21,6 +21,9 @@
         cmd: "docker login -u {{ quay_username }} --password-stdin quay.io"
         stdin: "{{ quay_password }}"
 
+    # 'success' will be set to false in the Run Integration Tests step
+    # if any test fails. After the tests run, the Check results step
+    # will cause a global failure if 'success' is set to false.
     - name: Set tests as successful
       set_fact:
         success: true

--- a/ansible/tasks/test-collection-method.yml
+++ b/ansible/tasks/test-collection-method.yml
@@ -13,21 +13,27 @@
 - name: Cleanup old containers
   shell: "docker rm -f $(docker ps -aq) >/dev/null 2>&1 || true"
 
-- name: Run integration tests
-  shell: "make -C {{ collector_root }}/integration-tests {{ collector_test | default('ci-integration-tests') }}"
-  environment:
-    COLLECTION_METHOD: "{{ collection_method }}"
-  register: test_result
-  delegate_to: localhost
+- block:
+  - name: Run integration tests
+    shell: "make -C {{ collector_root }}/integration-tests {{ collector_test | default('ci-integration-tests') }}"
+    environment:
+      COLLECTION_METHOD: "{{ collection_method }}"
+    register: test_result
+    delegate_to: localhost
 
-- name: Write integration test log
-  copy:
-    content: "{{ test_result.stdout }}"
-    dest: "{{ logs_root }}/integration-test.log"
-  delegate_to: localhost
+  - name: Write integration test log
+    copy:
+      content: "{{ test_result.stdout }}"
+      dest: "{{ logs_root }}/integration-test.log"
+    delegate_to: localhost
 
-- name: Report
-  shell: "make -C {{ collector_root }}/integration-tests report"
-  environment:
-    LOG_FILE: "{{ logs_root }}/integration-test.log"
-  delegate_to: localhost
+  - name: Report
+    shell: "make -C {{ collector_root }}/integration-tests report"
+    environment:
+      LOG_FILE: "{{ logs_root }}/integration-test.log"
+    delegate_to: localhost
+
+  rescue:
+  - name: Set tests as failed
+    set_fact:
+      success: false


### PR DESCRIPTION
## Description

This change makes it so if one of the integration test running with eBPF fails, the tests with kernel-modules still executes.

<details>
<summary>Example log of test failing and continuing to run.</summary>

```
PLAY [Create VMs] ******************************************************************************************************************************************

PLAY [Provision VMs] ***************************************************************************************************************************************

PLAY [Run integration tests] *******************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]
ok: [collector-dev-rhel-8-mmoltras]

TASK [Log into quay.io] ************************************************************************************************************************************
changed: [collector-dev-rhel-7-mmoltras]

TASK [Set tests as successful] *****************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]

TASK [Run Integration Tests] *******************************************************************************************************************************
included: /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/tasks/test-collection-method.yml for collector-dev-rhel-7-mmoltras => (item=ebpf)
included: /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/tasks/test-collection-method.yml for collector-dev-rhel-7-mmoltras => (item=kernel_module)

TASK [Log into quay.io] ************************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras]

TASK [set_fact] ********************************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]

TASK [Set tests as successful] *****************************************************************************************************************************
ok: [collector-dev-rhel-8-mmoltras]

TASK [Run Integration Tests] *******************************************************************************************************************************
included: /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/tasks/test-collection-method.yml for collector-dev-rhel-8-mmoltras => (item=ebpf)
included: /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/tasks/test-collection-method.yml for collector-dev-rhel-8-mmoltras => (item=kernel_module)

TASK [set_fact] ********************************************************************************************************************************************
ok: [collector-dev-rhel-8-mmoltras]

TASK [Cleanup old containers] ******************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras]

TASK [Cleanup old containers] ******************************************************************************************************************************
changed: [collector-dev-rhel-7-mmoltras]

TASK [Run integration tests] *******************************************************************************************************************************
fatal: [collector-dev-rhel-7-mmoltras -> localhost]: FAILED! => {
    "changed": true,
    "cmd": "make -C /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/../integration-tests process-listening-on-port",
    "delta": "0:01:01.573167",
    "end": "2022-11-07 17:59:35.647923",
    "rc": 2,
    "start": "2022-11-07 17:58:34.074756"
}

STDOUT:

docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
go version
go version go1.19.2 darwin/amd64
set -o pipefail ; \
	go test -timeout 90m -count=1 -v \
	  -run TestProcessListeningOnPort 2>&1 | tee -a integration-test.log
=== RUN   TestProcessListeningOnPort
Error: Checking if container running
    require.go:794:
        	Error Trace:	integration_test.go:746
        	            				suite.go:64
        	            				integration_test.go:135
        	Error:      	Received unexpected error:
        	            	strconv.ParseBool: parsing "/etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory\ntrue": invalid syntax
        	Test:       	TestProcessListeningOnPort
--- FAIL: TestProcessListeningOnPort (58.25s)
FAIL
exit status 1
FAIL	github.com/stackrox/collector/integration-tests	58.910s


STDERR:

make: *** [process-listening-on-port] Error 1


MSG:

non-zero return code

TASK [Set tests as failed] *********************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]

TASK [set_fact] ********************************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]

TASK [Cleanup old containers] ******************************************************************************************************************************
changed: [collector-dev-rhel-7-mmoltras]

TASK [Run integration tests] *******************************************************************************************************************************
fatal: [collector-dev-rhel-7-mmoltras -> localhost]: FAILED! => {
    "changed": true,
    "cmd": "make -C /Users/mmoltras/go/src/github.com/stackrox/collector/ansible/../integration-tests process-listening-on-port",
    "delta": "0:00:58.255933",
    "end": "2022-11-07 18:00:39.830478",
    "rc": 2,
    "start": "2022-11-07 17:59:41.574545"
}

STDOUT:

docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
go version
go version go1.19.2 darwin/amd64
set -o pipefail ; \
	go test -timeout 90m -count=1 -v \
	  -run TestProcessListeningOnPort 2>&1 | tee -a integration-test.log
=== RUN   TestProcessListeningOnPort
Error: Checking if container running
    require.go:794:
        	Error Trace:	integration_test.go:746
        	            				suite.go:64
        	            				integration_test.go:135
        	Error:      	Received unexpected error:
        	            	strconv.ParseBool: parsing "/etc/profile.d/lang.sh: line 19: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory\ntrue": invalid syntax
        	Test:       	TestProcessListeningOnPort
--- FAIL: TestProcessListeningOnPort (56.15s)
FAIL
exit status 1
FAIL	github.com/stackrox/collector/integration-tests	56.456s


STDERR:

make: *** [process-listening-on-port] Error 1


MSG:

non-zero return code

TASK [Set tests as failed] *********************************************************************************************************************************
ok: [collector-dev-rhel-7-mmoltras]

TASK [Check results] ***************************************************************************************************************************************
fatal: [collector-dev-rhel-7-mmoltras]: FAILED! => {
    "changed": false
}

MSG:

Tests failed

TASK [Run integration tests] *******************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [Write integration test log] **************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [Report] **********************************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [set_fact] ********************************************************************************************************************************************
ok: [collector-dev-rhel-8-mmoltras]

TASK [Cleanup old containers] ******************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras]

TASK [Run integration tests] *******************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [Write integration test log] **************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [Report] **********************************************************************************************************************************************
changed: [collector-dev-rhel-8-mmoltras -> localhost]

TASK [Check results] ***************************************************************************************************************************************
skipping: [collector-dev-rhel-8-mmoltras]

PLAY [Teardown VMs] ****************************************************************************************************************************************

PLAY RECAP *************************************************************************************************************************************************
collector-dev-rhel-7-mmoltras : ok=11   changed=3    unreachable=0    failed=1    skipped=0    rescued=2    ignored=0
collector-dev-rhel-8-mmoltras : ok=15   changed=9    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

</details>


## Checklist
- [x] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

Manually run failing integration tests and checked the tests kept going only to fail once all variations are done.