### PR TITLE
Jv update mock grpc server image

### DIFF
--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -71,7 +71,7 @@ func NewCollectorManager(e Executor, name string) *CollectorManager {
 		DisableGrpcServer: false,
 		BootstrapOnly:     false,
 		CollectorImage:    collectorImage,
-		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-281-g25a7abf818",
+		GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.73.x-95-gd43176a427",
 		Env:               env,
 		Mounts:            mounts,
 		TestName:          name,


### PR DESCRIPTION
## Description

Updates the mock grpc server image used by the integration tests, to be able to handle a large number of messages. See this PR in stackrox/stackrox https://github.com/stackrox/stackrox/pull/3976 that actually made the change in the grpc server image.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

See the testing in this PR https://github.com/stackrox/stackrox/pull/3976
