### PR TITLE
Move the driver upload out of the driver build workflow

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -220,38 +220,3 @@ jobs:
           path: /tmp/FAILURES
           if-no-files-found: ignore
           retention-days: 1
-
-  upload-drivers:
-    runs-on: ubuntu-latest
-    needs:
-      - split-tasks
-      - build-drivers
-
-    steps:
-      - name: Restore built drivers
-        uses: actions/download-artifact@v3
-        with:
-          name: built-drivers
-          path: /tmp/output/
-
-      - name: Choose destination bucket
-        id: gcp-bucket
-        run: |
-          # TODO: Move these buckets to the proper ones when we completely switch off OSCI
-          if [[ "${{ github.event_name == 'pull_request' }}" == "true" ]]; then
-            echo "gcp-bucket=mauro-drivers-test/pr-builds/${{ needs.split-tasks.outputs.branch-name }}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "gcp-bucket=mauro-drivers-test/drivers" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
-
-      - name: Push drivers
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: /tmp/output/
-          parent: false
-          destination: ${{ steps.gcp-bucket.outputs.gcp-bucket }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,12 @@ jobs:
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
 
+  upload-drivers:
+    uses: ./.github/workflows/upload-drivers.yml
+    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
+    needs: build-drivers
+    secrets: inherit
+
   check-drivers-build:
     runs-on: ubuntu-latest
     needs: build-drivers

--- a/.github/workflows/upload-drivers.yml
+++ b/.github/workflows/upload-drivers.yml
@@ -1,0 +1,37 @@
+name: Upload drivers to GCP
+
+on:
+  workflow_call:
+
+jobs:
+  upload-drivers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Restore built drivers
+        uses: actions/download-artifact@v3
+        with:
+          name: built-drivers
+          path: /tmp/output/
+
+      - name: Choose destination bucket
+        id: gcp-bucket
+        run: |
+          # TODO: Move these buckets to the proper ones when we completely switch off OSCI
+          if [[ ${{ github.event_name }} == "pull_request" ]]; then
+            echo "gcp-bucket=mauro-drivers-test/pr-builds/${GITHUB_HEAD_REF}/${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "gcp-bucket=mauro-drivers-test/drivers" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+
+      - name: Push drivers
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: /tmp/output/
+          parent: false
+          destination: ${{ steps.gcp-bucket.outputs.gcp-bucket }}


### PR DESCRIPTION
## Description

By making this change, checking for driver build failures can happen in parallel with the upload.

The check will also not depend on the upload to succeeded to show a build error.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Green CI with `no-cache` should be enough
