### PR TITLE
Exclude 8.x-x UBI images for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,10 @@ updates:
     directory: collector/container/
     schedule:
       interval: "weekly"
+    ignore:
+    - dependency-name: registry.access.redhat.com/ubi8/ubi
+      versions:
+      - 8.x-x
   - package-ecosystem: 'docker'
     directory: integration-tests/container/benchmark/
     schedule:

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,0 +1,19 @@
+name: dependabot validate
+
+on:
+  pull_request:
+    paths:
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependabot-validate.yml'
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: marocchino/validate-dependabot@v2
+        id: validate
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always()
+        with:
+          header: validate-dependabot
+          message: ${{ steps.validate.outputs.markdown }}


### PR DESCRIPTION
## Description

Dependabot should only be trying to update images to `ubi:8.x` versions, this PR attempts to limit it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
