### PR TITLE
Cleanup remaining OSCI code from kernel-splitter.py

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -110,19 +110,10 @@ jobs:
       - name: Split kernels
         env:
           TASKS_DIR: /tmp/tasks
-          RHEL8_BUILDERS: ${{ steps.set-parallel.outputs.parallel-jobs }}
-          FC36_BUILDERS: ${{ steps.set-parallel.outputs.parallel-jobs }}
+          DRIVER_BUILDERS: ${{ steps.set-parallel.outputs.parallel-jobs }}
 
         run: |
           ${{ github.workspace }}/kernel-modules/build/kernel-splitter.py
-
-          # TODO: This is a compatibility issue with OSCI, ideally all tasks
-          # should be in a consistent path. Ensure that happens once we remove
-          # OSCI
-          if [[ -f /tmp/tasks/fc36/all ]]; then
-            mkdir -p /tmp/tasks/fc36/0
-            mv /tmp/tasks/fc36/all /tmp/tasks/fc36/0/all
-          fi
 
       - name: Store tasks and sources
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

Minor cleanup, removes some code that was left for compatibility with OSCI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `no-cache` label.
