### PR TITLE
Add a small workflow for notifications on MODULE_VERSION change

### DIFF
--- a/.github/workflows/notify-module-version.yml
+++ b/.github/workflows/notify-module-version.yml
@@ -1,0 +1,27 @@
+name: Notify MODULE_VERSION changed
+
+on:
+  push:
+    branches:
+    - master
+    - release-*
+    # TODO: Remove after testing
+    - mauro-*
+    paths:
+    - kernel-modules/MODULE_VERSION
+
+jobs:
+  notify:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Slack notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+        SLACK_CHANNEL: oncall
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_LINK_NAMES: true
+        SLACK_TITLE: MODULE_VERSION has changed!
+        MSG_MINIMAL: commit
+        SLACK_MESSAGE: |
+          @collector-team update the downstream sources accordingly.


### PR DESCRIPTION
## Description

Since downstream breaks if we don't update it with the new `MODULE_VERSION`, this notification should remind us to consistently do that.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Manually trigger a notification on a non-protected branch.
