### PR TITLE
Use the proper indent configuration for .cpp and .h files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[collector/{*.cpp,lib/*.cpp,lib/*.h}]
+indent_style = space
+indent_size = 2
+
 [*.sh]
 indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[collector/{*.cpp,lib/*.cpp,lib/*.h}]
+[collector/{*.cpp,lib/*.cpp,lib/*.h,test/*.cpp}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
## Description

The current `.editorconfig` file doesn't set the style for our `.cpp` and `.h` files, which means the indentation is either derived from content (in VSCode), or left untouched (in things like neovim). `clang-format` fixes style problems after editing files, but it is a bit distracting when your editor is trying to use tabs or 4 spaces and getting it mixed up with the existing 2 space indented lines.

Since we already have a `.editorconfig` file in the repo, we might as well configure it to use 2 spaces on `.cpp` and `.h` files found under `collector/` and `collector/lib/`.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

This change is purely for editor configuration, no functional changes will occur. That said, the change works as expected on neovim with an `editorconfig` plugin.
