### PR TITLE
Silence compiler warnings about signedness comparison issues.

### DIFF
--- a/collector/lib/ProfilerHandler.cpp
+++ b/collector/lib/ProfilerHandler.cpp
@@ -44,7 +44,7 @@ bool ProfilerHandler::SendHeapProfile(struct mg_connection* conn) {
     if (mg_send_http_ok(conn, "application/octet-stream", heap_profile_length_) < 0) {
       return false;
     }
-    if (mg_write(conn, heap_profile_.get(), heap_profile_length_) != heap_profile_length_) {
+    if (mg_write(conn, heap_profile_.get(), heap_profile_length_) != (int)heap_profile_length_) {
       return false;
     }
   }

--- a/collector/test/NRadixTest.cpp
+++ b/collector/test/NRadixTest.cpp
@@ -335,7 +335,7 @@ TEST(NRadixTest, BenchMarkNetworkLookup) {
   // Generate IPv4 networks.
   UnorderedSet<IPNet> ipv4_network_set;
   ipv4_network_set.reserve(num_ipv4_nets);
-  for (int i = 0; i < num_ipv4_nets; i++) {
+  for (size_t i = 0; i < num_ipv4_nets; i++) {
     ipv4_network_set.insert(IPNet(Address(ip_distr(ip_gen)), mask_distr(mask_gen)));
   }
 
@@ -343,7 +343,7 @@ TEST(NRadixTest, BenchMarkNetworkLookup) {
   mask_distr = std::uniform_int_distribution<unsigned char>(0x21, 0x80);
   UnorderedSet<IPNet> ipv6_network_set;
   ipv6_network_set.reserve(num_ipv6_nets);
-  for (int i = 0; i < num_ipv6_nets; i++) {
+  for (size_t i = 0; i < num_ipv6_nets; i++) {
     ipv6_network_set.insert(IPNet(Address(ip_distr(ip_gen), ip_distr(ip_gen)), mask_distr(mask_gen)));
   }
 


### PR DESCRIPTION
## Description

The fixed warnings are:
```
warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
```

## Testing Performed

Existing tests should cover the changes.
