### PR TITLE
rox-14174 collector should report udp endpoints

### DIFF
--- a/collector/connscrape.cpp
+++ b/collector/connscrape.cpp
@@ -38,12 +38,13 @@ BoolEnvVar scrape_endpoints("SCRAPE_ENDPOINTS", true);
 
 int main(int argc, char** argv) {
   const char* proc_dir = "/proc";
+  bool collect_udp = true;
 
   if (argc > 1) {
     proc_dir = argv[1];
   }
 
-  ConnScraper scraper(proc_dir);
+  ConnScraper scraper(proc_dir, collect_udp);
   std::vector<Connection> conns;
   std::vector<ContainerEndpoint> endpoints;
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -56,6 +56,8 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
 BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", true);
+// If true, UDP listening endpoints will be reported
+BoolEnvVar set_are_udp_listening_endpoints_collected("ROX_COLLECT_UDP_LISTENING_ENDPOINTS", false);
 
 BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
@@ -189,6 +191,13 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
 
   if (set_enable_core_dump) {
     enable_core_dump_ = true;
+  }
+
+  if (set_are_udp_listening_endpoints_collected) {
+    are_udp_listening_endpoints_collected_ = true;
+    CLOG(INFO) << "Collecting UDP listening endpoints";
+  } else {
+    CLOG(INFO) << "Not collecting UDP listening endpoints";
   }
 
   HandleAfterglowEnvVars();

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -132,11 +132,8 @@ end
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
   bool core_bpf_hardfail_;
-<<<<<<< HEAD
   bool import_users_;
-=======
   bool are_udp_listening_endpoints_collected_ = false;
->>>>>>> a4040548 (X-Smart-Squash: Squashed 32 commits:)
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -108,6 +108,7 @@ end
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
   bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
   bool ImportUsers() const { return import_users_; }
+  bool AreUdpListeningEndpointsCollected() const { return are_udp_listening_endpoints_collected_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -131,7 +132,11 @@ end
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
   bool core_bpf_hardfail_;
+<<<<<<< HEAD
   bool import_users_;
+=======
+  bool are_udp_listening_endpoints_collected_ = false;
+>>>>>>> a4040548 (X-Smart-Squash: Squashed 32 commits:)
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -94,7 +94,7 @@ void CollectorService::RunForever() {
       if (config_.IsProcessesListeningOnPortsEnabled()) {
         process_store = std::make_shared<ProcessStore>(&sysdig_);
       }
-      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
+      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), config_.AreUdpListeningEndpointsCollected(), process_store);
       conn_tracker = std::make_shared<ConnectionTracker>();
       UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
       conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));

--- a/collector/lib/NetworkConnection.cpp
+++ b/collector/lib/NetworkConnection.cpp
@@ -55,9 +55,9 @@ size_t Hash(const L4ProtoPortPair& pp) {
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint) {
   if (container_endpoint.originator()) {
-    return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << *container_endpoint.originator();
+    return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << container_endpoint.l4proto() << ": " << *container_endpoint.originator();
   } else {
-    return os << container_endpoint.container() << ": " << container_endpoint.endpoint();
+    return os << container_endpoint.container() << ": " << container_endpoint.endpoint() << ": " << container_endpoint.l4proto();
   }
 }
 

--- a/collector/lib/ProcfsScraper.h
+++ b/collector/lib/ProcfsScraper.h
@@ -42,15 +42,15 @@ class IConnScraper {
 // ConnScraper is a class that allows scraping a `/proc`-like directory structure for active network connections.
 class ConnScraper : public IConnScraper {
  public:
-  explicit ConnScraper(std::string proc_path, std::shared_ptr<ProcessStore> process_store = 0)
-      : proc_path_(std::move(proc_path)),
-        process_store_(process_store) {}
+  explicit ConnScraper(std::string proc_path, bool are_udp_listening_endpoints_collected, std::shared_ptr<ProcessStore> process_store = 0)
+      : proc_path_(std::move(proc_path)), are_udp_listening_endpoints_collected_(are_udp_listening_endpoints_collected), process_store_(process_store) {}
 
   // Scrape returns a snapshot of all active network connections in the given vector.
   bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints);
 
  private:
   std::string proc_path_;
+  bool are_udp_listening_endpoints_collected_;
   std::shared_ptr<ProcessStore> process_store_;
 };
 

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -411,3 +411,99 @@ func TestConnectionsAndEndpointsUDPNoFork(t *testing.T) {
 	}
 	suite.Run(t, mixedHighLowPorts)
 }
+
+func TestConnectionsAndEndpointsUDPPersistent(t *testing.T) {
+	persistentConnection := &suites.ConnectionsAndEndpointsTestSuite{
+		Server: suites.Container{
+			Name: "socat-server-udp-persistent",
+			Cmd:  "socat -d -d -v -u UDP4-LISTEN:40,reuseaddr,fork - &> /socat-log.txt &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   ":40",
+					RemoteAddress:  "CLIENT_IP",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: []common.EndpointInfo{
+				{
+					Protocol: "L4_PROTOCOL_UDP",
+					Address: &common.ListenAddress{
+						AddressData: `"\000\000\000\000"`,
+						Port:        40,
+						IpNetwork:   `"\000\000\000\000 " `,
+					},
+				},
+			},
+		},
+		Client: suites.Container{
+			Name: "socat-client-udp-persistent",
+			Cmd:  "while [ true ]; do echo hello; sleep 1; done | socat -d -d -v -u - UDP4:SERVER_IP:40 &> /socat-log.txt &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "SERVER_IP:40",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+	}
+	suite.Run(t, persistentConnection)
+}
+
+func TestConnectionsAndEndpointsUDPPersistent2(t *testing.T) {
+	persistentConnection := &suites.ConnectionsAndEndpointsTestSuite{
+		Server: suites.Container{
+			Name: "socat-server-udp-persistent",
+			Cmd:  "socat -d -d -v -u UDP4-LISTEN:40,reuseaddr,fork,bind=SERVER_IP - &> /socat-log.txt &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   ":40",
+					RemoteAddress:  "CLIENT_IP",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: []common.EndpointInfo{
+				{
+					Protocol: "L4_PROTOCOL_UDP",
+					Address: &common.ListenAddress{
+						AddressData: `"\000\000\000\000"`,
+						Port:        40,
+						IpNetwork:   `"\000\000\000\000 " `,
+					},
+				},
+			},
+		},
+		Client: suites.Container{
+			Name: "socat-client-udp-persistent",
+			Cmd:  "while [ true ]; do echo hello; sleep 1; done | socat -d -d -v -u - UDP4:SERVER_IP:40 &> /socat-log.txt &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "SERVER_IP:40",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+	}
+	suite.Run(t, persistentConnection)
+}
+
+func TestUdp(t *testing.T) {
+	udpTestSuite := &suites.UdpTestSuite{CollectUdp: true}
+	suite.Run(t, udpTestSuite)
+}
+
+func TestUdpDisabled(t *testing.T) {
+	udpTestSuite := &suites.UdpTestSuite{CollectUdp: false}
+	suite.Run(t, udpTestSuite)
+}

--- a/integration-tests/suites/udp.go
+++ b/integration-tests/suites/udp.go
@@ -1,0 +1,114 @@
+package suites
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/stackrox/collector/integration-tests/suites/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type UdpTestSuite struct {
+	IntegrationTestSuiteBase
+	ListenContainer string
+	SendtoContainer string
+	CollectUdp      bool
+}
+
+// This test checks if we are reporting UDP endpoints correctly. It launches collector and two
+// socat containers. One listens for UDP messages and the other is set up to send UDP messages.
+// We make sure that listening UDP endpoint is seen and that the sending UDP endpoint is not.
+
+func (s *UdpTestSuite) SetupSuite() {
+
+	s.metrics = map[string]float64{}
+	s.executor = common.NewExecutor()
+	s.StartContainerStats()
+	s.collector = common.NewCollectorManager(s.executor, s.T().Name())
+
+	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
+	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
+	s.collector.Env["ROX_COLLECT_UDP_LISTENING_ENDPOINTS"] = strconv.FormatBool(s.CollectUdp)
+
+	err := s.collector.Setup()
+	s.Require().NoError(err)
+
+	err = s.collector.Launch()
+	s.Require().NoError(err)
+	time.Sleep(30 * time.Second)
+
+	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")
+
+	containerListenID, err := s.launchContainer("socat-listen", processImage, "/bin/sh", "-c", "/bin/sleep 3000")
+	s.Require().NoError(err)
+
+	containerSendtoID, err := s.launchContainer("socat-sendto", processImage, "/bin/sh", "-c", "/bin/sleep 3000")
+	s.Require().NoError(err)
+
+	_, err = s.execContainer("socat-listen", []string{"/bin/sh", "-c", "socat -d -d -v UDP-RECVFROM:80,fork - &> /socat-log.txt &"})
+	s.Require().NoError(err)
+
+	listenIP, err := s.getIPAddress("socat-listen")
+	s.Require().NoError(err)
+
+	_, err = s.execContainer("socat-sendto", []string{"/bin/sh", "-c", "echo Hello | socat -d -d -v UDP-SENDTO:" + listenIP + ":80 STDIN &> /socat-log.txt &"})
+	s.Require().NoError(err)
+
+	s.ListenContainer = common.ContainerShortID(containerListenID)
+	s.SendtoContainer = common.ContainerShortID(containerSendtoID)
+
+	time.Sleep(6 * time.Second)
+
+	err = s.collector.TearDown()
+	s.Require().NoError(err)
+
+	s.db, err = s.collector.BoltDB()
+	s.Require().NoError(err)
+}
+
+func (s *UdpTestSuite) TearDownSuite() {
+	s.cleanupContainer([]string{"socat-listen", "socat-sendto", "collector"})
+	stats := s.GetContainerStats()
+	s.PrintContainerStats(stats)
+	s.WritePerfResults("UDP", stats, s.metrics)
+}
+
+func (s *UdpTestSuite) TestUdp() {
+	processes, err := s.GetProcesses(s.ListenContainer)
+	s.Require().NoError(err)
+
+	assert.Equal(s.T(), 4, len(processes))
+
+	sendtoProcesses, err := s.GetProcesses(s.SendtoContainer)
+	s.Require().NoError(err)
+	sendtoEndpoints, err := s.GetEndpoints(s.SendtoContainer)
+	s.Require().Error(err)
+
+	// There should not be any UDP listening endpoints in the container sending UDP messages
+	assert.Equal(s.T(), 0, len(sendtoEndpoints))
+	assert.Equal(s.T(), 4, len(sendtoProcesses))
+
+	if s.CollectUdp {
+		// If UDP endpoints are collected we should expect to see it
+		endpoints, err := s.GetEndpoints(s.ListenContainer)
+		s.Require().NoError(err)
+
+		if !assert.Equal(s.T(), 1, len(endpoints)) {
+			// We can't continue if this is not the case, so panic immediately.
+			// It indicates an internal issue with this test and the non-deterministic
+			// way in which endpoints are reported.
+			assert.FailNowf(s.T(), "", "retrieved %d endpoints (expect 1)", len(endpoints))
+		}
+
+		assert.Equal(s.T(), "L4_PROTOCOL_UDP", endpoints[0].Protocol)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessName, processes[3].Name)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessExecFilePath, processes[3].ExePath)
+		assert.Equal(s.T(), endpoints[0].Originator.ProcessArgs, processes[3].Args)
+		assert.Equal(s.T(), 80, endpoints[0].Address.Port)
+
+	} else {
+		// If collecting UDP is disabled trying to get the endpoints from the bucket should result in an error
+		_, err := s.GetEndpoints(s.ListenContainer)
+		s.Require().Error(err)
+	}
+}


### PR DESCRIPTION
## Description

Currently ProcfsScraper only scrapes TCP endpoints. With these changes it will also scrape UDP endpoints. This does not change anything in regards to how connections are reported.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly
- [x] Run in stackrox/stackrox CI for master branch https://github.com/stackrox/stackrox/pull/4371
       Upgrade test failed, because of processes listening on ports.
- [x] Run manually and see UDP endpoints in network graph

**Automated testing**
  - [x] Added integration tests

## Testing Performed

CI is sufficient
