### PR TITLE
Bump Garden Linux VM to 934.2

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -64,4 +64,4 @@ virtual_machines:
   garden-linux:
     project: sap-se-gcp-gardenlinux
     images:
-      - gardenlinux-gcp-gardener-prod-amd64-934-1-b1021e6
+      - gardenlinux-gcp-gardener-prod-amd64-934-2-d693dc1


### PR DESCRIPTION
## Description

Self explanatory, bumping the testing VM being used for Garden to latest release.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Run with `all-integration-tests` label and check gardenlinux test passes.
