### PR TITLE
Add Slack notifications

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -117,3 +117,18 @@ jobs:
             ${{ github.workspace }}/integration-tests/container-logs/**/*
             ${{ github.workspace }}/integration-tests/perf.json
             ${{ github.workspace }}/integration-tests/performance-logs/**/*
+
+      - name: Slack notification
+        # TODO: this is the correct if condition
+        #if: failure() && github.event_name == 'push'
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+          SLACK_CHANNEL: oncall
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: ${{ inputs.vm_type }} integration test failed
+          MSG_MINIMAL: actions url, commit
+          SLACK_MESSAGE: |
+            @collector-team

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -119,9 +119,7 @@ jobs:
             ${{ github.workspace }}/integration-tests/performance-logs/**/*
 
       - name: Slack notification
-        # TODO: this is the correct if condition
-        #if: failure() && github.event_name == 'push'
-        if: always()
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -129,6 +129,6 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_LINK_NAMES: true
           SLACK_TITLE: ${{ inputs.vm_type }} integration test failed
-          MSG_MINIMAL: actions url, commit
+          MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @collector-team

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
   check-drivers-build:
     runs-on: ubuntu-latest
     needs: build-drivers
-    # TODO: Add back this check
-    #if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
+    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
     steps:
       - uses: actions/checkout@v3
 
@@ -36,11 +35,8 @@ jobs:
         run: |
           FAILURES_DIR=/tmp/FAILURES/ ${{ github.workspace }}/.openshift-ci/drivers/scripts/drivers-build-failures.sh
 
-          # TODO: Rollback this change
-          exit 1
-
       - name: Slack notification
-        if: failure()
+        if: failure() && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
@@ -48,6 +44,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_LINK_NAMES: true
           SLACK_TITLE: Driver build check failed
+          MSG_MINIMAL: actions url, commit
           SLACK_MESSAGE: |
             @collector-team
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_LINK_NAMES: true
           SLACK_TITLE: Driver build check failed
-          MSG_MINIMAL: actions url, commit
+          MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @collector-team
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
   check-drivers-build:
     runs-on: ubuntu-latest
     needs: build-drivers
-    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
+    # TODO: Add back this check
+    #if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
     steps:
       - uses: actions/checkout@v3
 
@@ -32,8 +33,23 @@ jobs:
           path: /tmp/FAILURES
 
       - name: Check build failures
-        run:
+        run: |
           FAILURES_DIR=/tmp/FAILURES/ ${{ github.workspace }}/.openshift-ci/drivers/scripts/drivers-build-failures.sh
+
+          # TODO: Rollback this change
+          exit 1
+
+      - name: Slack notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+          SLACK_CHANNEL: oncall
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: Driver build check failed
+          SLACK_MESSAGE: |
+            @collector-team
 
   build-collector-slim:
     uses: ./.github/workflows/collector-slim.yml


### PR DESCRIPTION
## Description

Add slack notifications for driver build errors and integration tests failures on pushes.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Did some manual testing and alerts are properly showing up in the oncall channel.