### PR TITLE
Ensure the fc36 builder tasks are in the right path

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -110,6 +110,14 @@ jobs:
         run: |
           ${{ github.workspace }}/.openshift-ci/drivers/scripts/kernel-splitter.py
 
+          # TODO: This is a compatibility issue with OSCI, ideally all tasks
+          # should be in a consistent path. Ensure that happens once we remove
+          # OSCI
+          if [[ -f /tmp/tasks/fc36/all ]]; then
+            mkdir -p /tmp/tasks/fc36/0
+            mv /tmp/tasks/fc36/all /tmp/tasks/fc36/0/all
+          fi
+
       - name: Store tasks and sources
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Description

Due to a compatibility issue with OSCI, the fc36 tasks are placed under `/tmp/tasks/fc36/all` when a single builder is needed, but GHA looks for this under `/tmp/tasks/fc36/0/all`, so we simply move the file when needed.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `no-cache` and make sure the `0` shard of is not overwritten with all tasks.