### PR TITLE
Add 3.73.1 to RELEASED_VERSIONS

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -14,3 +14,4 @@
 3.11.2 3.72.2  # Rox release 3.72.2 by roxbot at Wed Nov  9 17:41:06 UTC 2022
 3.12.0 3.73.0  # Rox release 3.73.0 by roxbot at Wed Nov 30 16:32:40 UTC 2022
 3.11.2 3.72.3  # Rox release 3.72.3 by roxbot at Thu Jan 12 22:05:44 UTC 2023
+3.12.0 3.73.1  # Rox release 3.73.1 by roxbot at Wed Dec 19 11:38:00 UTC 2022


### PR DESCRIPTION
## Description

Automated PR for version 3.73.1 failed, so we are adding it manually. The time stamp is approximated to the creation of the release and tag.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is enough
