### PR TITLE
Move CI to GHA

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
+  DEFAULT_BUILDER_TAG: cache
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
 
 jobs:
@@ -32,7 +33,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-          echo 'COLLECTOR_BUILDER_TAG=cache-gha' >> "$GITHUB_ENV"
+          echo "COLLECTOR_BUILDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"
 
       - name: PR checks
         id: pr-checks
@@ -41,12 +42,12 @@ jobs:
           # We have 2 options:
           # - We build the builder from scratch and give it a custom tag
           # - We use the existing cache
-          COLLECTOR_BUILDER_TAG="cache-gha"
+          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
             COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
             echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           else
-            docker pull quay.io/stackrox-io/collector-builder:cache-gha || true
+            docker pull "quay.io/stackrox-io/collector-builder:${DEFAULT_BUILDER_TAG}" || true
           fi
 
           echo "COLLECTOR_BUILDER_TAG=$COLLECTOR_BUILDER_TAG" >> "$GITHUB_ENV"
@@ -79,7 +80,7 @@ jobs:
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Push builder to stackrox-io
-        if: ${{ github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != 'cache-gha' }}
+        if: github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
@@ -100,7 +101,7 @@ jobs:
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
       - name: Push builder to rhacs-eng
-        if: ${{ github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != 'cache-gha' }}
+        if: github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
           docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -24,6 +24,10 @@ on:
         description: |
           Bucket to push built support-packages into
         value: ${{ jobs.common-variables.outputs.support-packages-bucket }}
+      public-support-packages-bucket:
+        description: |
+          Public bucket to push built support-packages into
+        value: ${{ jobs.common-variables.outputs.public-support-packages-bucket }}
 
 jobs:
   common-variables:
@@ -35,6 +39,7 @@ jobs:
       push-drivers-bucket: ${{ steps.gcp-buckets.outputs.push-drivers-bucket }}
       bundles-bucket: ${{ steps.gcp-buckets.outputs.bundles-bucket }}
       support-packages-bucket: ${{ steps.gcp-buckets.outputs.support-packages-bucket }}
+      public-support-packages-bucket: ${{ steps.gcp-buckets.outputs.public-support-packages-bucket }}
 
     steps:
       - uses: actions/checkout@v3
@@ -46,9 +51,9 @@ jobs:
         id: collector-env
         run: |
           if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
-            COLLECTOR_TAG="${{ github.ref_name }}-gha"
+            COLLECTOR_TAG="${{ github.ref_name }}"
           else
-            COLLECTOR_TAG="$(make tag)-gha"
+            COLLECTOR_TAG="$(make tag)"
           fi
 
           echo "collector-tag=${COLLECTOR_TAG}" >> "$GITHUB_OUTPUT"
@@ -57,15 +62,18 @@ jobs:
       - name: Set GCP buckets
         id: gcp-buckets
         run: |
-          # TODO: Move these buckets to the proper ones when we completely switch off OSCI
-          MAIN_DRIVER_BUCKET="mauro-drivers-test/drivers"
-          STAGING_DRIVER_BUCKET="mauro-drivers-test/pr-builds/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          MAIN_DRIVER_BUCKET="collector-modules-osci"
+          STAGING_DRIVER_BUCKET="stackrox-collector-modules-staging/pr-builds/${GITHUB_HEAD_REF}/${{ github.run_id }}"
           BUNDLES_BUCKET="collector-kernel-bundles-public"
-          SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/support-packages/master"
-          STAGING_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages"
+          STAGING_SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          PUBLIC_SUPPORT_PACKAGES_BUCKET="collector-support-public/offline/v1/support-packages"
 
-          echo "drivers-bucket=${MAIN_DRIVER_BUCKET}" >> "$GITHUB_OUTPUT"
-          echo "bundles-bucket=${BUNDLES_BUCKET}" >> "$GITHUB_OUTPUT"
+          {
+            echo "drivers-bucket=${MAIN_DRIVER_BUCKET}"
+            echo "bundles-bucket=${BUNDLES_BUCKET}"
+            echo "public-support-packages-bucket=${PUBLIC_SUPPORT_PACKAGES_BUCKET}"
+          } >> "$GITHUB_OUTPUT"
 
           if [[ ${{ github.event_name }} == "pull_request" ]]; then
             echo "push-drivers-bucket=${STAGING_DRIVER_BUCKET}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,11 +99,7 @@ jobs:
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       support-packages-bucket: ${{ needs.init.outputs.support-packages-bucket }}
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
-    # If you want to test this workflow in a PR, you will need to replace
-    # this condition with `${{ always() }}`, since skipping the upload of
-    # bundles will cause this workflow to skip as well.
-    # if: ${{ github.event_name != 'pull_request' }}
-    if: always()
+    if: always() && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
     needs:
     - init
     - build-drivers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
       branch-name: ${{ needs.build-drivers.outputs.branch-name }}
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       support-packages-bucket: ${{ needs.init.outputs.support-packages-bucket }}
+      public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,8 @@ jobs:
     # If you want to test this workflow in a PR, you will need to replace
     # this condition with `${{ always() }}`, since skipping the upload of
     # bundles will cause this workflow to skip as well.
-    if: ${{ github.event_name != 'pull_request' }}
+    # if: ${{ github.event_name != 'pull_request' }}
+    if: always()
     needs:
     - init
     - build-drivers

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
         description: Bucket where support-packages will be pushed to
+      public-support-packages-bucket:
+        type: string
+        required: true
+        description: Public bucket where support-packages will be pushed to
 
 
 jobs:
@@ -77,6 +81,14 @@ jobs:
           path: /tmp/support-packages/output
           parent: false
           destination: ${{ inputs.support-packages-bucket }}
+
+      - name: Push support-packages to public bucket
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        if: github.event_name == 'push'
+        with:
+          path: /tmp/support-packages/output
+          parent: false
+          destination: ${{ inputs.public-support-packages-bucket }}
 
       - name: Slack notification
         if: failure() && github.event_name == 'push'


### PR DESCRIPTION
## Description

This is the final step for making GHA the official CI solution, OSCI needs to be taken offline first. The PR will remain in draft in order to prevent OSCI from running (GHA jobs trigger regardless of this), once OSCI is disabled we can open and merge this PR directly.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Testing as much of the affected CI jobs as possible through the `build-builder-image` and `no-cache` labels, as well as testing the support-packages. final test will need to happen on the master branch though.
