### PR TITLE
Fix kernel versions being used as relative path

### DIFF
--- a/collector/lib/DriverCandidates.cpp
+++ b/collector/lib/DriverCandidates.cpp
@@ -33,7 +33,7 @@ std::optional<DriverCandidate> getUbuntuBackport(HostInfo& host, bool useEbpf) {
     if (kernel.version.find(candidate) != std::string::npos) {
       std::string backport = kernel.release + candidate;
       std::string name = driverFullName(backport, useEbpf);
-      return DriverCandidate(std::move(name), useEbpf, std::move(backport));
+      return DriverCandidate(std::move(name), useEbpf);
     }
   }
 
@@ -60,7 +60,7 @@ std::optional<DriverCandidate> getGardenLinuxCandidate(HostInfo& host, bool useE
   std::string shortName = kernel.release + "-gl-" + match.str();
   std::string name = driverFullName(shortName, useEbpf);
 
-  return DriverCandidate(name, useEbpf, shortName);
+  return DriverCandidate(name, useEbpf);
 }
 
 // The kvm driver for minikube uses a custom kernel built from
@@ -79,7 +79,7 @@ std::optional<DriverCandidate> getMinikubeCandidate(HostInfo& host, bool useEbpf
 
   std::string shortName = kernel.ShortRelease() + "-minikube-" + minikube_version;
   std::string name = driverFullName(shortName, useEbpf);
-  return DriverCandidate(name, useEbpf, shortName);
+  return DriverCandidate(name, useEbpf);
 }
 
 // Normalizes this host's release string into something collector can use
@@ -123,14 +123,14 @@ DriverCandidate getHostCandidate(HostInfo& host, bool useEbpf) {
   std::string hostCandidate = normalizeReleaseString(host);
   std::string hostCandidateFullName = driverFullName(hostCandidate, useEbpf);
 
-  return DriverCandidate(hostCandidateFullName, useEbpf, hostCandidate);
+  return DriverCandidate(hostCandidateFullName, useEbpf);
 }
 
 DriverCandidate getUserDriverCandidate(const char* full_name, bool useEbpf) {
   std::filesystem::path driver_file(full_name);
 
   if (driver_file.is_absolute()) {
-    return DriverCandidate(driver_file.filename(), useEbpf, driver_file.parent_path(), false);
+    return DriverCandidate(driver_file.filename(), useEbpf, false, driver_file.parent_path());
   }
 
   return DriverCandidate(driver_file, useEbpf, false);
@@ -146,7 +146,7 @@ std::vector<DriverCandidate> GetKernelCandidates(bool useEbpf) {
 
     for (const auto& candidate_name : SplitStringView(sview)) {
       std::string name = driverFullName(candidate_name, useEbpf);
-      candidates.emplace_back(std::move(name), useEbpf, std::move(candidate_name));
+      candidates.emplace_back(std::move(name), useEbpf);
     }
 
     return candidates;

--- a/collector/test/DriverCandidatesTest.cpp
+++ b/collector/test/DriverCandidatesTest.cpp
@@ -51,6 +51,7 @@ TEST(getGardenLinuxCandidateTest, Garden576_1) {
   std::string release("5.10.0-9-cloud-amd64");
   std::string version("#1 SMP Debian 5.10.83-1gardenlinux1 (2021-12-03)");
   std::string expected_driver("collector-ebpf-5.10.0-9-cloud-amd64-gl-5.10.83-1gardenlinux1.o");
+  std::string expected_path("/kernel-modules");
   KernelVersion kv(release, version);
 
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(kv));
@@ -59,6 +60,9 @@ TEST(getGardenLinuxCandidateTest, Garden576_1) {
 
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
+  EXPECT_EQ(candidate->GetPath(), expected_path);
+  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_TRUE(candidate->IsDownloadable());
 }
 
 TEST(getGardenLinuxCandidateTest, Garden318) {
@@ -66,6 +70,7 @@ TEST(getGardenLinuxCandidateTest, Garden318) {
   std::string release("5.4.0-6-cloud-amd64");
   std::string version("#1 SMP Debian 5.4.93-1 (2021-02-09)");
   std::string expected_driver("collector-ebpf-5.4.0-6-cloud-amd64-gl-5.4.93-1.o");
+  std::string expected_path("/kernel-modules");
   KernelVersion kv(release, version);
 
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(kv));
@@ -74,6 +79,9 @@ TEST(getGardenLinuxCandidateTest, Garden318) {
 
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
+  EXPECT_EQ(candidate->GetPath(), expected_path);
+  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_TRUE(candidate->IsDownloadable());
 }
 
 TEST(getMinikubeCandidateTest, v1_27_1) {
@@ -82,6 +90,7 @@ TEST(getMinikubeCandidateTest, v1_27_1) {
   std::string version("#1 SMP Wed Oct 27 22:52:27 UTC 2021 x86_64 GNU/Linux");
   std::string minikube_version("v1.27.1");
   std::string expected_driver("collector-ebpf-5.10.57-minikube-v1.27.1.o");
+  std::string expected_path("/kernel-modules");
   KernelVersion kv(release, version);
 
   EXPECT_CALL(host, GetMinikubeVersion()).WillOnce(Return(minikube_version));
@@ -91,6 +100,9 @@ TEST(getMinikubeCandidateTest, v1_27_1) {
 
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
+  EXPECT_EQ(candidate->GetPath(), expected_path);
+  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_TRUE(candidate->IsDownloadable());
 }
 
 TEST(getMinikubeCandidateTest, v1_24_0) {
@@ -99,6 +111,7 @@ TEST(getMinikubeCandidateTest, v1_24_0) {
   std::string version("#1 SMP Wed Oct 27 22:52:27 UTC 2021 x86_64 GNU/Linux");
   std::string minikube_version("v1.24.0");
   std::string expected_driver("collector-ebpf-4.19.202-minikube-v1.24.0.o");
+  std::string expected_path("/kernel-modules");
   KernelVersion kv(release, version);
 
   EXPECT_CALL(host, GetMinikubeVersion()).WillOnce(Return(minikube_version));
@@ -108,6 +121,9 @@ TEST(getMinikubeCandidateTest, v1_24_0) {
 
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
+  EXPECT_EQ(candidate->GetPath(), expected_path);
+  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_TRUE(candidate->IsDownloadable());
 }
 
 TEST(getMinikubeCandidateTest, NoVersion) {
@@ -231,53 +247,5 @@ TEST(normalizeReleaseStringTest, Garden318Kernel) {
   auto normalized_kernel = normalizeReleaseString(host);
 
   EXPECT_EQ(normalized_kernel, expected_kernel);
-}
-
-TEST(SplitStringViewTest, TestSplitStr) {
-  std::string_view view("aaaa bbbb cccc dddd");
-  std::vector<std::string> splits = SplitStringView(view, ' ');
-  ASSERT_EQ(4, splits.size());
-
-  std::vector<std::string> expected = {
-      "aaaa",
-      "bbbb",
-      "cccc",
-      "dddd",
-  };
-
-  for (std::string::size_type i = 0; i < splits.size(); i++) {
-    ASSERT_EQ(expected[i], splits[i]);
-  }
-}
-
-TEST(SplitStringViewTest, TestSplitStrNoDelimiter) {
-  std::string_view view("aaaa");
-  std::vector<std::string> splits = SplitStringView(view, ' ');
-  ASSERT_EQ(1, splits.size());
-  ASSERT_EQ("aaaa", splits[0]);
-}
-
-TEST(SplitStringViewTest, TestSplitDelimiterAtEnd) {
-  std::string_view view("a b c ");
-  std::vector<std::string> expected{
-      "a",
-      "b",
-      "c",
-      "",
-  };
-  std::vector<std::string> splits = SplitStringView(view, ' ');
-  ASSERT_EQ(expected, splits);
-}
-
-TEST(SplitStringViewTest, TestSplitDoubleDelimiter) {
-  std::string_view view("a b  c");
-  std::vector<std::string> expected{
-      "a",
-      "b",
-      "",
-      "c",
-  };
-  std::vector<std::string> splits = SplitStringView(view, ' ');
-  ASSERT_EQ(expected, splits);
 }
 }  // namespace collector

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -21,46 +21,62 @@ You should have received a copy of the GNU General Public License along with thi
 * version.
 */
 
-#ifndef _DRIVER_CANDIDATES_H_
-#define _DRIVER_CANDIDATES_H_
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-spec-builders.h>
 
-#include <string>
-#include <vector>
+#include "Utility.cpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
 
 namespace collector {
 
-class DriverCandidate {
- public:
-  DriverCandidate(const std::string& name, bool useEbpf, bool downloadable = true, const std::string& path = "/kernel-modules") : name_(name), path_(path), downloadable_(downloadable) {
-    if (useEbpf) {
-      collection_method_ = EBPF;
-    } else {
-      collection_method_ = KERNEL_MODULE;
-    }
-  }
+TEST(SplitStringViewTest, TestSplitStr) {
+  std::string_view view("aaaa bbbb cccc dddd");
+  std::vector<std::string> splits = SplitStringView(view, ' ');
+  ASSERT_EQ(4, splits.size());
 
-  inline const std::string& GetPath() const { return path_; }
-
-  inline const std::string& GetName() const { return name_; }
-
-  inline bool IsDownloadable() const { return downloadable_; }
-
-  inline bool IsEbpf() const { return collection_method_ == EBPF; }
-
- private:
-  enum collectionMethod {
-    EBPF = 0,
-    KERNEL_MODULE,
+  std::vector<std::string> expected = {
+      "aaaa",
+      "bbbb",
+      "cccc",
+      "dddd",
   };
 
-  std::string name_;
-  std::string path_;
-  bool downloadable_;
-  collectionMethod collection_method_;
-};
+  for (std::string::size_type i = 0; i < splits.size(); i++) {
+    ASSERT_EQ(expected[i], splits[i]);
+  }
+}
 
-// Get kernel candidates
-std::vector<DriverCandidate> GetKernelCandidates(bool useEbpf);
+TEST(SplitStringViewTest, TestSplitStrNoDelimiter) {
+  std::string_view view("aaaa");
+  std::vector<std::string> splits = SplitStringView(view, ' ');
+  ASSERT_EQ(1, splits.size());
+  ASSERT_EQ("aaaa", splits[0]);
+}
 
+TEST(SplitStringViewTest, TestSplitDelimiterAtEnd) {
+  std::string_view view("a b c ");
+  std::vector<std::string> expected{
+      "a",
+      "b",
+      "c",
+      "",
+  };
+  std::vector<std::string> splits = SplitStringView(view, ' ');
+  ASSERT_EQ(expected, splits);
+}
+
+TEST(SplitStringViewTest, TestSplitDoubleDelimiter) {
+  std::string_view view("a b  c");
+  std::vector<std::string> expected{
+      "a",
+      "b",
+      "",
+      "c",
+  };
+  std::vector<std::string> splits = SplitStringView(view, ' ');
+  ASSERT_EQ(expected, splits);
+}
 }  // namespace collector
-#endif  // _DRIVER_CANDIDATES_H_


### PR DESCRIPTION
## Description

A quick change to the `DriverCandidate` constructor in #1040 before merging resulted in the kernel version being used as the relative path for some candidates. This PR fixes that small bug.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Double check paths are correct in the integration test logs.
