### PR TITLE
Fix setting of tag names when running from a schedule event

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -30,14 +30,14 @@ jobs:
           submodules: true
 
       - name: Checks for main and release branches
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name != 'pull_request'
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           echo "COLLECTOR_BUILDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"
 
       - name: PR checks
         id: pr-checks
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         run: |
           # We have 2 options:
           # - We build the builder from scratch and give it a custom tag


### PR DESCRIPTION
## Description

When running from a `schedule` event, such as a the jobs related to CPaaS, the tags for the collector builder are not being set. This PR makes it so the same rules as push events are applied to schedule events.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Not much to test, schedule events can only be triggered once merged into the default branch.
