### PR TITLE
Simplifies Makefile targets for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,73 +92,19 @@ image-dev-full: image-dev build-drivers
 		--build-arg max_layer_depth=1 \
 		$(CURDIR)/kernel-modules/container
 
-.PHONY: integration-tests-benchmark
-integration-tests-benchmark:
-	make -C integration-tests benchmark ||\
-		( .openshift-ci/slack/notify-if-needed.sh "benchmark" $$? )
-
-.PHONY: integration-tests-baseline
-integration-tests-baseline:
-	make -C integration-tests baseline ||\
-		( .openshift-ci/slack/notify-if-needed.sh "benchmark-baseline" $$? )
-
-.PHONY: integration-tests-process-network
-integration-tests-process-network:
-	make -C integration-tests process-network ||\
-		( .openshift-ci/slack/notify-if-needed.sh "process-network" $$? )
-
-.PHONY: integration-tests-missing-proc-scrape
-integration-tests-missing-proc-scrape:
-	make -C integration-tests missing-proc-scrape ||\
-		( .openshift-ci/slack/notify-if-needed.sh "missing-proc-scrape" $$? )
-
-.PHONY: integration-tests-repeat-network
-integration-tests-repeat-network:
-	make -C integration-tests repeat-network ||\
-		( .openshift-ci/slack/notify-if-needed.sh "repeat-network" $$? )
-
-.PHONY: integration-tests-image-label-json
-integration-tests-image-label-json:
-	make -C integration-tests image-label-json ||\
-		( .openshift-ci/slack/notify-if-needed.sh "image-label-json" $$? )
-
-.PHONY: integration-tests-procfsscaper
-integration-tests-procfsscaper:
-	make -C integration-tests procfsscraper ||\
-		( .openshift-ci/slack/notify-if-needed.sh "procfsscaper" $$? )
-
-.PHONY: integration-tests-process-listening-on-port
-integration-tests-process-listening-on-port:
-	make -C integration-tests process-listening-on-port ||\
-		( .openshift-ci/slack/notify-if-needed.sh "process-listening-on-port" $$? )
-
-.PHONY: integration-tests-symbolic-link-process
-integration-tests-symbolic-link-process:
-	make -C integration-tests symbolic-link-process ||\
-		( .openshift-ci/slack/notify-if-needed.sh "symbolic-link-process" $$? )
-
-.PHONY: integration-tests-socat
-integration-tests-socat:
-	make -C integration-tests socat ||\
-		( .openshift-ci/slack/notify-if-needed.sh "socat" $$? )
-
 .PHONY: integration-tests-report
 integration-tests-report:
 	make -C integration-tests report
 
 .PHONY: ci-integration-tests
-ci-integration-tests: integration-tests-repeat-network \
-					  integration-tests-process-network \
-					  integration-tests-missing-proc-scrape \
-					  integration-tests-image-label-json \
-					  integration-tests-procfsscaper \
-					  integration-tests-process-listening-on-port \
-					  integration-tests-symbolic-link-process \
-					  integration-tests-socat
+ci-integration-tests:
+	make -C integration-tests ci-integration-tests || \
+		( .openshift-ci/slack/notify-if-needed.sh "integration-tests" $$? )
 
 .PHONY: ci-benchmarks
-ci-benchmarks: integration-tests-baseline \
-			   integration-tests-benchmark
+ci-benchmarks:
+	make -C integration-tests ci-benchmarks || \
+		( .openshift-ci/slack/notify-if-needed.sh "benchmarks" $$? )
 
 .PHONY: ci-all-tests
 ci-all-tests: ci-benchmarks ci-integration-tests

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -14,11 +14,29 @@ SHELL=/bin/bash
 # Environment variable COLLECTOR_IMAGE is used by integration-tests
 export COLLECTOR_IMAGE
 
+ALL_TESTS = $(shell go test -list .)
+
+#
+# Macro to define a test-specific target, based on the list
+# of tests provided by the go test utility
+#
+define make-test-target
+$1: docker-clean
+	go version
+	set -o pipefail; \
+		go test -timeout 60m -count=1 -v \
+		-run $1 2>&1 | tee -a integration-test.log
+endef
+
+# Generates all the specific test targets
+$(foreach element,$(ALL_TESTS),$(eval $(call make-test-target,$(element))))
+
+# Run everything on CI, rather than specific tests.
 .PHONY: ci-integration-tests
-ci-integration-tests: process-network image-label-json 
-ci-integration-tests: repeat-network missing-proc-scrape procfsscraper
-ci-integration-tests: process-listening-on-port
-ci-integration-tests: symbolic-link-process
+ci-integration-tests: docker-clean
+	go version
+	set -o pipefail; \
+		go test -timeout 120m -v 2>&1 | tee -a integration-test.log
 
 .PHONY: ci-benchmarks
 ci-benchmarks: baseline
@@ -28,76 +46,11 @@ ci-benchmarks: benchmark
 docker-clean:
 	docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
 
-.PHONY: process-network
-process-network: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 60m -count=1 -v \
- 	  -run TestProcessNetwork 2>&1 | tee -a integration-test.log
-
 .PHONY:
-benchmark: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 60m -count=1 -v \
-	  -run TestBenchmarkCollector 2>&1 | tee -a integration-test.log
+benchmark: TestBenchmarkCollector
 
 .PHONY: baseline
-baseline: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 60m -count=1 -v \
-	  -run TestBenchmarkBaseline 2>&1 | tee -a integration-test.log
-
-.PHONY: image-label-json
-image-label-json: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 60m -count=1 -v \
-	  -run TestImageLabelJSON 2>&1 | tee -a integration-test.log
-
-.PHONY: missing-proc-scrape
-missing-proc-scrape: docker-clean
-	./scripts/create-fake-proc-dir.sh
-	go version
-	set -o pipefail ; \
-	go test -timeout 60m -count=1 -v \
-	  -run TestMissingProcScrape 2>&1 | tee -a integration-test.log
-
-.PHONY: repeat-network
-repeat-network: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 90m -count=1 -v \
-	  -run TestRepeatedNetworkFlow 2>&1 | tee -a integration-test.log
-
-.PHONY: procfsscraper
-procfsscraper: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 90m -count=1 -v \
-	  -run TestProcfsScraper 2>&1 | tee -a integration-test.log
-
-.PHONY: process-listening-on-port
-process-listening-on-port: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 90m -count=1 -v \
-	  -run TestProcessListeningOnPort 2>&1 | tee -a integration-test.log
-
-.PHONY: symbolic-link-process
-symbolic-link-process: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 90m -count=1 -v \
-	  -run TestSymbolicLinkProcess 2>&1 | tee -a integration-test.log
-
-.PHONY: socat
-socat: docker-clean
-	go version
-	set -o pipefail ; \
-	go test -timeout 90m -count=1 -v \
-	  -run TestSocat 2>&1 | tee -a integration-test.log
+baseline: TestBenchmarkBaseline
 
 LOG_FILE ?= integration-test.log
 .PHONY: report


### PR DESCRIPTION
## Description

Removes test-specific targets in favour of auto-generated targets based on output of `go test -list` to make the system a little more scalable to large numbers of tests.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly
