### PR TITLE
GHA workflow for linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
+  

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+      - uses: mfinelli/setup-shfmt@v2
       - uses: pre-commit/action@v3.0.0
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # fetch all to allow linting of differences between branches
+          fetch_depth: 0
       - uses: actions/setup-python@v3
       - uses: mfinelli/setup-shfmt@v2
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,6 @@
 name: Lint
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - release-*
+on: [pull-request]
 
 jobs:
   lint:
@@ -15,4 +10,7 @@ jobs:
       - uses: actions/setup-python@v3
       - uses: mfinelli/setup-shfmt@v2
       - uses: pre-commit/action@v3.0.0
+        with:
+          # ensure we're only linting the diff between the PR and the base ref
+          extra_args: --from-ref HEAD --to-ref ${{ github.event.pull_request.base.ref }}
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           # fetch all to allow linting of differences between branches
-          fetch_depth: 0
+          fetch-depth: 0
       - uses: actions/setup-python@v3
       - uses: mfinelli/setup-shfmt@v2
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: pre-commit/action@v3.0.0
         with:
           # ensure we're only linting the diff between the PR and the base ref
-          extra_args: --from-ref HEAD --to-ref ${{ github.event.pull_request.base.ref }}
+          extra_args: --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref HEAD
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [pull-request]
+on: [pull_request]
 
 jobs:
   lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
     rev: "6230247"
     hooks:
       - id: clang-format
+
+  - repo: https://github.com/rhysd/actionlint.git
+    rev: "v1.6.22"
+    hooks:
+      - id: actionlint-docker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git@github.com:syntaqx/git-hooks.git
+  - repo: https://github.com/syntaqx/git-hooks.git
     rev: "v0.0.17"
     hooks:
       - id: shfmt
@@ -7,12 +7,12 @@ repos:
           - -d
       - id: shellcheck
 
-  - repo: git@github.com:pycqa/flake8.git
+  - repo: https://github.com/pycqa/flake8.git
     rev: "4.0.1"
     hooks:
       - id: flake8
 
-  - repo: git@github.com:doublify/pre-commit-clang-format
+  - repo: https://github.com/doublify/pre-commit-clang-format.git
     rev: "6230247"
     hooks:
       - id: clang-format


### PR DESCRIPTION
## Description

Very simple workflow for running linters across the codebase, using pre-commit. Notable change is a move from SSH to HTTPS for cloning the pre-commit actions as well as running the hooks only on the diff between a PR and the base branch (usually master, but it is configured for any base branch) 

this has all been successfully tested locally.

