### PR TITLE
ROX-13628 Create an external representation of endpoints

### DIFF
--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -134,8 +134,8 @@ class ConnectionTracker {
   static bool CheckIfOldConnShouldBeInactiveInDelta(const T& conn_key, const ConnStatus& conn_status, const UnorderedMap<T, ConnStatus>& new_state, int64_t time_micros, int64_t time_at_last_scrape, int64_t afterglow_period_micros);
 
   // ComputeDelta computes a diff between new_state and *old_state, and stores the diff in *old_state.
-  template <typename T>
-  static void ComputeDelta(const UnorderedMap<T, ConnStatus>& new_state, UnorderedMap<T, ConnStatus>* old_state);
+  template <typename T, typename E>
+  static void ComputeDelta(const UnorderedMap<T, ConnStatus, E>& new_state, UnorderedMap<T, ConnStatus, E>* old_state);
 
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
@@ -214,8 +214,8 @@ void ConnectionTracker::UpdateOldState(UnorderedMap<T, ConnStatus>* old_state, c
   }
 }
 
-template <typename T>
-void ConnectionTracker::ComputeDelta(const UnorderedMap<T, ConnStatus>& new_state, UnorderedMap<T, ConnStatus>* old_state) {
+template <typename T, typename E>
+void ConnectionTracker::ComputeDelta(const UnorderedMap<T, ConnStatus, E>& new_state, UnorderedMap<T, ConnStatus, E>* old_state) {
   // Insert all objects from the new state, if anything changed about them.
   for (const auto& conn : new_state) {
     auto insert_res = old_state->insert(conn);

--- a/collector/lib/Hash.h
+++ b/collector/lib/Hash.h
@@ -120,8 +120,8 @@ size_t HashAll(const FirstArg& first, const RestArgs&... rest) {
 template <typename E>
 using UnorderedSet = std::unordered_set<E, Hasher>;
 
-template <typename K, typename V>
-using UnorderedMap = std::unordered_map<K, V, Hasher>;
+template <typename K, typename V, typename E = std::equal_to<K>>
+using UnorderedMap = std::unordered_map<K, V, Hasher, E>;
 
 }  // namespace collector
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -229,11 +229,9 @@ void NetworkStatusNotifier::ConvertEndpointsToAdvertisedRepresentation(const Con
   for (auto cep : from) {
     auto insert_result = to.insert(cep);
 
-    if (!insert_result.second && cep.second.IsActive()) {
-      /* collision case
-         Replace the existing endpoint by the "active" one.
-         Since they are equal, replacing an active endpoint with an active one doesn't make any difference. */
-      (*insert_result.first).second = cep.second;
+    if (!insert_result.second) {
+      // collision case: keep the latest activity
+      (*insert_result.first).second.MergeFrom(cep.second);
     }
   }
 }

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -205,14 +205,14 @@ bool NetworkStatusNotifier::UpdateAllConnsAndEndpoints() {
 }
 
 bool NetworkStatusNotifier::ExternalContainerEndpointEquality::operator()(const ContainerEndpoint& lhs, const ContainerEndpoint& rhs) const {
-  if (bool(lhs.originator()) != bool(lhs.originator())) {
+  if (bool(lhs.originator()) != bool(rhs.originator())) {
     return false;
   }
 
   if (lhs.originator()) {
-    auto& lhs_oritinator = *lhs.originator();
-    auto& rhs_oritinator = *rhs.originator();
-    if ((lhs_oritinator.comm() != rhs_oritinator.comm()) || (lhs_oritinator.exe_path() != rhs_oritinator.exe_path()) || (lhs_oritinator.args() != rhs_oritinator.args())) {
+    auto& lhs_originator = *lhs.originator();
+    auto& rhs_originator = *rhs.originator();
+    if ((lhs_originator.comm() != rhs_originator.comm()) || (lhs_originator.exe_path() != rhs_originator.exe_path()) || (lhs_originator.args() != rhs_originator.args())) {
       return false;
     }
   }

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -328,6 +328,9 @@ void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<
 void NetworkStatusNotifier::AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const ContainerEndpointMap& delta) {
   for (const auto& delta_entry : delta) {
     auto* endpoint_proto = ContainerEndpointToProto(delta_entry.first);
+
+    CLOG(DEBUG) << delta_entry.first << " active:" << delta_entry.second.IsActive();
+
     if (!delta_entry.second.IsActive()) {
       *endpoint_proto->mutable_close_timestamp() = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(
           delta_entry.second.LastActiveTime());
@@ -357,7 +360,6 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   if (cep.originator()) {
     endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
   }
-  CLOG(DEBUG) << cep;
 
   return endpoint_proto;
 }


### PR DESCRIPTION
## Description

In Collector, an endpoint now represents a listening socket with a reference to the process making use of it. When an endpoint is published, however, the process information is stripped down to represent a the name and parameters of this process instead of the precise instance.

This as an impact on the life-cycle of endpoint objects "as seen from the outside". For instance, the same endpoint opened by several processes having the same attributes should appear as a single endpoint.

In order to implement this model, we propose to squash all instances of internal endpoints which "look the same" and publish the result.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests
