### PR TITLE
Use a clearer message when downstream nightly fails

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -75,7 +75,7 @@ jobs:
           SLACK_CHANNEL: collector-notifications
           SLACK_COLOR: failure
           SLACK_LINK_NAMES: true
-          SLACK_TITLE: CPaaS driver build check failed
+          SLACK_TITLE: Downstream nightly failed
           MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @collector-team


### PR DESCRIPTION
## Description

This is an extremely simple change that provides a slightly clearer notification message when the downstream nightly workflow fails.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Not much to test, as long as the yaml is valid, functionality is unaffected.
