### PR TITLE
More fixes to driver builds on GHA

### DIFF
--- a/.github/drivers/mock-cache.sh
+++ b/.github/drivers/mock-cache.sh
@@ -12,7 +12,7 @@ for module_version_dir in /tmp/kobuild-tmp/versions-src/*; do
     mkdir -p "/tmp/kernel-modules/$module_version/"
 
     # If the bucket doesn't exist, we are building a new version of drivers
-    if ! gsutil ls "gs://mauro-drivers-test/drivers/${module_version}/" 1>&2 2> /dev/null; then
+    if ! gsutil ls "gs://mauro-drivers-test/drivers/${module_version}/" > /dev/null; then
         echo "Could not find cached drivers for '${module_version}'. Continuing with no cache"
         continue
     fi

--- a/.github/drivers/mock-cache.sh
+++ b/.github/drivers/mock-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
 
 # TODO: Move the buckets back to the official ones once we are done testing
 

--- a/.github/drivers/mock-cache.sh
+++ b/.github/drivers/mock-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 
 # TODO: Move the buckets back to the official ones once we are done testing
 

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -241,7 +241,7 @@ jobs:
           if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
             echo "gcp-bucket=mauro-drivers-test/pr-builds/${{ needs.split-tasks.outputs.branch-name }}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           else
-            echo "gcp-bucket=mauro-drivers-test/master" >> "$GITHUB_OUTPUT"
+            echo "gcp-bucket=mauro-drivers-test/drivers" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Authenticate with GCP


### PR DESCRIPTION
## Description

This PR makes 2 small changes:
- Properly silences a `gsutil ls` as to not flood logs.
- Ensures the same location is used for pushing drivers and pulling them back down.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is enough.