### PR TITLE
Support packages on gha

### DIFF
--- a/.github/support-packages/create-metadata-dir.sh
+++ b/.github/support-packages/create-metadata-dir.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
+    version="$(basename "$version_dir")"
+    git checkout "${version}"
+
+    driver_version="$(cat "${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION")"
+    echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
+done

--- a/.github/support-packages/create-metadata-dir.sh
+++ b/.github/support-packages/create-metadata-dir.sh
@@ -6,8 +6,7 @@ for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
     version="$(basename "$version_dir")"
     git checkout "${version}"
 
-    driver_version="$(cat "${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION")"
-    echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
+    cp "${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION" "${version_dir}/MODULE_VERSION"
 done
 
 git checkout "${BRANCH_NAME}"

--- a/.github/support-packages/create-metadata-dir.sh
+++ b/.github/support-packages/create-metadata-dir.sh
@@ -9,3 +9,5 @@ for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
     driver_version="$(cat "${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION")"
     echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
 done
+
+git checkout "${BRANCH_NAME}"

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -7,6 +7,10 @@ on:
         description: |
           Number of builders used to build drivers, 0 if no driver is built
         value: ${{ jobs.split-tasks.outputs.parallel-jobs }}
+      branch-name:
+        description: |
+          Branch CI is running on
+        value: ${{ jobs.split-tasks.outputs.branch-name }}
 
 jobs:
   split-tasks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,4 +75,5 @@ jobs:
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages') }}
+    needs: build-drivers
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
 
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
-    if: ${{ always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages')) }}
+    # If you want to test this workflow in a PR, you will need to replace
+    # this condition with `${{ always() }}`, since skipping the upload of
+    # bundles will cause this workflow to skip as well.
+    if: ${{ github.event_name != 'pull_request' }}
     needs: upload-drivers
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,6 @@ jobs:
 
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages') }}
+    if: ${{ always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages')) }}
     needs: upload-drivers
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,5 +75,5 @@ jobs:
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages') }}
-    needs: build-drivers
+    needs: upload-drivers
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,10 +74,14 @@ jobs:
 
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
+    with:
+      branch-name: ${{ needs.build-drivers.outputs.branch-name }}
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.
     #if: ${{ github.event_name != 'pull_request' }}
     if: always()
-    needs: upload-drivers
+    needs:
+    - build-drivers
+    - upload-drivers
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,8 @@ jobs:
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.
-    if: ${{ github.event_name != 'pull_request' }}
+    #if: ${{ github.event_name != 'pull_request' }}
+    if: always()
     needs:
     - build-drivers
     - upload-drivers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,8 +79,7 @@ jobs:
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.
-    #if: ${{ github.event_name != 'pull_request' }}
-    if: always()
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
     - build-drivers
     - upload-drivers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,3 +71,7 @@ jobs:
     - build-collector-slim
     - build-collector-full
     secrets: inherit
+
+  build-support-packages:
+    uses: ./.github/workflows/support-packages.yml
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,3 +75,4 @@ jobs:
   build-support-packages:
     uses: ./.github/workflows/support-packages.yml
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test-support-packages') }}
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.
-    if: ${{ github.event_name != 'pull_request' }}
+    #if: ${{ github.event_name != 'pull_request' }}
+    if: always()
     needs: upload-drivers
     secrets: inherit

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -60,7 +60,7 @@ jobs:
         id: output-bucket
         run: |
           if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
-            echo "output-bucket=mauro-drivers-test/support-packages/${GITHUB_HEAD_NAME}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+            echo "output-bucket=mauro-drivers-test/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           else
             echo "output-bucket=mauro-drivers-test/support-packages/master" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -80,3 +80,16 @@ jobs:
           path: /tmp/support-packages/output
           parent: false
           destination: ${{ steps.output-bucket.outputs.output-bucket }}
+
+      - name: Slack notification
+        if: failure() && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+          SLACK_CHANNEL: oncall
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: Support package job failed
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @collector-team

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -24,6 +24,11 @@ jobs:
             version="$(basename "$version_dir")"
             git checkout "${version}"
 
+            if [[ ! -f ${{ github.workspace }}/kernel-modules/MODULE_VERSION ]]; then
+              # Versions without this file are already unsupported, skip them
+              continue
+            fi
+
             driver_version="$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
             echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
           done

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -24,11 +24,6 @@ jobs:
             version="$(basename "$version_dir")"
             git checkout "${version}"
 
-            if [[ ! -f ${{ github.workspace }}/kernel-modules/MODULE_VERSION ]]; then
-              # Versions without this file are already unsupported, skip them
-              continue
-            fi
-
             driver_version="$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
             echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
           done

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: action/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -52,6 +52,15 @@ jobs:
 
       - name: Create index file
         run: |
+          relative_path="collector/support-packages"
+
+          if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
+              relative_path="${relative_path}/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          fi
+
+          DOWNLOAD_BASE_URL="https://install.stackrox.io"
+          export BASE_URL="${DOWNLOAD_BASE_URL}/${relative_path}"
+
           ${{ github.workspace }}/kernel-modules/support-packages/05-create-index.py \
             /tmp/support-packages/metadata \
             /tmp/support-packages/output

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -20,16 +20,7 @@ jobs:
 
       - name: Create driver version metadata
         run: |
-          for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
-            version="$(basename "$version_dir")"
-            git checkout "${version}"
-
-            driver_version="$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
-            echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
-          done
-
-          # Checkout master to have the latest license file
-          git checkout master
+          ./.github/support-packages/create-metadata-dir.sh
 
       - name: Group versions by driver version
         run: |

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -36,6 +36,11 @@ jobs:
           ${{ github.workspace }}/kernel-modules/support-packages/03-group-by-module-version.sh \
             /tmp/support-packages/metadata
 
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+
       - name: Create support-packages
         run: |
           ${{ github.workspace }}/kernel-modules/support-packages/04-create-support-packages.sh \
@@ -58,11 +63,6 @@ jobs:
           else
             echo "output-bucket=mauro-drivers-test/support-packages/master" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: Push support-packages
         uses: 'google-github-actions/upload-cloud-storage@v1'

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -43,9 +43,10 @@ jobs:
 
       - name: Create support-packages
         run: |
+          # TODO: Change the bucket to the production one, once we are done testing
           ${{ github.workspace }}/kernel-modules/support-packages/04-create-support-packages.sh \
             ${{ github.workspace }}/collector/LICENSE-kernel-modules.txt \
-            gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656 \
+            gs://mauro-drivers-test/drivers \
             /tmp/support-packages/metadata \
             /tmp/support-packages/output
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -1,0 +1,72 @@
+name: Build and push support-packages
+
+on:
+  workflow_call:
+
+jobs:
+  build-support-packages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: action/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Map collector to stackrox versions
+        run: |
+          ${{ github.workspace }}/kernel-modules/support-packages/01-collector-to-rox-version-map.py \
+            ${{ github.workspace }}/RELEASED_VERSIONS \
+            /tmp/support-packages/metadata
+
+      - name: Create driver version metadata
+        run: |
+          for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
+            version="$(basename "$version_dir")"
+            git checkout "${version}"
+
+            driver_version="$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
+            echo "${driver_version}" > "${version_dir}/MODULE_VERSION"
+          done
+
+          # Checkout master to have the latest license file
+          git checkout master
+
+      - name: Group versions by driver version
+        run: |
+          ${{ github.workspace }}/kernel-modules/support-packages/03-group-by-module-version.sh \
+            /tmp/support-packages/metadata
+
+      - name: Create support-packages
+        run: |
+          ${{ github.workspace }}/kernel-modules/support-packages/04-create-support-packages.sh \
+            ${{ github.workspace }}/collector/LICENSE-kernel-modules.txt \
+            gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656 \
+            /tmp/support-packages/metadata \
+            /tmp/support-packages/output
+
+      - name: Create index file
+        run: |
+          ${{ github.workspace }}/kernel-modules/support-packages/05-create-index.py \
+            /tmp/support-packages/metadata \
+            /tmp/support-packages/output
+
+      - name: Set output bucket
+        id: output-bucket
+        run: |
+          if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
+            echo "output-bucket=mauro-drivers-test/support-packages/${GITHUB_HEAD_NAME}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "output-bucket=mauro-drivers-test/support-packages/master" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+
+      - name: Push support-packages
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: /tmp/support-packages/output
+          parent: false
+          destination: ${{ steps.output-bucket.outputs.output-bucket }}

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -2,6 +2,11 @@ name: Build and push support-packages
 
 on:
   workflow_call:
+    inputs:
+      branch-name:
+        type: string
+        required: true
+        description: Branch CI is running on
 
 jobs:
   build-support-packages:
@@ -19,6 +24,8 @@ jobs:
             /tmp/support-packages/metadata
 
       - name: Create driver version metadata
+        env:
+          BRANCH_NAME: ${{ inputs.branch-name }}
         run: |
           ./.github/support-packages/create-metadata-dir.sh
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Set output bucket
         id: output-bucket
         run: |
+          # TODO: Change the bucket to the production one, once we are done testing
           if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
             echo "output-bucket=mauro-drivers-test/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Description

This PR adds a workflow for creating and pushing support packages on GHA. The procedure is relatively straight forward, most of the process consists of calling the scripts under `kernel-modules/support-packages` in the right order and with the correct environment variables and parameters set.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Manually checked at least one support package is properly formatted.
- [x] Manually checked the integrity file works.
- [x] Reviewed the contents of the generated `index.html` file are correct.
- [x] The `latest` file used for releases is correct and properly pushed.