### PR TITLE
Move unsupported versions to RELEASED_VERSIONS.unsupported

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -7,15 +7,8 @@
 # now-unsupported releases.
 # IMPORTANT: THIS FILE ALWAYS NEEDS TO END WITH A NEWLINE CHARACTER
 
-3.7.0 3.69.0  # Rox release 3.69.0 by 0x656b694d at Tue Mar 15 17:01:36 UTC 2022
-3.7.3 3.69.1  # Rox release 3.69.1 by 0x656b694d at Wed Apr  6 21:13:36 UTC 2022
-3.8.1 3.70.0  # Rox release 3.70.0 by JoukoVirtanen at Fri May 27 21:22:32 UTC 2022
-3.6.4 3.68.2  # Rox release 3.68.2 by JoukoVirtanen at Fri Jun 17 01:22:13 UTC 2022
-3.8.2 3.70.1  # Rox release 3.70.1 by JoukoVirtanen at Fri Jun 17 22:43:18 UTC 2022
-3.7.6 3.69.2  # Rox release 3.69.2 by JoukoVirtanen at Tue Jun 21 17:02:21 UTC 2022
 3.9.0 3.71.0  # Rox release 3.71.0 by roxbot at Thu Jul 21 09:58:32 UTC 2022
 3.11.0 3.72.0  # Rox release 3.72.0 by roxbot at Mon Sep 26 10:21:46 UTC 2022
-3.8.3 3.70.2  # Rox release 3.70.2 by 0x656b694d at Wed Oct  5 15:38:12 UTC 2022
 3.9.1 3.71.2  # Rox release 3.71.2 by roxbot at Thu Oct 13 20:24:23 UTC 2022
 3.11.1 3.72.1  # Rox release 3.72.1 by roxbot at Tue Oct 18 17:09:49 UTC 2022
 3.11.2 3.72.2  # Rox release 3.72.2 by roxbot at Wed Nov  9 17:41:06 UTC 2022

--- a/RELEASED_VERSIONS.unsupported
+++ b/RELEASED_VERSIONS.unsupported
@@ -127,3 +127,10 @@
 3.5.0 3.67.1  # Rox release 3.67.1 by dhaus67 at Mon Dec  6 13:37:46 UTC 2021
 3.6.0 3.68.0  # Rox release 3.68.0 by vikin91 at Thu Feb  3 08:58:34 UTC 2021
 3.6.0 3.68.1  # Rox release 3.68.1 by vikin91 at Thu Feb  10 21:08:34 UTC 2021
+3.7.0 3.69.0  # Rox release 3.69.0 by 0x656b694d at Tue Mar 15 17:01:36 UTC 2022
+3.7.3 3.69.1  # Rox release 3.69.1 by 0x656b694d at Wed Apr  6 21:13:36 UTC 2022
+3.8.1 3.70.0  # Rox release 3.70.0 by JoukoVirtanen at Fri May 27 21:22:32 UTC 2022
+3.6.4 3.68.2  # Rox release 3.68.2 by JoukoVirtanen at Fri Jun 17 01:22:13 UTC 2022
+3.8.2 3.70.1  # Rox release 3.70.1 by JoukoVirtanen at Fri Jun 17 22:43:18 UTC 2022
+3.7.6 3.69.2  # Rox release 3.69.2 by JoukoVirtanen at Tue Jun 21 17:02:21 UTC 2022
+3.8.3 3.70.2  # Rox release 3.70.2 by 0x656b694d at Wed Oct  5 15:38:12 UTC 2022


### PR DESCRIPTION
## Description

The 3.68, 3.69 and 3.70 stackrox versions have already reached EOL, so we should update our supported collector versions to reflect this. Added bonus, the following driver versions will no longer be built for added kernels:
- The last sysdig driver version
- 1.0.0

Support packages for the previous versions will also not be updated anymore.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- Green CI should be enough.