### PR TITLE
Migrate CPaaS related CI to GHA

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -22,7 +22,11 @@ on:
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      contains(github.event.pull_request.labels.*.name, 'build-full-images') ||
+      contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
@@ -105,7 +109,10 @@ jobs:
 
   retag-collector-full:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
+    if: |
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'build-full-images') &&
+      !contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
     env:
       COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -18,6 +18,11 @@ on:
         required: true
         description: |
           GCP bucket to pull drivers from.
+      max-layer-depth:
+        type: string
+        default: "5"
+        description: |
+          Max layer the drivers will be split into
 
 jobs:
   build-collector-full:
@@ -63,13 +68,13 @@ jobs:
       - name: Pull slim image and build full image
         run: |
           docker build \
-            --target=probe-layer-5 \
+            --target=probe-layer-${{ inputs.max-layer-depth }} \
             --tag "${COLLECTOR_IMAGE}" \
             --build-arg collector_repo=quay.io/stackrox-io/collector \
             --build-arg collector_version=${{ inputs.collector-tag }} \
             --build-arg module_version="${DRIVER_VERSION}" \
             --build-arg max_layer_size=300 \
-            --build-arg max_layer_depth=5 \
+            --build-arg max_layer_depth=${{ inputs.max-layer-depth }} \
             "${{ github.workspace }}/kernel-modules/container"
 
       - name: Login to quay.io/stackrox-io

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -8,6 +8,12 @@ on:
         required: true
         description: |
           The tag used to build the collector image
+      build-full-image:
+        type: boolean
+        required: true
+        description: |
+          If true, the full collector image will be built, else, the -slim
+          image of collector will be retagged.
       skip-built-drivers:
         type: boolean
         required: true
@@ -27,11 +33,7 @@ on:
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'schedule' ||
-      contains(github.event.pull_request.labels.*.name, 'build-full-images') ||
-      contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+    if: inputs.build-full-image
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
@@ -114,10 +116,7 @@ jobs:
 
   retag-collector-full:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.labels.*.name, 'build-full-images') &&
-      !contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+    if: ${{ !inputs.build-full-image }}
     env:
       COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -26,6 +26,8 @@ jobs:
         - ppc64le
 
     steps:
+      - uses: actions/checkout@v3
+
       - uses: docker/login-action@v2
         with:
           registry: brew.registry.redhat.io

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -62,7 +62,7 @@ jobs:
             files=("${driver_version_dir}"/*.{gz,unavail})
             [[ "${#files[@]}" -gt 0 ]] || continue
             printf '%s\n' "${files[@]}" | \
-              gsutil -m cp -n -I "${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+          gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
           done
 
       - name: Push support-packages

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -70,7 +70,7 @@ jobs:
             files=("${driver_version_dir}"/*.{gz,unavail})
             [[ "${#files[@]}" -gt 0 ]] || continue
             printf '%s\n' "${files[@]}" | \
-              gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+              gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/${{ matrix.platform }}/$(basename "${driver_version_dir}")/"
           done
 
       - name: Push support-packages

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
       - name: Push drivers
         run : |
           set -x
@@ -62,7 +65,7 @@ jobs:
             files=("${driver_version_dir}"/*.{gz,unavail})
             [[ "${#files[@]}" -gt 0 ]] || continue
             printf '%s\n' "${files[@]}" | \
-          gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+              gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
           done
 
       - name: Push support-packages

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -55,11 +55,15 @@ jobs:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: Push drivers
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: ${{ env.DRIVER_TMP_DIR }}
-          parent: false
-          destination: ${{ inputs.drivers-bucket }}/${{ github.run_id }}
+        run : |
+          set -x
+
+          for driver_version_dir in "${DRIVER_TMP_DIR}"/*; do
+            files=("${driver_version_dir}"/*.{gz,unavail})
+            [[ "${#files[@]}" -gt 0 ]] || continue
+            printf '%s\n' "${files[@]}" | \
+              gsutil -m cp -n -I "${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+          done
 
       - name: Push support-packages
         uses: 'google-github-actions/upload-cloud-storage@v1'

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
-          destination: ${{ inputs.support-packages-bucket }}/${{ github.run_id }}/${{ matrix.platform }}
+          destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}
 
       - name: Check build failures
         id: drivers-build-failures

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -44,7 +44,7 @@ jobs:
 
           TMP_DIR="$(mktemp -d)"
           {
-            echo "FAILURES_TMP_DIR=${TMP_DIR}/FAILURES"
+            echo "FAILURES_DIR=${TMP_DIR}/FAILURES"
             echo "DRIVER_TMP_DIR=${TMP_DIR}/kernel-modules"
             echo "SUPPORT_PACKAGE_TMP_DIR=${TMP_DIR}/support-packages"
           } >> "$GITHUB_ENV"
@@ -83,7 +83,7 @@ jobs:
       - name: Check build failures
         id: drivers-build-failures
         run: |
-          FAILURES_DIR=/tmp/FAILURES/ ${{ github.workspace }}/.openshift-ci/drivers/scripts/drivers-build-failures.sh
+          ${{ github.workspace }}/.openshift-ci/drivers/scripts/drivers-build-failures.sh
 
       - name: Slack notification
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Push drivers
         run : |
-          set -x
+          shopt -s nullglob
+          shopt -s dotglob
 
           for driver_version_dir in "${DRIVER_TMP_DIR}"/*; do
             files=("${driver_version_dir}"/*.{gz,unavail})

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -54,18 +54,16 @@ jobs:
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
-      - name: Sync drivers
-        run: |
-          for driver_version_dir in "${DRIVER_TMP_DIR}"/*; do
-              files=("${driver_version_dir}"/*.{gz,unavail})
-              [[ "${#files[@]}" -gt 0 ]] || continue
-              printf '%s\n' "${files[@]}" | \
-                gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
-          done
+      - name: Push drivers
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: ${{ env.DRIVER_TMP_DIR }}/${{ github.run_id }}
+          parent: false
+          destination: ${{ inputs.drivers-bucket }}
 
       - name: Push support-packages
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
+          path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}/${{ github.run_id }}
           parent: false
           destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Push drivers
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: ${{ env.DRIVER_TMP_DIR }}/${{ github.run_id }}
+          path: ${{ env.DRIVER_TMP_DIR }}
           parent: false
-          destination: ${{ inputs.drivers-bucket }}
+          destination: ${{ inputs.drivers-bucket }}/${{ github.run_id }}
 
       - name: Push support-packages
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}/${{ github.run_id }}
+          path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
-          destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}
+          destination: ${{ inputs.support-packages-bucket }}/${{ github.run_id }}/${{ matrix.platform }}

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -51,7 +51,7 @@ jobs:
               files=("${driver_version_dir}"/*.{gz,unavail})
               [[ "${#files[@]}" -gt 0 ]] || continue
               printf '%s\n' "${files[@]}" | \
-                gsutil -m cp -n -I "${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+                gsutil -m cp -n -I "gs://${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
           done
 
       - name: Push support-packages

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -43,9 +43,13 @@ jobs:
             brew.registry.redhat.io/rh-osbs/rhacs-drivers-build-rhel8:0.1.0
 
           TMP_DIR="$(mktemp -d)"
-          echo "DRIVER_TMP_DIR=${TMP_DIR}/kernel-modules" >> "$GITHUB_ENV"
-          echo "SUPPORT_PACKAGE_TMP_DIR=${TMP_DIR}/support-packages" >> "$GITHUB_ENV"
+          {
+            echo "FAILURES_TMP_DIR=${TMP_DIR}/FAILURES"
+            echo "DRIVER_TMP_DIR=${TMP_DIR}/kernel-modules"
+            echo "SUPPORT_PACKAGE_TMP_DIR=${TMP_DIR}/support-packages"
+          } >> "$GITHUB_ENV"
 
+          docker cp drivers:/FAILURES/ "${TMP_DIR}"
           docker cp drivers:/kernel-modules/ "${TMP_DIR}"
           docker cp drivers:/support-packages/ "${TMP_DIR}"
 
@@ -75,3 +79,21 @@ jobs:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
           destination: ${{ inputs.support-packages-bucket }}/${{ github.run_id }}/${{ matrix.platform }}
+
+      - name: Check build failures
+        id: drivers-build-failures
+        run: |
+          FAILURES_DIR=/tmp/FAILURES/ ${{ github.workspace }}/.openshift-ci/drivers/scripts/drivers-build-failures.sh
+
+      - name: Slack notification
+        if: failure() && github.event_name == 'schedule'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ONCALL }}
+          SLACK_CHANNEL: oncall
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: CPaaS driver build check failed
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @collector-team

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -17,6 +17,14 @@ on:
 jobs:
   sync-drivers:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - x86
+        - s390x
+        - ppc64le
+
     steps:
       - uses: docker/login-action@v2
         with:
@@ -27,18 +35,17 @@ jobs:
       - name: Download driver image and extract files
         run: |
           docker create \
+            --platform linux/${{ matrix.platform }} \
             --name drivers \
             --pull always \
             brew.registry.redhat.io/rh-osbs/rhacs-drivers-build-rhel8:0.1.0
 
-          DRIVER_TMP_DIR="$(mktemp -d)"
-          echo "DRIVER_TMP_DIR=${DRIVER_TMP_DIR}" >> "$GITHUB_ENV"
+          TMP_DIR="$(mktemp -d)"
+          echo "DRIVER_TMP_DIR=${TMP_DIR}/kernel-modules" >> "$GITHUB_ENV"
+          echo "SUPPORT_PACKAGE_TMP_DIR=${TMP_DIR}/support-packages" >> "$GITHUB_ENV"
 
-          SUPPORT_PACKAGE_TMP_DIR="$(mktemp -d)"
-          echo "SUPPORT_PACKAGE_TMP_DIR=${SUPPORT_PACKAGE_TMP_DIR}" >> "$GITHUB_ENV"
-
-          docker cp drivers:/kernel-modules/ "${DRIVER_TMP_DIR}"
-          docker cp drivers:/support-packages/ "${SUPPORT_PACKAGE_TMP_DIR}"
+          docker cp drivers:/kernel-modules/ "${TMP_DIR}"
+          docker cp drivers:/support-packages/ "${TMP_DIR}"
 
       - name: Authenticate with GCP
         uses: 'google-github-actions/auth@v1'
@@ -57,6 +64,6 @@ jobs:
       - name: Push support-packages
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
-          path: /tmp/support-packages/output
+          path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
-          destination: ${{ inputs.support-packages-bucket }}
+          destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - x86
+        - x86_64
         - s390x
         - ppc64le
 

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -2,7 +2,7 @@ name: CPaaS related workflows
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * *'
   # TODO: Remove the PR trigger once done testing
   pull_request:
 
@@ -35,8 +35,29 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       skip-built-drivers: true
+      max-layer-depth: "0"
     secrets: inherit
     needs:
     - init
     - build-collector-slim
     - sync-drivers-and-support-packages
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+
+  integration-tests:
+    uses: ./.github/workflows/integration-tests-vm-type.yml
+    strategy:
+      # ensure that if one part of the matrix fails, the
+      # rest will continue
+      fail-fast: false
+      matrix:
+        vm_type:
+          - rhel
+          - rhel-sap
+    with:
+      vm_type: ${{ matrix.vm_type }}
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+    needs:
+    - init
+    - build-collector-full
+    secrets: inherit
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -1,0 +1,19 @@
+name: CPaaS related workflows
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  # TODO: Remove the PR trigger once done testing
+  pull_request:
+
+jobs:
+  init:
+    uses: ./.github/workflows/init.yml
+
+  sync-drivers-and-support-packages:
+    uses: ./.github/workflows/cpaas/sync-drivers.yml
+    needs: init
+    secrets: inherit
+    with:
+      support-packages-bucket: ${{ needs.init.outputs.cpaas-support-packages-bucket }}
+      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/init.yml
 
   sync-drivers-and-support-packages:
-    uses: ./.github/workflows/cpaas/sync-drivers.yml
+    uses: ./.github/workflows/cpaas-sync-drivers.yml
     needs: init
     secrets: inherit
     with:

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -35,7 +35,7 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       skip-built-drivers: true
-      max-layer-depth: "0"
+      max-layer-depth: "1"
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -3,13 +3,11 @@ name: CPaaS related workflows
 on:
   schedule:
     - cron: '0 6 * * *'
-  # TODO: Remove the PR trigger once done testing
-  pull_request:
+  workflow_call:
 
 jobs:
   init:
     uses: ./.github/workflows/init.yml
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
 
   sync-drivers-and-support-packages:
     uses: ./.github/workflows/cpaas-sync-drivers.yml
@@ -18,7 +16,6 @@ jobs:
     with:
       support-packages-bucket: ${{ needs.init.outputs.cpaas-support-packages-bucket }}
       drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
 
   build-collector-slim:
     uses: ./.github/workflows/collector-slim.yml
@@ -27,7 +24,6 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       collector-image: ${{ needs.init.outputs.collector-image }}-cpaas
     secrets: inherit
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
 
   build-collector-full:
     uses: ./.github/workflows/collector-full.yml
@@ -42,7 +38,6 @@ jobs:
     - init
     - build-collector-slim
     - sync-drivers-and-support-packages
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
 
   integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
@@ -62,4 +57,3 @@ jobs:
     - init
     - build-collector-full
     secrets: inherit
-    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -56,6 +56,7 @@ jobs:
     with:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+      offline-mode: true
     needs:
     - init
     - build-collector-full

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -33,9 +33,10 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
+      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
       skip-built-drivers: true
       max-layer-depth: "1"
+      build-full-image: true
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   init:
     uses: ./.github/workflows/init.yml
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
 
   sync-drivers-and-support-packages:
     uses: ./.github/workflows/cpaas-sync-drivers.yml
@@ -17,3 +18,25 @@ jobs:
     with:
       support-packages-bucket: ${{ needs.init.outputs.cpaas-support-packages-bucket }}
       drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+
+  build-collector-slim:
+    uses: ./.github/workflows/collector-slim.yml
+    needs: init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+      collector-image: ${{ needs.init.outputs.collector-image }}-cpaas
+    secrets: inherit
+    if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+
+  build-collector-full:
+    uses: ./.github/workflows/collector-full.yml
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
+      skip-built-drivers: true
+    secrets: inherit
+    needs:
+    - init
+    - build-collector-slim
+    - sync-drivers-and-support-packages

--- a/.github/workflows/cpaas/sync-drivers.yml
+++ b/.github/workflows/cpaas/sync-drivers.yml
@@ -1,0 +1,62 @@
+name: Sync CPaaS built drivers with GCP
+
+on:
+  workflow_call:
+    inputs:
+      support-packages-bucket:
+        type: string
+        required: true
+        description: |
+          Bucket where CPaaS support packages will be pushed to.
+      drivers-bucket:
+        type: string
+        required: true
+        description: |
+          Bucket where CPaaS drivers will be pushed to.
+
+jobs:
+  sync-drivers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: brew.registry.redhat.io
+          username: ${{ secrets.REDHAT_USERNAME }}
+          password: ${{ secrets.REDHAT_PASSWORD }}
+
+      - name: Download driver image and extract files
+        run: |
+          docker create \
+            --name drivers \
+            --pull always \
+            brew.registry.redhat.io/rh-osbs/rhacs-drivers-build-rhel8:0.1.0
+
+          DRIVER_TMP_DIR="$(mktemp -d)"
+          echo "DRIVER_TMP_DIR=${DRIVER_TMP_DIR}" >> "$GITHUB_ENV"
+
+          SUPPORT_PACKAGE_TMP_DIR="$(mktemp -d)"
+          echo "SUPPORT_PACKAGE_TMP_DIR=${SUPPORT_PACKAGE_TMP_DIR}" >> "$GITHUB_ENV"
+
+          docker cp drivers:/kernel-modules/ "${DRIVER_TMP_DIR}"
+          docker cp drivers:/support-packages/ "${SUPPORT_PACKAGE_TMP_DIR}"
+
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+
+      - name: Sync drivers
+        run: |
+          for driver_version_dir in "${DRIVER_TMP_DIR}"/*; do
+              files=("${driver_version_dir}"/*.{gz,unavail})
+              [[ "${#files[@]}" -gt 0 ]] || continue
+              printf '%s\n' "${files[@]}" | \
+                gsutil -m cp -n -I "${{ inputs.drivers-bucket }}/$(basename "${driver_version_dir}")/"
+          done
+
+      - name: Push support-packages
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: /tmp/support-packages/output
+          parent: false
+          destination: ${{ inputs.support-packages-bucket }}

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set GCP buckets
         id: gcp-buckets
         run: |
-          STAGING_RELATIVE_PATH="${GITHUB_HEAD_REF}/${{ github.run_id}}"
+          STAGING_RELATIVE_PATH="${GITHUB_HEAD_REF}/${{ github.run_id }}"
 
           MAIN_DRIVER_BUCKET="collector-modules-osci"
           STAGING_DRIVER_BUCKET="stackrox-collector-modules-staging/pr-builds/${STAGING_RELATIVE_PATH}"

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -79,19 +79,27 @@ jobs:
           PUBLIC_SUPPORT_PACKAGES_BUCKET="collector-support-public/offline/v1/support-packages"
           CPAAS_DRIVERS_BUCKET="mauro-drivers-test/cpaas/drivers"
           CPAAS_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/support-packages"
+          CPAAS_STAGING_DRIVERS_BUCKET="mauro-drivers-test/cpaas/staging/drivers"
+          CPAAS_STAGING_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/staging/support-packages"
 
           {
             echo "drivers-bucket=${MAIN_DRIVER_BUCKET}"
             echo "bundles-bucket=${BUNDLES_BUCKET}"
             echo "public-support-packages-bucket=${PUBLIC_SUPPORT_PACKAGES_BUCKET}"
-            echo "cpaas-drivers-bucket=${CPAAS_DRIVERS_BUCKET}"
-            echo "cpaas-support-packages-bucket=${CPAAS_SUPPORT_PACKAGES_BUCKET}"
           } >> "$GITHUB_OUTPUT"
 
           if [[ ${{ github.event_name }} == "pull_request" ]]; then
-            echo "push-drivers-bucket=${STAGING_DRIVER_BUCKET}" >> "$GITHUB_OUTPUT"
-            echo "support-packages-bucket=${STAGING_SUPPORT_PACKAGES_BUCKET}" >> "$GITHUB_OUTPUT"
+            {
+              echo "push-drivers-bucket=${STAGING_DRIVER_BUCKET}"
+              echo "support-packages-bucket=${STAGING_SUPPORT_PACKAGES_BUCKET}"
+              echo "cpaas-drivers-bucket=${CPAAS_STAGING_DRIVERS_BUCKET}"
+              echo "cpaas-support-packages-bucket=${CPAAS_STAGING_SUPPORT_PACKAGES_BUCKET}"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "push-drivers-bucket=${MAIN_DRIVER_BUCKET}" >> "$GITHUB_OUTPUT"
-            echo "support-packages-bucket=${SUPPORT_PACKAGES_BUCKET}" >> "$GITHUB_OUTPUT"
+            {
+              echo "push-drivers-bucket=${MAIN_DRIVER_BUCKET}"
+              echo "support-packages-bucket=${SUPPORT_PACKAGES_BUCKET}"
+              echo "cpaas-drivers-bucket=${CPAAS_DRIVERS_BUCKET}"
+              echo "cpaas-support-packages-bucket=${CPAAS_SUPPORT_PACKAGES_BUCKET}"
+            } >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -28,7 +28,14 @@ on:
         description: |
           Public bucket to push built support-packages into
         value: ${{ jobs.common-variables.outputs.public-support-packages-bucket }}
-
+      cpaas-support-packages-bucket:
+        description: |
+          Bucket to push CPaaS built support-packages into
+        value: ${{ jobs.common-variables.outputs.cpaas-support-packages-bucket }}
+      cpaas-drivers-bucket:
+        description: |
+          Bucket to push CPaaS built drivers into
+        value: ${{ jobs.common-variables.outputs.cpaas-drivers-bucket }}
 jobs:
   common-variables:
     runs-on: ubuntu-latest
@@ -40,6 +47,8 @@ jobs:
       bundles-bucket: ${{ steps.gcp-buckets.outputs.bundles-bucket }}
       support-packages-bucket: ${{ steps.gcp-buckets.outputs.support-packages-bucket }}
       public-support-packages-bucket: ${{ steps.gcp-buckets.outputs.public-support-packages-bucket }}
+      cpaas-drivers-bucket: ${{ steps.gcp-buckets.outputs.cpaas-drivers-bucket }}
+      cpaas-support-packages-bucket: ${{ steps.gcp-buckets.outputs.cpaas-support-packages-bucket }}
 
     steps:
       - uses: actions/checkout@v3
@@ -68,11 +77,15 @@ jobs:
           SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages"
           STAGING_SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}"
           PUBLIC_SUPPORT_PACKAGES_BUCKET="collector-support-public/offline/v1/support-packages"
+          CPAAS_DRIVERS_BUCKET="mauro-drivers-test/cpaas/drivers"
+          CPAAS_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/support-packages"
 
           {
             echo "drivers-bucket=${MAIN_DRIVER_BUCKET}"
             echo "bundles-bucket=${BUNDLES_BUCKET}"
             echo "public-support-packages-bucket=${PUBLIC_SUPPORT_PACKAGES_BUCKET}"
+            echo "cpaas-drivers-bucket=${CPAAS_DRIVERS_BUCKET}"
+            echo "cpaas-support-packages-bucket=${CPAAS_SUPPORT_PACKAGES_BUCKET}"
           } >> "$GITHUB_OUTPUT"
 
           if [[ ${{ github.event_name }} == "pull_request" ]]; then

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -71,16 +71,19 @@ jobs:
       - name: Set GCP buckets
         id: gcp-buckets
         run: |
+          STAGING_RELATIVE_PATH="${GITHUB_HEAD_REF}/${{ github.run_id}}"
+
           MAIN_DRIVER_BUCKET="collector-modules-osci"
-          STAGING_DRIVER_BUCKET="stackrox-collector-modules-staging/pr-builds/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          STAGING_DRIVER_BUCKET="stackrox-collector-modules-staging/pr-builds/${STAGING_RELATIVE_PATH}"
           BUNDLES_BUCKET="collector-kernel-bundles-public"
           SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages"
-          STAGING_SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages/${GITHUB_HEAD_REF}/${{ github.run_id }}"
+          STAGING_SUPPORT_PACKAGES_BUCKET="sr-roxc/collector/support-packages/${STAGING_RELATIVE_PATH}"
           PUBLIC_SUPPORT_PACKAGES_BUCKET="collector-support-public/offline/v1/support-packages"
+
           CPAAS_DRIVERS_BUCKET="mauro-drivers-test/cpaas/drivers"
           CPAAS_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/support-packages"
-          CPAAS_STAGING_DRIVERS_BUCKET="mauro-drivers-test/cpaas/staging/drivers"
-          CPAAS_STAGING_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/staging/support-packages"
+          CPAAS_STAGING_DRIVERS_BUCKET="mauro-drivers-test/cpaas/staging/drivers/${STAGING_RELATIVE_PATH}"
+          CPAAS_STAGING_SUPPORT_PACKAGES_BUCKET="mauro-drivers-test/cpaas/staging/support-packages/${STAGING_RELATIVE_PATH}"
 
           {
             echo "drivers-bucket=${MAIN_DRIVER_BUCKET}"

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -13,6 +13,11 @@ on:
           Tag used for running the integration tests
         type: string
         required: true
+      offline-mode:
+        description: |
+          Set to true to enable collector running in offline mode
+        type: boolean
+        default: false
 
 jobs:
   integration-tests:
@@ -95,7 +100,12 @@ jobs:
           make -C "${{ github.workspace }}/ansible" create-ci-vms
 
       - name: Run Tests
-        run: make -C "${{ github.workspace }}/ansible" integration-tests
+        run: |
+          if [[ "${{ inputs.offline-mode }}" == "true" ]]; then
+            export COLLECTOR_OFFLINE_MODE="true"
+          fi
+
+          make -C "${{ github.workspace }}/ansible" integration-tests
         env:
           QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
           QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,6 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
-      max-layer-depth: "0"
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
+      max-layer-depth: "0"
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,3 +110,4 @@ jobs:
   run-cpaas-steps:
     uses: ./.github/workflows/cpaas.yml
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,3 +106,7 @@ jobs:
     - build-drivers
     - upload-drivers
     secrets: inherit
+
+  run-cpaas-steps:
+    uses: ./.github/workflows/cpaas.yml
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
+      build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
     secrets: inherit
     needs:
     - init


### PR DESCRIPTION
## Description

This PR adds a new set of GHA workflows that allow for testing the downstream built drivers, as well as uploading those drivers and corresponding support-packages to GCP.

The new `cpaas-sync-drivers` workflow pulls the downstream built drivers image for all supported architectures (x86, ppc64le and s390x), extracts the drivers and support-packages from it and pushes them to GCP.

The `cpaas` workflow is based on existing workflows that are used in the `main` workflow, but taking parameters specific for the new use cases. It creates collector images embedding the downstream drivers into them and tags them with a `-cpaas` suffix. Those images are then used to run integration tests in offline mode in the pertinent VMs (`rhel` and `rhel-sap`).

There are currently 2 ways of triggering these new workflows:
- Adding the `run-cpaas-steps` label on PRs will trigger the workflows for that PR.
- Once a day, this workflow will run on the master branch, ensuring the downstream built drivers still work OK with the latest upstream changes and uploading any newly built downstream driver.

There are a few things to figure out before we can have these workflows push things to the upstream production buckets:
- Prevent drivers from different architectures from being embedded into the wrong image (i.e embed s390x drivers in a x86 image). This could be solved by pushing the drivers into subdirectories split by arch for the GCP bucket. This might create a separate problem when a running collector tries to download the driver directly, but some messing about with proxies might fix it easily.
- Support-packages don't have the arch for which they are built as part of their name, which means different architectures could collide of make it harder for users to find the correct support-package. Adding the arch to the download URL would fix this, but it would mean we also need to correct the index file generated for [cdn.stackrox.io](https://cdn.stackrox.io/collector/support-packages/index.html).

While we discuss these remaining questions with the team, we could start running these new workflows, since they are pushing to separate buckets and should not interfere with day to day operations.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Green CI should be enough.