### PR TITLE
Drop dockerized BLOCKLIST

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -63,7 +63,6 @@
 5.15.0-2-cloud-amd64
 5.15.0-3-amd64
 5.15.0-3-cloud-amd64
-4.19.121-dockerdesktop-2021-01-21-15-36-34
 # TODO(ROX-10917)
 4.18.0-372.9.1.rt7.166.el8.x86_64 * mod
 # TODO(ROX-11190)
@@ -75,3 +74,9 @@
 ~^[6-9]\.[0-9]+\..* 2.0.1 mod
 ~^5\.14\.21-150400.*-default 2.0.1 mod
 ~^5\.14\.21-150400.*-default 1.0.0 mod
+# We no longer support docker desktop as a dev environment
+*-dockerdesktop-*
+# Oracle Linux kernel modules require `libdtrace-ctf`,
+# which is unavailable in UBI/RHEL, we could add a
+# dedicated builder if need be
+*.el7uek.* * mod

--- a/kernel-modules/build/apply-blocklist.py
+++ b/kernel-modules/build/apply-blocklist.py
@@ -9,6 +9,11 @@ strip_comment_re = re.compile(r'\s*(?:#.*)?$')
 
 space_re = re.compile(r'\s+')
 
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def pattern_to_re(pat):
     if not pat:
         return ".*"
@@ -17,10 +22,12 @@ def pattern_to_re(pat):
     parts = pat.split('*')
     return '.*'.join(re.escape(part) for part in parts)
 
+
 def open_input(filename):
     if filename == '-':
         return sys.stdin
     return open(filename)
+
 
 def main(blocklist_file, tasks_file='-'):
     blocklist_regexes = []
@@ -45,6 +52,8 @@ def main(blocklist_file, tasks_file='-'):
                 continue
             if not blocklist_re.match(line):
                 print(line)
+            else:
+                eprint(f'Blocked kernel: {line}')
 
 
 if __name__ == '__main__':

--- a/kernel-modules/dockerized/scripts/get-build-tasks.sh
+++ b/kernel-modules/dockerized/scripts/get-build-tasks.sh
@@ -81,4 +81,3 @@ done
 
 # non-blocklisted-build-tasks is populated from the BLOCKLIST file to exclude build tasks which would fail.
 "${SCRIPTS_DIR}/apply-blocklist.py" "${BLOCKLIST_DIR}/BLOCKLIST" "${ALL_BUILD_TASKS}" > "${NON_BLOCKLISTED_TASKS}"
-"${SCRIPTS_DIR}/apply-blocklist.py" "${BLOCKLIST_DIR}/dockerized/BLOCKLIST" "${NON_BLOCKLISTED_TASKS}" > "${OUTPUT_DIR}/build-tasks"

--- a/kernel-modules/dockerized/scripts/get-build-tasks.sh
+++ b/kernel-modules/dockerized/scripts/get-build-tasks.sh
@@ -13,9 +13,6 @@ SCRIPTS_DIR="${SCRIPTS_DIR:-/scripts}"
 ALL_BUILD_TASKS="${OUTPUT_DIR}/all-build-tasks"
 echo > "${ALL_BUILD_TASKS}"
 
-NON_BLOCKLISTED_TASKS="${OUTPUT_DIR}/non-blocklisted-build-tasks"
-echo > "${NON_BLOCKLISTED_TASKS}"
-
 append_task() {
     local kernel_version="$1"
     local module_dir="$2"
@@ -80,4 +77,4 @@ for module_dir in "${CACHE_DIR}/kobuild-tmp/versions-src"/*; do
 done
 
 # non-blocklisted-build-tasks is populated from the BLOCKLIST file to exclude build tasks which would fail.
-"${SCRIPTS_DIR}/apply-blocklist.py" "${BLOCKLIST_DIR}/BLOCKLIST" "${ALL_BUILD_TASKS}" > "${NON_BLOCKLISTED_TASKS}"
+"${SCRIPTS_DIR}/apply-blocklist.py" "${BLOCKLIST_DIR}/BLOCKLIST" "${ALL_BUILD_TASKS}" > "${OUTPUT_DIR}/build-tasks"


### PR DESCRIPTION
## Description

Some kernels were being blocked from being compiled because GHA applied an additional BLOCKLIST file meant for the now deprecated dockerized build of drivers. This PR makes it so the only BLOCKLIST applied is the one located under `kernel-modules/BLOCKLIST`.

I will create a follow up PR removing the dockerized directory and cleaning up a bit, since we haven't used much of it in the past months.

I've also made it so the list of blocked kernels are output to GHA logs, that way it will be easier for us to spot a missing driver due to the blocklist.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Green CI with `build-full-images` label.
