### PR TITLE
Exclude broken Debian bundles from driver builds

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -15,6 +15,8 @@
 5.16.0-1-amd64
 5.17.0-2-cloud-amd64
 5.17.0-2-amd64
+5.19.0-2-amd64
+5.19.0-2-cloud-amd64
 # backport 5.8
 5.8.*20.04
 # TODO(ROX-6789) - backport 5.7+ patches to legacy collector versions


### PR DESCRIPTION
## Description

The drivers added to `BLOCKLIST` are currently failing due to a known problem with kernel-packer that breaks the bundles.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] Green check for driver builds
