### PR TITLE
Bump Garden Linux VM to 934.5

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -64,4 +64,4 @@ virtual_machines:
   garden-linux:
     project: sap-se-gcp-gardenlinux
     images:
-      - gardenlinux-gcp-gardener-prod-amd64-934-4-0062513
+      - gardenlinux-gcp-gardener-prod-amd64-934-5-59b6440


### PR DESCRIPTION
## Description

Self explanatory, bumping the Garden Linux VM version to the latest available.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Ensure the Garden Linux test works once the driver is added.
