### PR TITLE
Remove the dynamic configuration of base image for collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,6 @@ image: collector unittest container-dockerfile
 image-dev: collector unittest container-dockerfile
 	make -C collector txt-files
 	docker build --build-arg collector_version="$(COLLECTOR_TAG)" \
-		--build-arg BASE_REGISTRY=quay.io \
-		--build-arg BASE_IMAGE=centos/centos \
-		--build-arg BASE_TAG=stream8 \
 		--build-arg BUILD_TYPE=devel \
 		-f collector/container/Dockerfile.gen \
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \

--- a/collector/container/Dockerfile.template
+++ b/collector/container/Dockerfile.template
@@ -1,8 +1,4 @@
-ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8/ubi-minimal
-ARG BASE_TAG=8.7
-
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ARG BUILD_TYPE=rhel
 ARG ROOT_DIR=.

--- a/collector/container/devel/final-step.sh
+++ b/collector/container/devel/final-step.sh
@@ -6,9 +6,9 @@ echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 
 mv collector-wrapper.sh /usr/local/bin/
 chmod 700 bootstrap.sh
-dnf upgrade -y
-dnf install -y kmod
+microdnf upgrade -y
+microdnf install -y kmod
 
-dnf install -y libasan valgrind
+microdnf install -y libasan
 
 echo "${MODULE_VERSION}" > /kernel-modules/MODULE_VERSION.txt


### PR DESCRIPTION
## Description

This PR removes the possibility to dynamically change the base image used for the collector image. Originally this allowed us to have a UBI and Ubuntu based images, we then dropped Ubuntu images and started using this to build a development image based on centos stream. Because the devel and prod images are pretty close to each other, I believe it is more beneficial for us to have the image set to the production one so that dependabot can bump it on its own.

The devel image will now be based on ubi-minimal, which means the available packages are somewhat limited, but it is still possible to directly install gdb on it, which is the most important thing we want in it IMO.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Manually built the `-dev` collector image successfully.