### PR TITLE
Sets CMAKE_POSITION_INDEPENDENT_CODE in collector CMakeLists.txt

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-de
 set(CMAKE_CXX_FLAGS_DEBUG "-g -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
 
+# Ensures that shared and static libraries are built as position
+# independent
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 if(NOT DEFINED ENV{DISABLE_PROFILING})
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOLLECTOR_PROFILING")
 endif()


### PR DESCRIPTION
## Description

Sets CMAKE_POSITION_INDEPENDENT_CODE to supersede changes to [libscap](https://github.com/stackrox/falcosecurity-libs/blob/master/userspace/libscap/CMakeLists.txt#L66-L67) and [libsinp](https://github.com/stackrox/falcosecurity-libs/blob/master/userspace/libsinsp/CMakeLists.txt#L59-L60) builds in our Falco fork.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Tested locally, with builds using CMAKE_POSITION_INDEPENDENT_CODE ON, with it OFF, and with the Falco options ENABLE_PIC on and off. All tests were done with a modified Falco fork without the changes we've added in the build for libsinsp and libscap
