### PR TITLE
Allow up to 10 forks of ansible

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,4 +3,4 @@ stdout_callback=debug
 stderr_callback=debug
 host_key_checking=False
 remote_tmp = /tmp/ansible
-
+forks = 10


### PR DESCRIPTION

## Description

By default ansible allows up to 5 forks, which was causing a slow down on tests run on 6 or more VMs. This patch ups the max number of forks to 10.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
CI with `all-integration-tests` label should be enough.