### PR TITLE
Adds zone looping to VM creation

### DIFF
--- a/ansible/ci/group_vars/all.yml
+++ b/ansible/ci/group_vars/all.yml
@@ -3,8 +3,12 @@
 gcp_project: "stackrox-ci"
 gcp_auth_kind: "serviceaccount"
 gcp_service_account_file: /tmp/secret/stackrox-collector-e2e-tests/GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT
-gcp_zone: "us-central1-a"
 gcp_instance_prefix: collector-ci
+gcp_available_zones:
+  - us-central1-a
+  - us-central1-b
+  - us-central1-c
+  - us-central1-f
 ansible_user: deadbeef
 
 gcp_default_labels:

--- a/ansible/dev/group_vars/all.yml
+++ b/ansible/dev/group_vars/all.yml
@@ -3,8 +3,12 @@
 gcp_project: "stackrox-dev"
 gcp_auth_kind: "application"
 gcp_service_account_file: null
-gcp_zone: "us-central1-a"
 gcp_instance_prefix: collector-dev
+gcp_available_zones:
+  - us-central1-a
+  - us-central1-b
+  - us-central1-c
+  - us-central1-f
 ansible_user: "{{ lookup('env', 'USER') }}"
 
 gcp_default_labels:

--- a/ansible/roles/create-all-vms/tasks/main.yml
+++ b/ansible/roles/create-all-vms/tasks/main.yml
@@ -13,6 +13,7 @@
     vm_platform: "{{ item.0.key }}"
     vm_config: "{{ item.0.key }}_{{ item.1 }}"
     vm_collection_method: "{{ collection_method | default('any') | replace('-', '_') }}"
+    vm_available_zones: "{{ gcp_available_zones }}"
 
   #
   # The loop will create the "item" variable, which can be used throughout the task
@@ -47,6 +48,7 @@
     vm_platform: "{{ item.0.key }}"
     vm_config: "{{ item.0.key }}_{{ item.0.key }}"
     vm_collection_method: "{{ collection_method | default('any') | replace('-', '_') }}"
+    vm_available_zones: "{{ gcp_available_zones }}"
 
   #
   # The loop will create the "item" variable, which can be used throughout the task

--- a/ansible/roles/create-vm/tasks/main.yml
+++ b/ansible/roles/create-vm/tasks/main.yml
@@ -33,10 +33,27 @@
           disk_size_gb: "{{ vm_disk_size | default(20) }}"
           source_image: "{{ gcp_source_image }}"
     network_interfaces:
-      - network: 
+      - network:
           name: "default"
         access_configs:
           - name: External NAT
             type: ONE_TO_ONE_NAT
     labels: "{{ gcp_default_labels | combine(gcp_extra_labels) }}"
 
+  # This looks like a lot, and its mostly because ansible support
+  # for "breaking" from a loop is not all that great at the moment.
+  # This approach has been taken from here:
+  #
+  # https://github.com/ansible/proposals/issues/140#issuecomment-649828067
+  loop: "{{ vm_available_zones }}"
+  loop_control:
+    loop_var: gcp_zone
+  register: instance_result
+  when: not condition
+  vars:
+    condition: "{{ (instance_result | default({'changed': false})).changed }}"
+
+# make sure to reset the instance_result otherwise subsequent VMs arent created
+- set_fact:
+    instance_result:
+      changed: false

--- a/ansible/roles/destroy-vm/tasks/main.yml
+++ b/ansible/roles/destroy-vm/tasks/main.yml
@@ -7,5 +7,6 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_auth_kind }}"
     service_account_file: "{{ gcp_service_account_file }}"
-    zone: "{{ gcp_zone }}"
+    # zone is set by the GCP inventory automatically
+    zone: "{{ zone }}"
     state: absent


### PR DESCRIPTION
## Description

To avoid the case where a zone is unable to accept our VM creation request, this PR changes the ansible logic to loop over a set of available zones, using the first one that succeeds. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
Tested locally, but unable to truly test when a zone fails. I have verified that if the previous execution fails it will continue to try the next zone. 
