### PR TITLE
Add symlink to gcc10-gcc

### DIFF
--- a/kernel-modules/build/fc36.Dockerfile
+++ b/kernel-modules/build/fc36.Dockerfile
@@ -14,7 +14,9 @@ RUN dnf -y install \
     # We trick Debian builds into thinking they have the required GCC binary
     ln -s /usr/bin/gcc /usr/bin/gcc-10 && \
     ln -s /usr/bin/gcc /usr/bin/gcc-11 && \
-    ln -s /usr/bin/gcc /usr/bin/gcc-12
+    ln -s /usr/bin/gcc /usr/bin/gcc-12 && \
+    # We also trick Amazon Linux
+    ln -s /usr/bin/gcc /usr/bin/gcc10-gcc
 
 COPY /build-kos /scripts/
 COPY /build-wrapper.sh /scripts/compile.sh

--- a/kernel-modules/build/fc36.Dockerfile
+++ b/kernel-modules/build/fc36.Dockerfile
@@ -16,7 +16,9 @@ RUN dnf -y install \
     ln -s /usr/bin/gcc /usr/bin/gcc-11 && \
     ln -s /usr/bin/gcc /usr/bin/gcc-12 && \
     # We also trick Amazon Linux
-    ln -s /usr/bin/gcc /usr/bin/gcc10-gcc
+    ln -s /usr/bin/gcc /usr/bin/gcc10-gcc && \
+    ln -s /usr/bin/ld.bfd /usr/bin/gcc10-ld.bfd && \
+    ln -s /usr/bin/objdump /usr/bin/gcc10-objdump
 
 COPY /build-kos /scripts/
 COPY /build-wrapper.sh /scripts/compile.sh


### PR DESCRIPTION
## Description

Symlink `gcc` to `gcc10-gcc` so that amazon linux kernel modules can be compiled.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough.