### PR TITLE
Moves Benchmark tests behind build tag

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -14,7 +14,7 @@ SHELL=/bin/bash
 # Environment variable COLLECTOR_IMAGE is used by integration-tests
 export COLLECTOR_IMAGE
 
-ALL_TESTS = $(shell go test -list .)
+ALL_TESTS = $(shell go test -tags all -list .)
 
 #
 # Macro to define a test-specific target, based on the list
@@ -24,7 +24,7 @@ define make-test-target
 $1: docker-clean
 	go version
 	set -o pipefail; \
-		go test -timeout 60m -count=1 -v \
+		go test -tags all -timeout 60m -count=1 -v \
 		-run $1 2>&1 | tee -a integration-test.log
 endef
 

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -14,7 +14,7 @@ SHELL=/bin/bash
 # Environment variable COLLECTOR_IMAGE is used by integration-tests
 export COLLECTOR_IMAGE
 
-ALL_TESTS = $(shell go test -tags all -list .)
+ALL_TESTS = $(shell go test -tags bench -list .)
 
 #
 # Macro to define a test-specific target, based on the list
@@ -24,7 +24,7 @@ define make-test-target
 $1: docker-clean
 	go version
 	set -o pipefail; \
-		go test -tags all -timeout 60m -count=1 -v \
+		go test -tags bench -timeout 60m -count=1 -v \
 		-run $1 2>&1 | tee -a integration-test.log
 endef
 

--- a/integration-tests/benchmark_test.go
+++ b/integration-tests/benchmark_test.go
@@ -1,5 +1,5 @@
-//go:build all
-// +build all
+//go:build bench
+// +build bench
 
 package integrationtests
 

--- a/integration-tests/benchmark_test.go
+++ b/integration-tests/benchmark_test.go
@@ -1,0 +1,20 @@
+//go:build all
+// +build all
+
+package integrationtests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stackrox/collector/integration-tests/suites"
+)
+
+func TestBenchmarkBaseline(t *testing.T) {
+	suite.Run(t, new(suites.BenchmarkBaselineTestSuite))
+}
+
+func TestBenchmarkCollector(t *testing.T) {
+	suite.Run(t, new(suites.BenchmarkCollectorTestSuite))
+}

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -114,11 +114,3 @@ func TestSymbolicLinkProcess(t *testing.T) {
 func TestSocat(t *testing.T) {
 	suite.Run(t, new(suites.SocatTestSuite))
 }
-
-func TestBenchmarkBaseline(t *testing.T) {
-	suite.Run(t, new(suites.BenchmarkBaselineTestSuite))
-}
-
-func TestBenchmarkCollector(t *testing.T) {
-	suite.Run(t, new(suites.BenchmarkCollectorTestSuite))
-}

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package suites
 
 import (

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -1,6 +1,3 @@
-//go:build all
-// +build all
-
 package suites
 
 import (


### PR DESCRIPTION
## Description

Prevents the benchmarks from running unless specified. They are currently running on master builds, which is slowing down the integration tests and causing some timeout errors.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

If any of these don't apply, please comment below.

## Testing Performed
Tested locally.
