### PR TITLE
ROX-13628 Create an external representation of endpoints (conntracker)

### DIFF
--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -40,6 +40,24 @@ static const NRadixTree private_networks_tree(PrivateNetworks());
 
 }  // namespace
 
+bool AdvertisedEndpointEquality::operator()(const ContainerEndpoint& lhs, const ContainerEndpoint& rhs) const {
+  if (bool(lhs.originator()) != bool(rhs.originator())) {
+    return false;
+  }
+
+  if (lhs.originator()) {
+    auto& lhs_originator = *lhs.originator();
+    auto& rhs_originator = *rhs.originator();
+
+    // Here is the real difference with the comparator in ContainerEndpointMap, which makes a deep compare of originators. We only focus on process-unique-key.
+    if ((lhs_originator.comm() != rhs_originator.comm()) || (lhs_originator.exe_path() != rhs_originator.exe_path()) || (lhs_originator.args() != rhs_originator.args())) {
+      return false;
+    }
+  }
+
+  return lhs.container() == rhs.container() && lhs.endpoint() == rhs.endpoint() && lhs.l4proto() == rhs.l4proto();
+}
+
 bool ContainsPrivateNetwork(Address::Family family, NRadixTree tree) {
   return tree.IsAnyIPNetSubset(family, private_networks_tree) || private_networks_tree.IsAnyIPNetSubset(family, tree);
 }
@@ -166,17 +184,13 @@ struct dont_filter {
   }
 };
 
-template <typename T, typename ProcessFn, typename FilterFn>
-UnorderedMap<T, ConnStatus> FetchState(UnorderedMap<T, ConnStatus>* state, bool clear_inactive,
-                                       const ProcessFn& process_fn, const FilterFn& filter_fn) {
+template <typename T, typename ProcessFn, typename FilterFn, typename E = std::equal_to<T>>
+UnorderedMap<T, ConnStatus, E> FetchState(UnorderedMap<T, ConnStatus>* state, bool clear_inactive,
+                                          const ProcessFn& process_fn, const FilterFn& filter_fn) {
   constexpr bool normalize = !std::is_same<ProcessFn, dont_normalize>::value;
   constexpr bool filter = !std::is_same<FilterFn, dont_filter>::value;
 
-  UnorderedMap<T, ConnStatus> fetched_state;
-
-  if (!clear_inactive && !normalize && !filter) {
-    return *state;
-  }
+  UnorderedMap<T, ConnStatus, E> fetched_state;
 
   for (auto it = state->begin(); it != state->end();) {
     const auto& entry = *it;
@@ -234,29 +248,34 @@ ConnMap ConnectionTracker::FetchConnState(bool normalize, bool clear_inactive) {
   return cm;
 }
 
-ContainerEndpointMap ConnectionTracker::FetchEndpointState(bool normalize, bool clear_inactive) {
-  ContainerEndpointMap cem;
+AdvertisedEndpointMap ConnectionTracker::FetchEndpointState(bool normalize, bool clear_inactive) {
+  AdvertisedEndpointMap cem;
   size_t state_size;
   WITH_LOCK(mutex_) {
     state_size = conn_state_.size();
     if (HasConnectionStateFilters()) {
       if (normalize) {
-        cem = FetchState(
+        cem = FetchState<ContainerEndpoint, std::function<ContainerEndpoint(const ContainerEndpoint&)>, std::function<bool(const ContainerEndpoint&)>, AdvertisedEndpointEquality>(
             &endpoint_state_, clear_inactive,
             [this](const ContainerEndpoint& cep) { return this->NormalizeContainerEndpoint(cep); },
             [this](const ContainerEndpoint& cep) { return this->ShouldFetchContainerEndpoint(cep); });
       } else {
-        cem = FetchState(&endpoint_state_, clear_inactive, dont_normalize(),
-                         [this](const ContainerEndpoint& cep) { return this->ShouldFetchContainerEndpoint(cep); });
+        cem = FetchState<ContainerEndpoint, dont_normalize, std::function<bool(const ContainerEndpoint&)>, AdvertisedEndpointEquality>(
+            &endpoint_state_, clear_inactive,
+            dont_normalize(),
+            [this](const ContainerEndpoint& cep) { return this->ShouldFetchContainerEndpoint(cep); });
       }
     } else {
       if (normalize) {
-        cem = FetchState(
+        cem = FetchState<ContainerEndpoint, std::function<ContainerEndpoint(const ContainerEndpoint&)>, dont_filter, AdvertisedEndpointEquality>(
             &endpoint_state_, clear_inactive,
             [this](const ContainerEndpoint& cep) { return this->NormalizeContainerEndpoint(cep); },
             dont_filter());
       } else {
-        cem = FetchState(&endpoint_state_, clear_inactive, dont_normalize(), dont_filter());
+        cem = FetchState<ContainerEndpoint, dont_normalize, dont_filter, AdvertisedEndpointEquality>(
+            &endpoint_state_, clear_inactive,
+            dont_normalize(),
+            dont_filter());
       }
     }
     COUNTER_ADD(CollectorStats::net_cep_inactive, (state_size - endpoint_state_.size()));

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -49,7 +49,8 @@ bool AdvertisedEndpointEquality::operator()(const ContainerEndpoint& lhs, const 
     auto& lhs_originator = *lhs.originator();
     auto& rhs_originator = *rhs.originator();
 
-    // Here is the real difference with the comparator in ContainerEndpointMap, which makes a deep compare of originators. We only focus on process-unique-key.
+    /* Here is the real difference with the comparator in ContainerEndpointMap.
+       We only compare attributes that are part of the serialized originator process object: storage::NetworkProcessUniqueKey */
     if ((lhs_originator.comm() != rhs_originator.comm()) || (lhs_originator.exe_path() != rhs_originator.exe_path()) || (lhs_originator.args() != rhs_originator.args())) {
       return false;
     }

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -89,7 +89,7 @@ class ConnStatus {
   uint64_t data_;
 };
 
-/* Adverstised Endpoint representation comparison operator. It matches when two endpoints are undistinguishable
+/* Advertised Endpoint representation comparison operator. It matches when two endpoints are indistinguishable
   as seen from the Sensor (their originator process unique key is equal) */
 class AdvertisedEndpointEquality {
  public:

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -89,8 +89,11 @@ class ConnStatus {
   uint64_t data_;
 };
 
-/* Advertised Endpoint representation comparison operator. It matches when two endpoints are indistinguishable
-  as seen from the Sensor (their originator process unique key is equal) */
+/* Advertised Endpoint representation comparison operator.
+   When an endpoint is advertised (sent in serialized form), its originator process is descibed
+   using storage::NetworkProcessUniqueKey. This structure only contains a subset of the process
+   attributes. The AdvertisedEndpointEquality matches endpoints by comparing only the advertised
+   attributes for the originator process. */
 class AdvertisedEndpointEquality {
  public:
   bool operator()(const ContainerEndpoint& lhs, const ContainerEndpoint& rhs) const;

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -134,8 +134,8 @@ class ConnectionTracker {
   static bool CheckIfOldConnShouldBeInactiveInDelta(const T& conn_key, const ConnStatus& conn_status, const UnorderedMap<T, ConnStatus>& new_state, int64_t time_micros, int64_t time_at_last_scrape, int64_t afterglow_period_micros);
 
   // ComputeDelta computes a diff between new_state and *old_state, and stores the diff in *old_state.
-  template <typename T>
-  static void ComputeDelta(const UnorderedMap<T, ConnStatus>& new_state, UnorderedMap<T, ConnStatus>* old_state);
+  template <typename T, typename E>
+  static void ComputeDelta(const UnorderedMap<T, ConnStatus, E>& new_state, UnorderedMap<T, ConnStatus, E>* old_state);
 
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
@@ -214,8 +214,8 @@ void ConnectionTracker::UpdateOldState(UnorderedMap<T, ConnStatus>* old_state, c
   }
 }
 
-template <typename T>
-void ConnectionTracker::ComputeDelta(const UnorderedMap<T, ConnStatus>& new_state, UnorderedMap<T, ConnStatus>* old_state) {
+template <typename T, typename E>
+void ConnectionTracker::ComputeDelta(const UnorderedMap<T, ConnStatus, E>& new_state, UnorderedMap<T, ConnStatus, E>* old_state) {
   // Insert all objects from the new state, if anything changed about them.
   for (const auto& conn : new_state) {
     auto insert_res = old_state->insert(conn);

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -89,8 +89,16 @@ class ConnStatus {
   uint64_t data_;
 };
 
+/* Adverstised Endpoint representation comparison operator. It matches when two endpoints are undistinguishable
+  as seen from the Sensor (their originator process unique key is equal) */
+class AdvertisedEndpointEquality {
+ public:
+  bool operator()(const ContainerEndpoint& lhs, const ContainerEndpoint& rhs) const;
+};
+
 using ConnMap = UnorderedMap<Connection, ConnStatus>;
 using ContainerEndpointMap = UnorderedMap<ContainerEndpoint, ConnStatus>;
+using AdvertisedEndpointMap = UnorderedMap<ContainerEndpoint, ConnStatus, AdvertisedEndpointEquality>;
 
 class CollectorStats;
 
@@ -108,7 +116,7 @@ class ConnectionTracker {
 
   // Atomically fetch a snapshot of the current state, removing all inactive connections if requested.
   ConnMap FetchConnState(bool normalize = false, bool clear_inactive = true);
-  ContainerEndpointMap FetchEndpointState(bool normalize = false, bool clear_inactive = true);
+  AdvertisedEndpointMap FetchEndpointState(bool normalize = false, bool clear_inactive = true);
 
   template <typename T>
   static void UpdateOldState(UnorderedMap<T, ConnStatus>* old_state, const UnorderedMap<T, ConnStatus>& new_state, int64_t time_micros, int64_t afterglow_period_micros);

--- a/collector/lib/Hash.h
+++ b/collector/lib/Hash.h
@@ -120,8 +120,8 @@ size_t HashAll(const FirstArg& first, const RestArgs&... rest) {
 template <typename E>
 using UnorderedSet = std::unordered_set<E, Hasher>;
 
-template <typename K, typename V>
-using UnorderedMap = std::unordered_map<K, V, Hasher>;
+template <typename K, typename V, typename E = std::equal_to<K>>
+using UnorderedMap = std::unordered_map<K, V, Hasher, E>;
 
 }  // namespace collector
 

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -358,6 +358,9 @@ class ContainerEndpoint {
 
   bool operator==(const ContainerEndpoint& other) const {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
+           /* Warning, the following equality uses the assumption that there can be only one Process
+              object per process in the system, and compares pointers directly for performance reasons.
+              This unicity is guaranteed by the ProcessStore. */
            originator_ == other.originator_;
   }
 

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -348,13 +348,13 @@ size_t Hash(const L4ProtoPortPair& pp);
 
 class ContainerEndpoint {
  public:
-  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, std::shared_ptr<Process> originator)
+  ContainerEndpoint(std::string container, const Endpoint& endpoint, L4Proto l4proto, std::shared_ptr<IProcess> originator)
       : container_(std::move(container)), endpoint_(endpoint), l4proto_(l4proto), originator_(originator) {}
 
   const std::string& container() const { return container_; }
   const Endpoint& endpoint() const { return endpoint_; }
   const L4Proto l4proto() const { return l4proto_; }
-  const std::shared_ptr<Process> originator() const { return originator_; }
+  const std::shared_ptr<IProcess> originator() const { return originator_; }
 
   bool operator==(const ContainerEndpoint& other) const {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
@@ -371,7 +371,7 @@ class ContainerEndpoint {
   std::string container_;
   Endpoint endpoint_;
   L4Proto l4proto_;
-  std::shared_ptr<Process> originator_;
+  std::shared_ptr<IProcess> originator_;
 };
 
 std::ostream& operator<<(std::ostream& os, const ContainerEndpoint& container_endpoint);

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -360,7 +360,7 @@ class ContainerEndpoint {
     return container_ == other.container_ && endpoint_ == other.endpoint_ && l4proto_ == other.l4proto_ &&
            /* Warning, the following equality uses the assumption that there can be only one Process
               object per process in the system, and compares pointers directly for performance reasons.
-              This unicity is guaranteed by the ProcessStore. */
+              This uniqueness is guaranteed by the ProcessStore. */
            originator_ == other.originator_;
   }
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -208,7 +208,7 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
   WaitUntilWriterStarted(writer, 10);
 
   ConnMap old_conn_state;
-  ContainerEndpointMap old_cep_state;
+  AdvertisedEndpointMap old_cep_state;
   auto next_scrape = std::chrono::system_clock::now();
 
   while (writer->Sleep(next_scrape)) {
@@ -220,7 +220,7 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
 
     const sensor::NetworkConnectionInfoMessage* msg;
     ConnMap new_conn_state;
-    ContainerEndpointMap new_cep_state;
+    AdvertisedEndpointMap new_cep_state;
     WITH_TIMER(CollectorStats::net_fetch_state) {
       new_conn_state = conn_tracker_->FetchConnState(true, true);
       ConnectionTracker::ComputeDelta(new_conn_state, &old_conn_state);
@@ -252,7 +252,7 @@ void NetworkStatusNotifier::RunSingleAfterglow(IDuplexClientWriter<sensor::Netwo
   WaitUntilWriterStarted(writer, 10);
 
   ConnMap old_conn_state;
-  ContainerEndpointMap old_cep_state;
+  AdvertisedEndpointMap old_cep_state;
   auto next_scrape = std::chrono::system_clock::now();
   int64_t time_at_last_scrape = NowMicros();
 
@@ -265,7 +265,7 @@ void NetworkStatusNotifier::RunSingleAfterglow(IDuplexClientWriter<sensor::Netwo
 
     int64_t time_micros = NowMicros();
     const sensor::NetworkConnectionInfoMessage* msg;
-    ContainerEndpointMap new_cep_state;
+    AdvertisedEndpointMap new_cep_state;
     ConnMap new_conn_state, delta_conn;
     WITH_TIMER(CollectorStats::net_fetch_state) {
       new_conn_state = conn_tracker_->FetchConnState(true, true);
@@ -297,7 +297,7 @@ void NetworkStatusNotifier::RunSingleAfterglow(IDuplexClientWriter<sensor::Netwo
   }
 }
 
-sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(const ConnMap& conn_delta, const ContainerEndpointMap& endpoint_delta) {
+sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(const ConnMap& conn_delta, const AdvertisedEndpointMap& endpoint_delta) {
   if (conn_delta.empty() && endpoint_delta.empty()) return nullptr;
 
   Reset();
@@ -325,7 +325,7 @@ void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<
   }
 }
 
-void NetworkStatusNotifier::AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const ContainerEndpointMap& delta) {
+void NetworkStatusNotifier::AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const AdvertisedEndpointMap& delta) {
   for (const auto& delta_entry : delta) {
     auto* endpoint_proto = ContainerEndpointToProto(delta_entry.first);
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -390,7 +390,7 @@ sensor::NetworkAddress* NetworkStatusNotifier::EndpointToProto(const collector::
   return addr_proto;
 }
 
-storage::NetworkProcessUniqueKey* NetworkStatusNotifier::ProcessToProto(const collector::Process& process) {
+storage::NetworkProcessUniqueKey* NetworkStatusNotifier::ProcessToProto(const collector::IProcess& process) {
   auto* process_proto = Allocate<storage::NetworkProcessUniqueKey>();
 
   process_proto->set_process_name(process.comm());

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -328,6 +328,9 @@ void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<
 void NetworkStatusNotifier::AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const ContainerEndpointMap& delta) {
   for (const auto& delta_entry : delta) {
     auto* endpoint_proto = ContainerEndpointToProto(delta_entry.first);
+
+    CLOG(DEBUG) << delta_entry.first << " active:" << delta_entry.second.IsActive();
+
     if (!delta_entry.second.IsActive()) {
       *endpoint_proto->mutable_close_timestamp() = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(
           delta_entry.second.LastActiveTime());
@@ -357,7 +360,6 @@ sensor::NetworkEndpoint* NetworkStatusNotifier::ContainerEndpointToProto(const C
   if (cep.originator()) {
     endpoint_proto->set_allocated_originator(ProcessToProto(*cep.originator().get()));
   }
-  CLOG(DEBUG) << cep;
 
   return endpoint_proto;
 }

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -54,7 +54,7 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   sensor::NetworkConnection* ConnToProto(const Connection& conn);
   sensor::NetworkEndpoint* ContainerEndpointToProto(const ContainerEndpoint& cep);
   sensor::NetworkAddress* EndpointToProto(const Endpoint& endpoint);
-  storage::NetworkProcessUniqueKey* ProcessToProto(const collector::Process& process);
+  storage::NetworkProcessUniqueKey* ProcessToProto(const collector::IProcess& process);
 
   void OnRecvControlMessage(const sensor::NetworkFlowsControlMessage* msg);
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -47,9 +47,9 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   void Stop();
 
  private:
-  sensor::NetworkConnectionInfoMessage* CreateInfoMessage(const ConnMap& conn_delta, const ContainerEndpointMap& cep_delta);
+  sensor::NetworkConnectionInfoMessage* CreateInfoMessage(const ConnMap& conn_delta, const AdvertisedEndpointMap& cep_delta);
   void AddConnections(::google::protobuf::RepeatedPtrField<sensor::NetworkConnection>* updates, const ConnMap& delta);
-  void AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const ContainerEndpointMap& delta);
+  void AddContainerEndpoints(::google::protobuf::RepeatedPtrField<sensor::NetworkEndpoint>* updates, const AdvertisedEndpointMap& delta);
 
   sensor::NetworkConnection* ConnToProto(const Connection& conn);
   sensor::NetworkEndpoint* ContainerEndpointToProto(const ContainerEndpoint& cep);

--- a/collector/lib/Process.cpp
+++ b/collector/lib/Process.cpp
@@ -36,7 +36,7 @@ ProcessStore::ProcessStore(SysdigService* falco_instance) : falco_instance_(falc
   cache_ = std::make_shared<std::unordered_map<uint64_t, std::weak_ptr<Process>>>();
 }
 
-const std::shared_ptr<Process> ProcessStore::Fetch(uint64_t pid) {
+const std::shared_ptr<IProcess> ProcessStore::Fetch(uint64_t pid) {
   auto cached_process_pair_iter = cache_->find(pid);
 
   if (cached_process_pair_iter != cache_->end()) {
@@ -161,7 +161,7 @@ void Process::WaitForProcessInfo() const {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const Process& process) {
+std::ostream& operator<<(std::ostream& os, const IProcess& process) {
   std::string processString = "ContainerID: " + process.container_id() + " Exe: " + process.exe() + " ExePath: ";
   processString += process.exe_path() + " Args: " + process.args() + " PID: " + std::to_string(process.pid());
   return os << processString;

--- a/collector/lib/ProcfsScraper.cpp
+++ b/collector/lib/ProcfsScraper.cpp
@@ -406,7 +406,7 @@ void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const C
           if (const auto* ep = Lookup(ns_network_data->listen_endpoints, socket.inode())) {
             if (!IsRelevantEndpoint(ep->endpoint)) continue;
 
-            std::shared_ptr<Process> process;
+            std::shared_ptr<IProcess> process;
 
             if (process_store) {
               process = process_store->Fetch(socket.pid());

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -114,3 +114,7 @@ func TestSymbolicLinkProcess(t *testing.T) {
 func TestSocat(t *testing.T) {
 	suite.Run(t, new(suites.SocatTestSuite))
 }
+
+func TestDuplicateEndpoints(t *testing.T) {
+	suite.Run(t, new(suites.DuplicateEndpointsTestSuite))
+}

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -1,6 +1,7 @@
 package suites
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -15,15 +16,19 @@ type DuplicateEndpointsTestSuite struct {
 }
 
 func (s *DuplicateEndpointsTestSuite) waitForEndpoints() {
+	s.executor.CopyFromHost(s.collector.DBPathRemote, s.collector.DBPath)
+	s.db, _ = s.collector.BoltDB()
 	_, err := s.GetEndpoints(s.serverContainer)
 	count := 0
 	maxCount := 60
 
 	for err != nil {
 		time.Sleep(1 * time.Second)
+		s.executor.CopyFromHost(s.collector.DBPathRemote, s.collector.DBPath)
 		_, err = s.GetEndpoints(s.serverContainer)
 		count += 1
 		if count == maxCount {
+			fmt.Println("Timedout waiting for endpoints")
 			break
 		}
 	}

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -51,10 +51,10 @@ func (s *DuplicateEndpointsTestSuite) killSocatProcess(port int) {
 // time 0.
 //
 // 1. Start a process that opens a different port, 81, slight after t=0
-// 2. At t=8 (the scape interval), port 81 should be reported
-// 3. At t=10, kill the process
-// 4. At t=10, start an identical process that opens port 81
-// 5. At t=16 (the second scrape) nothing should be reported.
+// 2. At t=20 (the scape interval), port 81 should be reported
+// 3. At t=22, kill the process
+// 4. At t=22, start an identical process that opens port 81
+// 5. At t=40 (the second scrape) nothing should be reported.
 //
 // The test expects only two reported endpoints.
 func (s *DuplicateEndpointsTestSuite) SetupSuite() {
@@ -64,7 +64,7 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 	s.StartContainerStats()
 	s.collector = common.NewCollectorManager(s.executor, s.T().Name())
 
-	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":8}`
+	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":20}`
 	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
 
 	err := s.collector.Setup()
@@ -86,7 +86,7 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 
 	_, err = s.execContainer("socat", command)
 	s.Require().NoError(err)
-	time.Sleep(10 * time.Second)
+	time.Sleep(22 * time.Second)
 	s.killSocatProcess(81)
 
 	_, err = s.execContainer("socat", command)

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -1,0 +1,113 @@
+package suites
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stackrox/collector/integration-tests/suites/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type DuplicateEndpointsTestSuite struct {
+	IntegrationTestSuiteBase
+	serverContainer string
+}
+
+func (s *DuplicateEndpointsTestSuite) waitForEndpoints() {
+	_, err := s.GetEndpoints(s.serverContainer)
+	count := 0
+	maxCount := 60
+
+	for err != nil {
+		time.Sleep(1 * time.Second)
+		_, err = s.GetEndpoints(s.serverContainer)
+		count += 1
+		if count == maxCount {
+			break
+		}
+	}
+}
+
+func (s *DuplicateEndpointsTestSuite) killSocatProcess(port int) {
+	// Example output    13 root      0:00 socat TCP-LISTEN:81,fork STDOUT
+	output, err := s.execContainer("socat", []string{"/bin/sh", "-c", "ps | grep socat.*LISTEN:" + strconv.Itoa(port) + ",fork | head -1"})
+	// When running remotely there are quotes around the response
+	outputReplaced := strings.Replace(output, "\"", "", -1)
+	outputTrimmed := strings.Trim(outputReplaced, " ")
+	pid := strings.Split(outputTrimmed, " ")[0]
+	s.Require().NoError(err)
+	_, err = s.execContainer("socat", []string{"/bin/sh", "-c", "kill -9 " + pid})
+	s.Require().NoError(err)
+}
+
+// The desired time line of events in this test is the following. Start a process that opens a port.
+// When this endpoint is reported in the mock grpc server we know that a scrape has occured. This is
+// time 0.
+//
+// 1. Start a process that opens a different port, 81, slight after t=0
+// 2. At t=8 (the scape interval), port 81 should be reported
+// 3. At t=10, kill the process
+// 4. At t=10, start an identical process that opens port 81
+// 5. At t=16 (the second scrape) nothing should be reported.
+//
+// The test expects only two reported endpoints.
+func (s *DuplicateEndpointsTestSuite) SetupSuite() {
+
+	s.metrics = map[string]float64{}
+	s.executor = common.NewExecutor()
+	s.StartContainerStats()
+	s.collector = common.NewCollectorManager(s.executor, s.T().Name())
+
+	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":8}`
+	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
+
+	err := s.collector.Setup()
+	s.Require().NoError(err)
+
+	err = s.collector.Launch()
+	s.Require().NoError(err)
+	time.Sleep(30 * time.Second)
+
+	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")
+
+	containerID, err := s.launchContainer("socat", processImage, "/bin/sh", "-c", "socat TCP-LISTEN:80,fork STDOUT")
+
+	s.Require().NoError(err)
+	s.serverContainer = common.ContainerShortID(containerID)
+	s.waitForEndpoints()
+
+	command := []string{"/bin/sh", "-c", "socat TCP-LISTEN:81,fork STDOUT &"}
+
+	_, err = s.execContainer("socat", command)
+	s.Require().NoError(err)
+	time.Sleep(10 * time.Second)
+	s.killSocatProcess(81)
+
+	_, err = s.execContainer("socat", command)
+
+	time.Sleep(20 * time.Second)
+
+	err = s.collector.TearDown()
+	s.Require().NoError(err)
+
+	s.db, err = s.collector.BoltDB()
+	s.Require().NoError(err)
+}
+
+func (s *DuplicateEndpointsTestSuite) TearDownSuite() {
+	s.cleanupContainer([]string{"socat", "collector"})
+	stats := s.GetContainerStats()
+	s.PrintContainerStats(stats)
+	s.WritePerfResults("DuplicateEndpoints", stats, s.metrics)
+}
+
+func (s *DuplicateEndpointsTestSuite) TestDuplicateEndpoints() {
+	processes, err := s.GetProcesses(s.serverContainer)
+	s.Require().NoError(err)
+	endpoints, err := s.GetEndpoints(s.serverContainer)
+	s.Require().NoError(err)
+
+	assert.Equal(s.T(), 2, len(endpoints))
+	assert.Equal(s.T(), 11, len(processes))
+}


### PR DESCRIPTION
## Description

In Collector, an endpoint now represents a listening socket with a reference to the process making use of it. When an endpoint is published, however, the process information is stripped down to represent a the name and parameters of this process instead of the precise instance.

This as an impact on the life-cycle of endpoint objects "as seen from the outside". For instance, the same endpoint opened by several processes having the same attributes should appear as a single endpoint.

In order to implement this model, we propose to change the comparison operator used by the ConnTracker when building the normalized list of endpoints.

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
  - [x] Added unit tests
  - [x] Added integration tests
