### PR TITLE
Restore built drivers on non-pr events

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Restore built drivers
         uses: actions/download-artifact@v3
-        if: ${{ github.event_name == 'pull_request' && !inputs.skip-built-drivers }}
+        if: ${{ !inputs.skip-built-drivers }}
         with:
           name: built-drivers
           path: /tmp/built-drivers/


### PR DESCRIPTION


## Description

When building the full version of collector on push, tag or schedule events, the newly built drivers should be added to the image too.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

No additional testing performed.
