### PR TITLE
ROX-13608 tunable thread table max size

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -55,6 +55,9 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 // If true, add originator process information in NetworkEndpoint
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
+// Configures the maximum number of threads in falco's table
+IntEnvVar falco_max_thread_table_size("ROX_FALCO_MAX_THREAD_TABLE_SIZE", CollectorConfig::kFalcoMaxThreadTableSize);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
@@ -66,6 +69,7 @@ constexpr char CollectorConfig::kChisel[];
 constexpr const char* CollectorConfig::kSyscalls[];
 constexpr bool CollectorConfig::kForceKernelModules;
 constexpr bool CollectorConfig::kEnableProcessesListeningOnPorts;
+constexpr int CollectorConfig::kFalcoMaxThreadTableSize;
 
 const UnorderedSet<L4ProtoPortPair> CollectorConfig::kIgnoredL4ProtoPortPairs = {{L4Proto::UDP, 9}};
 ;
@@ -80,6 +84,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   collection_method_ = kCollectionMethod;
   force_kernel_modules_ = kForceKernelModules;
   enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
+  falco_max_thread_table_size_ = falco_max_thread_table_size.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -56,7 +56,7 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
 // Configures the maximum number of threads in falco's table
-IntEnvVar falco_max_thread_table_size("ROX_FALCO_MAX_THREAD_TABLE_SIZE", CollectorConfig::kFalcoMaxThreadTableSize);
+IntEnvVar falco_max_thread_table_size("ROX_COLLECTOR_MAX_THREAD_TABLE_SIZE", CollectorConfig::kFalcoMaxThreadTableSize);
 
 }  // namespace
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -81,6 +81,7 @@ end
   static const UnorderedSet<L4ProtoPortPair> kIgnoredL4ProtoPortPairs;
   static constexpr bool kForceKernelModules = false;
   static constexpr bool kEnableProcessesListeningOnPorts = false;
+  static constexpr int kFalcoMaxThreadTableSize = -1;  // unafected by default
 
   CollectorConfig() = delete;
   CollectorConfig(CollectorArgs* collectorArgs);
@@ -101,6 +102,7 @@ end
   std::vector<std::string> Syscalls() const;
   int64_t AfterglowPeriod() const;
   std::string LogLevel() const;
+  int FalcoMaxThreadTableSize() const { return falco_max_thread_table_size_; }
   bool EnableSysdigLog() const { return enable_sysdig_log_; }
   bool DisableNetworkFlows() const { return disable_network_flows_; }
   const UnorderedSet<L4ProtoPortPair>& IgnoredL4ProtoPortPairs() const { return ignored_l4proto_port_pairs_; }
@@ -128,7 +130,7 @@ end
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
   bool curl_verbose_ = false;
   bool force_kernel_modules_ = false;
-
+  int falco_max_thread_table_size_;
   bool enable_sysdig_log_ = false;
   HostConfig host_config_;
   int64_t afterglow_period_micros_ = 300000000;  // 5 minutes in microseconds

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -57,9 +57,18 @@ struct ParseBool {
   }
 };
 
+struct ParseInt {
+  int operator()(int* out, std::string str_val) const {
+    size_t idx;
+    *out = std::stoi(str_val, &idx, 0);
+    return idx == str_val.length();
+  }
+};
+
 }  // namespace internal
 
 using BoolEnvVar = EnvVar<bool, internal::ParseBool>;
+using IntEnvVar = EnvVar<int, internal::ParseInt>;
 
 }  // namespace collector
 

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -58,7 +58,7 @@ struct ParseBool {
 };
 
 struct ParseInt {
-  int operator()(int* out, std::string str_val) const {
+  int operator()(int* out, const std::string& str_val) const {
     size_t idx;
     *out = std::stoi(str_val, &idx, 0);
     return idx == str_val.length();

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -66,6 +66,11 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
   SetChisel(config.Chisel());
 
   use_chisel_cache_ = config.UseChiselCache();
+
+  if (config.FalcoMaxThreadTableSize() > 0) {
+    CLOG(INFO) << "Thread table size limited to " << config.FalcoMaxThreadTableSize();
+    inspector_->m_thread_manager->set_max_thread_table_size(config.FalcoMaxThreadTableSize());
+  }
 }
 
 bool SysdigService::InitKernel(const CollectorConfig& config) {

--- a/docs/references.md
+++ b/docs/references.md
@@ -29,7 +29,7 @@ false.
 about the originator process on all network listening-endpoint objects.
 The default is false.
 
-* `ROX_FALCO_MAX_THREAD_TABLE_SIZE`: Prevent the Falco thread-table (list of
+* `ROX_COLLECTOR_MAX_THREAD_TABLE_SIZE`: Prevent the Falco thread-table (list of
 known processes running on the system) from growing over the specified value.
 The limit defaults to 520K processes and lowering it will prevent Collector
 from running out of memory because of an important number of processes.

--- a/docs/references.md
+++ b/docs/references.md
@@ -29,6 +29,13 @@ false.
 about the originator process on all network listening-endpoint objects.
 The default is false.
 
+* `ROX_FALCO_MAX_THREAD_TABLE_SIZE`: Prevent the Falco thread-table (list of
+known processes running on the system) from growing over the specified value.
+The limit defaults to 520K processes and lowering it will prevent Collector
+from running out of memory because of an important number of processes.
+When the limit is reached, information about endpoint originator processes
+will be incomplete.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 


### PR DESCRIPTION
## Description

New environment variable (`ROX_COLLECTOR_MAX_THREAD_TABLE_SIZE`) which, when set, defines an upper bound to the thread table size of Falco.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

