### PR TITLE
ROX-14201 New timer to track time waiting for process-info

### DIFF
--- a/collector/lib/CollectorStats.h
+++ b/collector/lib/CollectorStats.h
@@ -12,7 +12,8 @@
   X(net_scrape_update)  \
   X(net_fetch_state)    \
   X(net_create_message) \
-  X(net_write_message)
+  X(net_write_message)  \
+  X(process_info_wait)
 
 #define COUNTER_NAMES             \
   X(net_conn_updates)             \

--- a/collector/lib/Process.cpp
+++ b/collector/lib/Process.cpp
@@ -155,7 +155,9 @@ void Process::WaitForProcessInfo() const {
   if (process_info_pending_resolution_) {
     std::cv_status status;
 
-    status = process_info_condition_.wait_for(lock, std::chrono::seconds(30));
+    WITH_TIMER(CollectorStats::process_info_wait) {
+      status = process_info_condition_.wait_for(lock, std::chrono::seconds(30));
+    }
 
     CLOG_IF(std::cv_status::timeout == status, ERROR) << "Timed-out waiting for process-info. PID: " << pid();
   }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -246,6 +246,7 @@ Units: microseconds
 | net_fetch_state                                  | Time spent to build a delta message content (connections + endpoints) to send to Sensor                                              |
 | net_create_message                               | Time spent to serialize the delta message and store the resulting state for next computation.                                        |
 | net_write_message                                | Time spent sending the raw message content.                                                                                          |
+| process_info_wait                                | Time spent blocked waiting for process info to be resolved by Falco.                                                                 |
 
 
 ### Network status notifier counters


### PR DESCRIPTION
## Description

Falco is requested by Process objects to resolve details of the process they represent. This procedure is asynchronous and Process may wait for it to complete.

"process_info_wait" is the time spent waiting (in us)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly
