### PR TITLE
Add latest file to list of support packages

### DIFF
--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -60,6 +60,9 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     compress_files "$package_root" "${package_out_dir}/${filename}"
     generate_checksum "${package_out_dir}" "${filename}"
 
+    # Export the latest build filename
+    echo "${filename}" > "${package_out_dir}/latest"
+
     cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
     generate_checksum "${package_out_dir}" "${latest_filename}"
     rm -rf "$package_root" || true


### PR DESCRIPTION
## Description

This PR just adds a new file: `latest` - to the list of built support packages.
The `latest` file will contain the last build for that kernel module version.

Related to the conversation in Slack: https://srox.slack.com/archives/CFMQ5C2TT/p1669284268331969

**Open question**

- I'm not sure if this file will be properly synced to Google Storage.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
  - ~~[ ] Added unit tests~~
  - ~~[ ] Added integration tests~~
  - ~~[ ] Added regression tests~~

## Testing Performed

I didn't test it. I just made a conclusion from the code about what should be changed. 😞 
