### PR TITLE
Fix checksum file URLs for support-packages

### DIFF
--- a/kernel-modules/support-packages/05-create-index.py
+++ b/kernel-modules/support-packages/05-create-index.py
@@ -42,11 +42,11 @@ class SupportPackage(object):
 
     @property
     def checksum_url(self):
-        return '%s/%s/%s%s' % (os.getenv('BASE_URL'), self.architecture, self.module_version, self.chk_name)
+        return '%s/%s/%s/%s' % (os.getenv('BASE_URL'), self.architecture, self.module_version, self.chk_name)
 
     @property
     def checksum_url_latest(self):
-        return '%s/%s/%s%s' % (os.getenv('BASE_URL'), self.architecture, self.module_version, self.latest_chk_name) \
+        return '%s/%s/%s/%s' % (os.getenv('BASE_URL'), self.architecture, self.module_version, self.latest_chk_name) \
             if self.latest_chk_name is not None else None
 
     def __repr__(self):


### PR DESCRIPTION
## Description

Checksum URLs are missing a `/`, so we add it.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `test-support-packages` label and check the URL for checksums is correct in the generated index.html file.
