### PR TITLE
Collector and builder images on GHA

### DIFF
--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -25,24 +25,31 @@ jobs:
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           echo 'COLLECTOR_BUILDER_TAG=cache' >> "$GITHUB_ENV"
 
-      - name: Build builder on PRs
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
+      - name: PR checks for builder
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-          echo 'COLLECTOR_BUILDER_TAG=$(make tag)' >> "$GITHUB_ENV"
-
-      - name: Download cache image
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
-        run: |
-          docker pull quay.io/stackrox-io/collector-builder:cache
+          # We have 2 options:
+          # - We build the builder from scratch and give it a custom tag
+          # - We use the existing cache
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
+            echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
+            echo 'COLLECTOR_BUILDER_TAG=$(make tag)' >> "$GITHUB_ENV"
+          else
+            echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
+            docker pull quay.io/stackrox-io/collector-builder:cache
+          fi
 
       - name: Set environment variables
         run: |
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
-          # If COLLECTOR_BUILDER_TAG is not set at this point, we are in a PR using the cached image
-          if [[ -z "${COLLECTOR_BUILDER_TAG}" ]]; then
-            echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
+      - name: PR specific environment variables
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "COLLECTOR_APPEND_CID=true" >> "$GITHUB_ENV"
+
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
+            echo "ADDRESS_SANITIZER=true" >> "$GITHUB_ENV"
           fi
 
       - name: Build images
@@ -61,7 +68,10 @@ jobs:
           docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
-          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
+          # We only push the builder on pushes to master or if a PR built it with a custom tag
+          if [[ "${{ github.event_name == 'push' }}" == "true" || "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
+            docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
+          fi
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -58,8 +58,10 @@ jobs:
 
       - name: Retag and push stackrox-io
         run: |
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+          set -x
+
+          docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
+          docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -19,10 +19,17 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Check if builder should use cache
-        if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
+      - name: Build builder on master
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
+          echo 'COLLECTOR_BUILDER_TAG=cache' >> "$GITHUB_ENV"
+
+      - name: Build builder on PRs
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
+        run: |
+          echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
+          echo 'COLLECTOR_BUILDER_TAG=$(make tag)' >> "$GITHUB_ENV"
 
       - name: Download cache image
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
@@ -33,9 +40,8 @@ jobs:
         run: |
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
-          if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" == "true" ]]; then
-            echo "COLLECTOR_BUILDER_TAG=$(make tag)" >> "$GITHUB_ENV"
-          else
+          # If COLLECTOR_BUILDER_TAG is not set at this point, we are in a PR using the cached image
+          if [[ -n "${COLLECTOR_BUILDER_TAG}" ]]; then
             echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
           fi
 
@@ -51,14 +57,13 @@ jobs:
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Retag and push stackrox-io
-        run:
+        run: |
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
-
 
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v2
@@ -68,11 +73,9 @@ jobs:
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
       - name: Retag and push rhacs-eng
-        run:
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
-             "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
-             "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"
+        run: |
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"
 
           docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -39,7 +39,7 @@ jobs:
           # - We use the existing cache
           COLLECTOR_BUILDER_TAG="cache-gha"
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
-            COLLECTOR_BUILDER_TAG="${COLLECTOR_TAG}-gha"
+            COLLECTOR_BUILDER_TAG="${COLLECTOR_TAG}"
             echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           else
             docker pull quay.io/stackrox-io/collector-builder:cache-gha || true

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Push builder to stackrox-io
         if: ${{ github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != 'cache-gha' }}
         run: |
-          docker push "${{ inputs.TARGET_REGISTRY }}/collector-builder:${COLLECTOR_BUILDER_TAG}"
+          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v2

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Check if builder should use cache
         if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-builder-image')}}
@@ -30,9 +31,6 @@ jobs:
 
       - name: Set environment variables
         run: |
-          # Grab tag information
-          git fetch --recurse-submodules=no
-
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
           if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" != "true" ]]; then

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -61,7 +61,7 @@ jobs:
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
-          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_TAG}-slim"
+          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Set environment variables
         run: |
+          # Grab tag information
+          git fetch
+
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
           if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" != "true" ]]; then

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -1,0 +1,79 @@
+name: Collector image build
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-collector-image:
+    name: Build the collector slim image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Check if builder should use cache
+        if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-builder-image')}}
+        run: |
+          echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
+
+      - name: Download cache image
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
+        run: |
+          docker pull quay.io/stackrox-io/collector-builder:cache
+
+      - name: Set environment variables
+        run: |
+          echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
+
+          if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" != "true" ]]; then
+            echo "COLLECTOR_BUILDER_TAG=$(make tag)" >> "$GITHUB_ENV"
+          else
+            echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build images
+        run: |
+          make image
+
+      - name: Login to quay.io/stackrox-io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Retag and push stackrox-io
+        run:
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
+             "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
+             "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+
+          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_TAG}-slim"
+          docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
+          docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+
+
+      - name: Login to quay.io/rhacs-eng
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Retag and push rhacs-eng
+        run:
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
+             "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
+             "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"
+
+          docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
+          docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set environment variables
         run: |
           # Grab tag information
-          git fetch
+          git fetch --recurse-submodules=no
 
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -41,7 +41,7 @@ jobs:
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
           # If COLLECTOR_BUILDER_TAG is not set at this point, we are in a PR using the cached image
-          if [[ -n "${COLLECTOR_BUILDER_TAG}" ]]; then
+          if [[ -z "${COLLECTOR_BUILDER_TAG}" ]]; then
             echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
           fi
 
@@ -58,8 +58,6 @@ jobs:
 
       - name: Retag and push stackrox-io
         run: |
-          set -x
-
           docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if builder should use cache
-        if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-builder-image')}}
+        if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
 
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
 
-          if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" != "true" ]]; then
+          if [[ "${{ github.event_name == 'push' && github.ref_name == 'master' }}" == "true" ]]; then
             echo "COLLECTOR_BUILDER_TAG=$(make tag)" >> "$GITHUB_ENV"
           else
             echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -52,10 +52,8 @@ jobs:
 
       - name: Retag and push stackrox-io
         run:
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
-             "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
-          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" \
-             "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -19,33 +19,35 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Build builder on master
-        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+      - name: Set collector tag
+        run: |
+          COLLECTOR_TAG="$(make tag)-gha"
+          echo "COLLECTOR_TAG=${COLLECTOR_TAG}" >> "$GITHUB_ENV"
+
+      - name: Checks for main and release branches
+        if: ${{ github.event_name == 'push' }}
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-          echo 'COLLECTOR_BUILDER_TAG=cache' >> "$GITHUB_ENV"
+          echo 'COLLECTOR_BUILDER_TAG=cache-gha' >> "$GITHUB_ENV"
 
-      - name: PR checks for builder
+      - name: PR checks
+        id: pr-checks
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           # We have 2 options:
           # - We build the builder from scratch and give it a custom tag
           # - We use the existing cache
+          COLLECTOR_BUILDER_TAG="cache-gha"
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
+            COLLECTOR_BUILDER_TAG="${COLLECTOR_TAG}-gha"
             echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-            echo "COLLECTOR_BUILDER_TAG=$(make tag)" >> "$GITHUB_ENV"
           else
-            echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
-            docker pull quay.io/stackrox-io/collector-builder:cache
+            docker pull quay.io/stackrox-io/collector-builder:cache-gha || true
           fi
 
-      - name: Set environment variables
-        run: |
-          echo "COLLECTOR_TAG=$(make tag)" >> "$GITHUB_ENV"
+          echo "COLLECTOR_BUILDER_TAG=$COLLECTOR_BUILDER_TAG" >> "$GITHUB_ENV"
+          echo "builder-tag=$COLLECTOR_BUILDER_TAG" >> "$GITHUB_OUTPUT"
 
-      - name: PR specific environment variables
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
           echo "COLLECTOR_APPEND_CID=true" >> "$GITHUB_ENV"
 
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
@@ -63,17 +65,18 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
-      - name: Retag and push stackrox-io
+      - name: Retag and push collector to stackrox-io
         run: |
-          docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
-          docker --debug tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
+          docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
 
-          # We only push the builder on pushes to master or if a PR built it with a custom tag
-          if [[ "${{ github.event_name == 'push' }}" == "true" || "${COLLECTOR_BUILDER_TAG}" != "cache" ]]; then
-            docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
-          fi
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/stackrox-io/collector:${COLLECTOR_TAG}-base"
+
+      - name: Push builder to stackrox-io
+        if: ${{ github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != 'cache-gha' }}
+        run: |
+          docker push "${{ inputs.TARGET_REGISTRY }}/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v2
@@ -82,10 +85,16 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Retag and push rhacs-eng
+      - name: Retag and push collector to rhacs-eng
         run: |
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
           docker tag "quay.io/stackrox-io/collector:${COLLECTOR_TAG}" "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"
 
           docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-slim"
           docker push "quay.io/rhacs-eng/collector:${COLLECTOR_TAG}-base"
+
+      - name: Push builder to rhacs-eng
+        if: ${{ github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != 'cache-gha' }}
+        run: |
+          docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
+          docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"

--- a/.github/workflows/collector-image.yml
+++ b/.github/workflows/collector-image.yml
@@ -33,7 +33,7 @@ jobs:
           # - We use the existing cache
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
             echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-            echo 'COLLECTOR_BUILDER_TAG=$(make tag)' >> "$GITHUB_ENV"
+            echo "COLLECTOR_BUILDER_TAG=$(make tag)" >> "$GITHUB_ENV"
           else
             echo "COLLECTOR_BUILDER_TAG=cache" >> "$GITHUB_ENV"
             docker pull quay.io/stackrox-io/collector-builder:cache

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ teardown-dev:
 .PHONY: clean
 clean: teardown-dev
 	rm -rf cmake-build/
+	rm -f collector/container/Dockerfile.gen
 	make -C collector clean
 
 .PHONY: shfmt-check


### PR DESCRIPTION
## Description

This PR adds a GHA workflow for building the `-slim` and `-base` images of collector. We achieve this by making a few checks on what the context of the workflow is, setting a few environment variables and calling `make image` in a pretty similar way to what building the image locally for development is. Once the images are built, they are pushed to out `quay.io` registries to make the available for usage.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

--