### PR TITLE
Ignore empty driver build failure files

### DIFF
--- a/.openshift-ci/drivers/scripts/drivers-build-failures.sh
+++ b/.openshift-ci/drivers/scripts/drivers-build-failures.sh
@@ -9,6 +9,15 @@ failure_files=(*/*/*.log)
 
 for failure_file in "${failure_files[@]}"; do
     if [[ "$failure_file" =~ ^([^/]+)/([^/]+)/([^/]+)\.log$ ]]; then
+        # If the file is empty, there's nothing to alert on. Sometimes kernels
+        # that don't support eBPF leave the error file hanging around for no
+        # good reason (I suspect some shenanigan's with tee spawning after we
+        # mark the file for deletion).
+        if [[ ! -s "$failure_file" ]]; then
+            rm -f "$failure_file"
+            continue
+        fi
+
         kernel_version="${BASH_REMATCH[1]}"
         module_version="${BASH_REMATCH[2]}"
         probe_type="${BASH_REMATCH[3]}"
@@ -23,4 +32,6 @@ for failure_file in "${failure_files[@]}"; do
     fi
 done
 
+# We expand it again to ignore empty files.
+failure_files=(*/*/*.log)
 [[ "${#failure_files[@]}" == 0 ]]


### PR DESCRIPTION
## Description

When compiling a large number of drivers, sometimes some BPF drivers for kernels that don't support it are reported as failed to build, even though the actual build shows a message stating that it is being skipped. Since we redirect stderr to this file, an empty file would be the same as no error, so we should be ok to ignore it.

I suspect when the driver is skipped there might be some timing issue with the subshell being spawned to run tee, making it so we attempt to delete the file before it is actually created and then the subshell comes up and creates the empty file.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `no-cache` label should result in a green check for the driver build check step
