### PR TITLE
Adds image-upload ansible playbook 

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -26,6 +26,10 @@ destroy-vms:
 		--tags teardown \
 		vm-lifecycle.yml
 
+.PHONY: image-upload
+image-upload:
+	ansible-playbook -i $(CONTEXT) image-upload.yml
+
 .PHONY: integration-tests
 integration-tests: secrets.yml
 	ansible-playbook \

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -8,6 +8,7 @@ current_user: "{{ lookup('env', 'USER') }}"
 job_id: "{{ lookup('env', 'JOB_ID', default=current_user) }}"
 test_platform: "{{ lookup('env', 'VM_TYPE', default='rhel') }}"
 collector_root: "{{ playbook_dir }}/.."
+collector_repo: "quay.io/stackrox-io"
 
 virtual_machines:
   rhel:

--- a/ansible/image-upload.yml
+++ b/ansible/image-upload.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Push Collector Image to Hosts
+  vars_files:
+    - group_vars/all.yml
+  hosts: "platform_*:&job_id_{{ job_id }}"
+  strategy: free
+
+  tasks:
+    - name: Get Collector Image
+      shell: make -C "{{ collector_root }}" tag
+      register: collector_tag_result
+      delegate_to: localhost
+
+    - set_fact:
+        collector_tag: "{{ collector_tag_result.stdout | replace('\n', '') }}"
+
+    - name: Create tmp directory
+      tempfile:
+        state: directory
+      register: image_directory
+      delegate_to: localhost
+
+    - name: Save Collector Image
+      # we can't use the docker_image ansible tooling because it uses
+      # the local docker API directly, which doesn't work if you're
+      # using an SSH context or similar. It's safer and more robust
+      # to just call docker save directly.
+      shell: |
+        docker save -o {{ image_directory.path }}/collector.tar {{ collector_repo }}/collector:{{ collector_tag }}
+      delegate_to: localhost
+
+    - name: Copy Collector Image
+      copy:
+        src: "{{ image_directory.path }}/collector.tar"
+        dest: collector.tar
+
+    - name: Load Collector Image
+      shell:
+        cmd: docker load -i collector.tar
+
+    - name: Remove tmp directory
+      file:
+        path: "{{ image_directory.path }}"
+        state: absent

--- a/ansible/image-upload.yml
+++ b/ansible/image-upload.yml
@@ -15,6 +15,9 @@
     - set_fact:
         collector_tag: "{{ collector_tag_result.stdout | replace('\n', '') }}"
 
+    - set_fact:
+        collector_tag: "{{ lookup('env', 'COLLECTOR_TAG') | default(collector_tag) }}"
+
     - name: Create tmp directory
       tempfile:
         state: directory

--- a/ansible/image-upload.yml
+++ b/ansible/image-upload.yml
@@ -13,10 +13,10 @@
       delegate_to: localhost
 
     - set_fact:
-        collector_tag: "{{ collector_tag_result.stdout | replace('\n', '') }}"
+        collector_current_tag: "{{ collector_tag_result.stdout | replace('\n', '') }}"
 
     - set_fact:
-        collector_tag: "{{ lookup('env', 'COLLECTOR_TAG') | default(collector_tag) }}"
+        collector_tag: "{{ lookup('env', 'COLLECTOR_TAG', default=collector_current_tag) }}"
 
     - name: Create tmp directory
       tempfile:


### PR DESCRIPTION
## Description

Adds and image-upload ansible playbook to synchronize development Collector image builds with the ansible inventory. Intended primarily as a development tool for those who do not wish to use an intermediary quay repository.
