### PR TITLE
Minor fix when retagging collector full on PRs

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -106,6 +106,8 @@ jobs:
       COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Pull slim image
         run: |
           docker pull "${COLLECTOR_IMAGE_SLIM}"


### PR DESCRIPTION
## Description

When retagging collector slim to full on PRs, the repository needs to be checked out before using the `retag-and-push` action.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Green CI should be enough.
