### PR TITLE
Jv fix make dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ DEV_SSH_SERVER_KEY ?= $(CURDIR)/.collector_dev_ssh_host_ed25519_key
 export COLLECTOR_VERSION := $(COLLECTOR_TAG)
 export MODULE_VERSION := $(shell cat $(CURDIR)/kernel-modules/MODULE_VERSION)
 
-dev-build: image integration-tests-process-network
+dev-build: image
+	make -C integration-tests TestProcessNetwork
 
 .PHONY: tag
 tag:


### PR DESCRIPTION
## Description

Running make dev-build no longer works after changes to how make is used to run integration tests. This fixes that.

## Checklist
- [x] Investigated and inspected CI test results
      TestSocat failed in the integration tests for unrelated reasons
- [x] Ran make dev-build locally

## Testing Performed

See above