### PR TITLE
Fixes shell escaping problem in socat test

### DIFF
--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -10,6 +10,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+//
+// This test is to guard against behavior seen in Collector where multiple
+// process endpoints have incorrect originator process information due to a
+// bug in the PID processing for endpoints in the same container.
+//
+// https://issues.redhat.com/browse/ROX-13560
+//
+// The test will start two socat processes, with distinct listening ports
+// and check that their originators match the appropriate process.
+//
+
 type SocatTestSuite struct {
 	IntegrationTestSuiteBase
 	serverContainer string


### PR DESCRIPTION
## Description

Fixes a shell escaping problem in the socat test, by simplifying the command into two executions in the socat container.  

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
 ~- [ ] Added unit tests~
 ~- [ ] Added integration tests~
 ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Tested locally against RHEL8
