### PR TITLE
Unifies integration test notifications

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -113,16 +113,3 @@ jobs:
             ${{ github.workspace }}/integration-tests/container-logs/**/*
             ${{ github.workspace }}/integration-tests/perf.json
             ${{ github.workspace }}/integration-tests/performance-logs/**/*
-
-      - name: Slack notification
-        if: failure() && github.event_name == 'push'
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
-          SLACK_CHANNEL: oncall
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_LINK_NAMES: true
-          SLACK_TITLE: ${{ inputs.vm_type }} integration test failed
-          MSG_MINIMAL: actions url,commit
-          SLACK_MESSAGE: |
-            @collector-team

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    if: always() && contains(join(needs.*.result, ','), 'failure') # && github.event_name == 'push'
+    if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'push'
     needs:
       - required-integration-tests
       - all-integration-tests
@@ -55,8 +55,8 @@ jobs:
       - name: Slack notification
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
-          SLACK_CHANNEL: oncall
+          SLACK_WEBHOOK: ${{ secrets.SLACK_COLLECTOR_NOTIFICATIONS_WEBHOOK }}
+          SLACK_CHANNEL: collector-notifications
           SLACK_COLOR: failure
           SLACK_LINK_NAMES: true
           SLACK_TITLE: "NOTIFICATION TEST: Integration tests failed."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,12 +47,12 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
+    if: always() && contains(join(needs.*.result, ','), 'failure') # && github.event_name == 'push'
     needs:
       - required-integration-tests
       - all-integration-tests
     steps:
       - name: Slack notification
-        if: always() #&& contains(join(needs.*.result, ','), 'failure') && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,14 +52,14 @@ jobs:
       - all-integration-tests
     steps:
       - name: Slack notification
-        if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'push'
+        if: always() #&& contains(join(needs.*.result, ','), 'failure') && github.event_name == 'push'
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
           SLACK_CHANNEL: oncall
           SLACK_COLOR: failure
           SLACK_LINK_NAMES: true
-          SLACK_TITLE: Integration tests failed.
+          SLACK_TITLE: "NOTIFICATION TEST: Integration tests failed."
           MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @collector-team

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,3 +44,22 @@ jobs:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ inputs.collector-tag }}
     secrets: inherit
+
+  notify:
+    runs-on: ubuntu-latest
+    needs:
+      - required-integration-tests
+      - all-integration-tests
+    steps:
+      - name: Slack notification
+        if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'push'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+          SLACK_CHANNEL: oncall
+          SLACK_COLOR: failure
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: Integration tests failed.
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @collector-team

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
           SLACK_CHANNEL: collector-notifications
           SLACK_COLOR: failure
           SLACK_LINK_NAMES: true
-          SLACK_TITLE: "NOTIFICATION TEST: Integration tests failed."
+          SLACK_TITLE: "Integration tests failed."
           MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @collector-team


### PR DESCRIPTION
## Description

Puts notifications for integration tests one level higher so a notification is sent once instead of for each individual integration test platform.

## Checklist
- [ ] Investigated and inspected CI test results

