### PR TITLE
Add CO.RE eBPF candidate

### DIFF
--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
 
   if (!collector.InitKernel(args->GRPCServer(), candidates)) {
     startup_diagnostics.Log();
-    CLOG(FATAL) << "Failed to initialize collector service.";
+    CLOG(FATAL) << "Failed to initialize collector kernel components.";
   }
 
   // output the GPL notice only once the kernel object has been found or downloaded

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -206,18 +206,6 @@ int main(int argc, char** argv) {
 
   CLOG(INFO) << "Module version: " << GetModuleVersion();
 
-  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.GetCollectionMethod());
-  if (candidates.empty()) {
-    startup_diagnostics.Log();
-    CLOG(FATAL) << "No kernel candidates available";
-  }
-
-  const char* type = config.UseEbpf() ? "eBPF probe" : "kernel module";
-  CLOG(INFO) << "Attempting to find " << type << " - Candidate versions: ";
-  for (const auto& candidate : candidates) {
-    CLOG(INFO) << candidate.GetName();
-  }
-
   // Register signal handlers
   signal(SIGABRT, AbortHandler);
   signal(SIGSEGV, AbortHandler);
@@ -228,7 +216,7 @@ int main(int argc, char** argv) {
 
   CollectorService collector(config, &g_control, &g_signum);
 
-  if (!collector.InitKernel(args->GRPCServer(), candidates)) {
+  if (!SetupKernelDriver(collector, args->GRPCServer(), config)) {
     startup_diagnostics.Log();
     CLOG(FATAL) << "Failed to initialize collector kernel components.";
   }

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
 
   CLOG(INFO) << "Module version: " << GetModuleVersion();
 
-  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.UseEbpf());
+  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.CollectionMethod());
   if (candidates.empty()) {
     startup_diagnostics.Log();
     CLOG(FATAL) << "No kernel candidates available";

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
 
   CLOG(INFO) << "Module version: " << GetModuleVersion();
 
-  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.CollectionMethod());
+  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.GetCollectionMethod());
   if (candidates.empty()) {
     startup_diagnostics.Log();
     CLOG(FATAL) << "No kernel candidates available";

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -218,8 +218,6 @@ int main(int argc, char** argv) {
     CLOG(INFO) << candidate.GetName();
   }
 
-  // startup_diagnostics.KernelDriverDownloaded();
-
   // Register signal handlers
   signal(SIGABRT, AbortHandler);
   signal(SIGSEGV, AbortHandler);
@@ -238,7 +236,6 @@ int main(int argc, char** argv) {
   // output the GPL notice only once the kernel object has been found or downloaded
   gplNotice();
 
-  startup_diagnostics.KernelDriverLoaded();
   startup_diagnostics.Log();
 
   collector.RunForever();

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -72,8 +72,6 @@ using namespace collector;
 static std::atomic<ControlValue> g_control(ControlValue::RUN);
 static std::atomic<int> g_signum(0);
 
-static StartupDiagnostics g_startup_diagnostics;
-
 static void
 ShutdownHandler(int signum) {
   // Only set the control variable; the collector service will take care of the rest.
@@ -154,8 +152,8 @@ void gplNotice() {
   CLOG(INFO) << "";
   CLOG(INFO) << "This product uses kernel module and ebpf subcomponents licensed under the GNU";
   CLOG(INFO) << "GENERAL PURPOSE LICENSE Version 2 outlined in the /kernel-modules/LICENSE file.";
-  CLOG(INFO) << "Source code for the kernel module and ebpf subcomponents is available upon";
-  CLOG(INFO) << "request by contacting support@stackrox.com.";
+  CLOG(INFO) << "Source code for the kernel module and ebpf subcomponents is available at";
+  CLOG(INFO) << "https://github.com/stackrox/falcosecurity-libs/";
   CLOG(INFO) << "";
 }
 
@@ -168,32 +166,6 @@ void initialChecks() {
   if (stat("/module", &st) != 0 || !S_ISDIR(st.st_mode)) {
     CLOG(FATAL) << "Internal error: /module directory does not exist.";
   }
-}
-
-bool downloadKernelDriver(const CollectorArgs* args, CollectorConfig& config) {
-  CLOG(INFO) << "Module version: " << GetModuleVersion();
-  bool useEbpf = config.UseEbpf();
-
-  std::vector<DriverCandidate> kernel_candidates = GetKernelCandidates(useEbpf);
-
-  if (kernel_candidates.empty()) {
-    CLOG(ERROR) << "No kernel candidates available";
-    return false;
-  }
-
-  const char* type = useEbpf ? "eBPF probe" : "kernel module";
-  CLOG(INFO) << "Attempting to find " << type << " - Candidate versions: ";
-  for (const auto& candidate : kernel_candidates) {
-    CLOG(INFO) << candidate.GetName();
-  }
-
-  for (const auto& candidate : kernel_candidates) {
-    if (GetKernelObject(args->GRPCServer(), config.TLSConfiguration(), candidate, config.CurlVerbose())) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 int main(int argc, char** argv) {
@@ -212,6 +184,8 @@ int main(int argc, char** argv) {
 
   setCoreDumpLimit(config.IsCoreDumpEnabled());
 
+  auto& startup_diagnostics = StartupDiagnostics::GetInstance();
+
   // Extract configuration options
   bool useGRPC = !args->GRPCServer().empty();
   std::shared_ptr<grpc::Channel> sensor_connection;
@@ -222,24 +196,29 @@ int main(int argc, char** argv) {
     if (attemptGRPCConnection(sensor_connection)) {
       CLOG(INFO) << "Successfully connected to Sensor.";
     } else {
-      g_startup_diagnostics.Log();
+      startup_diagnostics.Log();
       CLOG(FATAL) << "Unable to connect to Sensor at '" << args->GRPCServer() << "'.";
     }
-    g_startup_diagnostics.ConnectedToSensor();
+    startup_diagnostics.ConnectedToSensor();
   } else {
     CLOG(INFO) << "GRPC is disabled. Specify GRPC_SERVER='server addr' env and signalFormat = 'signal_summary' and  signalOutput = 'grpc'";
   }
 
-  if (!downloadKernelDriver(args, config)) {
-    g_startup_diagnostics.Log();
-    HostInfo& host = HostInfo::Instance();
-    CLOG(FATAL) << "No suitable kernel object downloaded for kernel " << host.GetKernelVersion().release;
+  CLOG(INFO) << "Module version: " << GetModuleVersion();
+
+  std::vector<DriverCandidate> candidates = GetKernelCandidates(config.UseEbpf());
+  if (candidates.empty()) {
+    startup_diagnostics.Log();
+    CLOG(FATAL) << "No kernel candidates available";
   }
 
-  g_startup_diagnostics.KernelDriverDownloaded();
+  const char* type = config.UseEbpf() ? "eBPF probe" : "kernel module";
+  CLOG(INFO) << "Attempting to find " << type << " - Candidate versions: ";
+  for (const auto& candidate : candidates) {
+    CLOG(INFO) << candidate.GetName();
+  }
 
-  // output the GPL notice only once the kernel object has been found or downloaded
-  gplNotice();
+  // startup_diagnostics.KernelDriverDownloaded();
 
   // Register signal handlers
   signal(SIGABRT, AbortHandler);
@@ -251,13 +230,16 @@ int main(int argc, char** argv) {
 
   CollectorService collector(config, &g_control, &g_signum);
 
-  if (!collector.InitKernel()) {
-    g_startup_diagnostics.Log();
-    CLOG(FATAL) << "Failed to initialize collector kernel components.";
+  if (!collector.InitKernel(args->GRPCServer(), candidates)) {
+    startup_diagnostics.Log();
+    CLOG(FATAL) << "Failed to initialize collector service.";
   }
 
-  g_startup_diagnostics.KernelDriverLoaded();
-  g_startup_diagnostics.Log();
+  // output the GPL notice only once the kernel object has been found or downloaded
+  gplNotice();
+
+  startup_diagnostics.KernelDriverLoaded();
+  startup_diagnostics.Log();
 
   collector.RunForever();
 

--- a/collector/lib/CollectionMethod.h
+++ b/collector/lib/CollectionMethod.h
@@ -21,32 +21,15 @@ You should have received a copy of the GNU General Public License along with thi
 * version.
 */
 
-#ifndef COLLECTOR_HOSTCONFIG_H
-#define COLLECTOR_HOSTCONFIG_H
+#ifndef COLLECTION_METHOD_H
+#define COLLECTION_METHOD_H
 
-#include <optional>
-#include <string>
-
-#include "CollectionMethod.h"
-
-//
-// The HostConfig is runtime-configured based on the host where
-// collector is running. It is intended to inform minor adjustments to
-// the CollectorConfig, in cases where we can fall back to other ways
-// of operating.
-//
-class HostConfig {
- public:
-  HostConfig() = default;
-
-  collector::collectionMethod CollectionMethod() const { return *collection_method_; }
-  bool HasCollectionMethod() const { return collection_method_.has_value(); }
-  void SetCollectionMethod(collector::collectionMethod method) {
-    collection_method_ = method;
-  }
-
- private:
-  std::optional<collector::collectionMethod> collection_method_;
+namespace collector {
+enum collectionMethod {
+  EBPF = 0,
+  CORE_BPF,
+  KERNEL_MODULE,
 };
+}  // namespace collector
 
-#endif  // COLLECTOR_HOSTCONFIG_H
+#endif  // COLLECTION_METHOD_H

--- a/collector/lib/CollectionMethod.h
+++ b/collector/lib/CollectionMethod.h
@@ -25,7 +25,7 @@ You should have received a copy of the GNU General Public License along with thi
 #define COLLECTION_METHOD_H
 
 namespace collector {
-enum collectionMethod {
+enum CollectionMethod {
   EBPF = 0,
   CORE_BPF,
   KERNEL_MODULE,

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -277,7 +277,7 @@ CollectorArgs::CollectorConfig() const {
 }
 
 const std::string&
-CollectorArgs::CollectionMethod() const {
+CollectorArgs::GetCollectionMethod() const {
   return collectionMethod;
 }
 

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -72,7 +72,7 @@ static const option::Descriptor usage[] =
          "Options:"},
         {HELP, 0, "", "help", option::Arg::None, "  --help                \tPrint usage and exit."},
         {COLLECTOR_CONFIG, 0, "", "collector-config", checkCollectorConfig, "  --collector-config    \tREQUIRED: Collector config as a JSON string. Please refer to documentation on the valid JSON format."},
-        {COLLECTION_METHOD, 0, "", "collection-method", checkCollectionMethod, "  --collection-method   \tCollection method (kernel_module or ebpf)."},
+        {COLLECTION_METHOD, 0, "", "collection-method", checkCollectionMethod, "  --collection-method   \tCollection method (kernel_module, ebpf or core_bpf)."},
         {CHISEL, 0, "", "chisel", checkChisel, "  --chisel              \tChisel is a base64 encoded string."},
         {GRPC_SERVER, 0, "", "grpc-server", checkGRPCServer, "  --grpc-server         \tREQUIRED: GRPC server endpoint string in the form HOST1:PORT1."},
         {UNKNOWN, 0, "", "", option::Arg::None,

--- a/collector/lib/CollectorArgs.h
+++ b/collector/lib/CollectorArgs.h
@@ -46,7 +46,7 @@ class CollectorArgs {
   option::ArgStatus checkOptionalNumeric(const option::Option& option, bool msg);
 
   const Json::Value& CollectorConfig() const;
-  const std::string& CollectionMethod() const;
+  const std::string& GetCollectionMethod() const;
   const std::string& Chisel() const;
   const std::string& GRPCServer() const;
   const std::string& Message() const;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -60,7 +60,7 @@ BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", C
 constexpr bool CollectorConfig::kUseChiselCache;
 constexpr bool CollectorConfig::kTurnOffScrape;
 constexpr int CollectorConfig::kScrapeInterval;
-constexpr collectionMethod CollectorConfig::kCollectionMethod;
+constexpr CollectionMethod CollectorConfig::kCollectionMethod;
 constexpr char CollectorConfig::kChisel[];
 constexpr const char* CollectorConfig::kSyscalls[];
 constexpr bool CollectorConfig::kForceKernelModules;
@@ -148,8 +148,8 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
     }
 
     // Collection Method
-    if (args->CollectionMethod().length() > 0) {
-      const auto& cm = args->CollectionMethod();
+    if (args->GetCollectionMethod().length() > 0) {
+      const auto& cm = args->GetCollectionMethod();
 
       if (cm == "ebpf") {
         collection_method_ = EBPF;
@@ -234,7 +234,7 @@ bool CollectorConfig::UseChiselCache() const {
 }
 
 bool CollectorConfig::UseEbpf() const {
-  collectionMethod cm = CollectionMethod();
+  CollectionMethod cm = GetCollectionMethod();
   return (cm == EBPF || cm == CORE_BPF);
 }
 
@@ -250,9 +250,9 @@ std::string CollectorConfig::Chisel() const {
   return chisel_;
 }
 
-collectionMethod CollectorConfig::CollectionMethod() const {
+CollectionMethod CollectorConfig::GetCollectionMethod() const {
   if (host_config_.HasCollectionMethod()) {
-    return host_config_.CollectionMethod();
+    return host_config_.GetCollectionMethod();
   }
   return collection_method_;
 }
@@ -283,7 +283,7 @@ bool CollectorConfig::IsCoreDumpEnabled() const {
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
   return os
-         << "collection_method:" << c.CollectionMethod()
+         << "collection_method:" << c.GetCollectionMethod()
          << ", useChiselCache:" << c.UseChiselCache()
          << ", scrape_interval:" << c.ScrapeInterval()
          << ", turn_off_scrape:" << c.TurnOffScrape()

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -58,7 +58,6 @@ BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", C
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
-constexpr bool CollectorConfig::kSnapLen;
 constexpr bool CollectorConfig::kTurnOffScrape;
 constexpr int CollectorConfig::kScrapeInterval;
 constexpr char CollectorConfig::kCollectionMethod[];
@@ -75,7 +74,6 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   use_chisel_cache_ = kUseChiselCache;
   scrape_interval_ = kScrapeInterval;
   turn_off_scrape_ = kTurnOffScrape;
-  snap_len_ = kSnapLen;
   chisel_ = kChisel;
   collection_method_ = kCollectionMethod;
   force_kernel_modules_ = kForceKernelModules;
@@ -243,10 +241,6 @@ int CollectorConfig::ScrapeInterval() const {
   return scrape_interval_;
 }
 
-int CollectorConfig::SnapLen() const {
-  return snap_len_;
-}
-
 std::string CollectorConfig::Chisel() const {
   return chisel_;
 }
@@ -286,7 +280,6 @@ std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
   return os
          << "collection_method:" << c.CollectionMethod()
          << ", useChiselCache:" << c.UseChiselCache()
-         << ", snapLen:" << c.SnapLen()
          << ", scrape_interval:" << c.ScrapeInterval()
          << ", turn_off_scrape:" << c.TurnOffScrape()
          << ", hostname:" << c.Hostname()

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -41,7 +41,6 @@ class CollectorArgs;
 class CollectorConfig {
  public:
   static constexpr bool kUseChiselCache = true;
-  static constexpr bool kSnapLen = 0;
   static constexpr bool kTurnOffScrape = false;
   static constexpr int kScrapeInterval = 30;
   static constexpr char kCollectionMethod[] = "kernel-module";
@@ -93,7 +92,6 @@ end
   bool TurnOffScrape() const;
   bool ScrapeListenEndpoints() const { return scrape_listen_endpoints_; }
   int ScrapeInterval() const;
-  int SnapLen() const;
   std::string Chisel() const;
   std::string Hostname() const;
   std::string HostProc() const;
@@ -115,7 +113,6 @@ end
  protected:
   bool use_chisel_cache_;
   int scrape_interval_;
-  int snap_len_;
   std::string collection_method_;
   std::string chisel_;
   bool turn_off_scrape_;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -31,6 +31,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <grpcpp/channel.h>
 
+#include "CollectionMethod.h"
 #include "HostConfig.h"
 #include "NetworkConnection.h"
 
@@ -43,7 +44,7 @@ class CollectorConfig {
   static constexpr bool kUseChiselCache = true;
   static constexpr bool kTurnOffScrape = false;
   static constexpr int kScrapeInterval = 30;
-  static constexpr char kCollectionMethod[] = "kernel-module";
+  static constexpr collectionMethod kCollectionMethod = KERNEL_MODULE;
   static constexpr const char* kSyscalls[] = {
       "accept",
       "chdir",
@@ -95,7 +96,7 @@ end
   std::string Chisel() const;
   std::string Hostname() const;
   std::string HostProc() const;
-  std::string CollectionMethod() const;
+  collectionMethod CollectionMethod() const;
   std::vector<std::string> Syscalls() const;
   int64_t AfterglowPeriod() const;
   std::string LogLevel() const;
@@ -113,7 +114,7 @@ end
  protected:
   bool use_chisel_cache_;
   int scrape_interval_;
-  std::string collection_method_;
+  collectionMethod collection_method_;
   std::string chisel_;
   bool turn_off_scrape_;
   std::vector<std::string> syscalls_;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -44,7 +44,7 @@ class CollectorConfig {
   static constexpr bool kUseChiselCache = true;
   static constexpr bool kTurnOffScrape = false;
   static constexpr int kScrapeInterval = 30;
-  static constexpr collectionMethod kCollectionMethod = KERNEL_MODULE;
+  static constexpr CollectionMethod kCollectionMethod = KERNEL_MODULE;
   static constexpr const char* kSyscalls[] = {
       "accept",
       "chdir",
@@ -96,7 +96,7 @@ end
   std::string Chisel() const;
   std::string Hostname() const;
   std::string HostProc() const;
-  collectionMethod CollectionMethod() const;
+  CollectionMethod GetCollectionMethod() const;
   std::vector<std::string> Syscalls() const;
   int64_t AfterglowPeriod() const;
   std::string LogLevel() const;
@@ -114,7 +114,7 @@ end
  protected:
   bool use_chisel_cache_;
   int scrape_interval_;
-  collectionMethod collection_method_;
+  CollectionMethod collection_method_;
   std::string chisel_;
   bool turn_off_scrape_;
   std::vector<std::string> syscalls_;

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -165,6 +165,10 @@ bool CollectorService::InitKernel(const std::string& GRPCServer, const std::vect
     if (sysdig_.InitKernel(config_, candidate)) {
       startup_diagnostics.DriverSuccess(candidate.GetName());
       return true;
+    } else if (candidate.GetCollectionMethod() == KERNEL_MODULE) {
+      // Kernel module drops capabilities, so subsequent attempts could fail
+      // instead we use the legacy behaviour of failing.
+      break;
     }
   }
 

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -209,7 +209,7 @@ bool SetupKernelDriver(CollectorService& collector, const std::string& GRPCServe
     }
   }
 
-  CLOG(WARNING) << "Failed to initialize collector kernel components.";
+  CLOG(ERROR) << "Failed to initialize collector kernel components.";
   // No candidate managed to create a working collector service.
   return false;
 }

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -156,13 +156,14 @@ bool CollectorService::InitKernel(const std::string& GRPCServer, const std::vect
   for (const auto& candidate : candidates) {
     if (!GetKernelObject(GRPCServer, config_.TLSConfiguration(), candidate, config_.CurlVerbose())) {
       CLOG(WARNING) << "No suitable kernel object downloaded for " << candidate.GetName();
+      startup_diagnostics.DriverUnavailable(candidate.GetName());
       continue;
     }
 
-    // startup_diagnostics.KernelDriverDownloaded();
+    startup_diagnostics.DriverAvailable(candidate.GetName());
 
     if (sysdig_.InitKernel(config_, candidate)) {
-      // startup_diagnostics.Log();
+      startup_diagnostics.DriverSuccess(candidate.GetName());
       return true;
     }
   }

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -42,7 +42,7 @@ class CollectorService {
 
   void RunForever();
 
-  bool InitKernel(const std::string& GRPCServer, const std::vector<DriverCandidate>& candidates);
+  bool InitKernel(const DriverCandidate& candidate);
 
  private:
   void OnChiselReceived(const std::string& chisel);
@@ -59,6 +59,8 @@ class CollectorService {
 
   SysdigService sysdig_;
 };
+
+bool SetupKernelDriver(CollectorService& collector, const std::string& GRPCServer, const CollectorConfig& config);
 
 }  // namespace collector
 

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -29,6 +29,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include "CollectorConfig.h"
 #include "CollectorStats.h"
 #include "Control.h"
+#include "DriverCandidates.h"
 #include "SysdigService.h"
 
 namespace collector {
@@ -41,7 +42,7 @@ class CollectorService {
 
   void RunForever();
 
-  bool InitKernel();
+  bool InitKernel(const std::string& GRPCServer, const std::vector<DriverCandidate>& candidates);
 
  private:
   void OnChiselReceived(const std::string& chisel);

--- a/collector/lib/Diagnostics.h
+++ b/collector/lib/Diagnostics.h
@@ -19,10 +19,16 @@ class StartupDiagnostics : public IDiagnostics {
     CLOG(INFO) << "";
     CLOG(INFO) << "== Collector Startup Diagnostics: ==";
     CLOG(INFO) << " Connected to Sensor?       " << std::boolalpha << connectedToSensor_;
-    CLOG(INFO) << " Kernel driver available?   " << std::boolalpha << kernelDriverDownloaded_;
-    CLOG(INFO) << " Driver loaded into kernel? " << std::boolalpha << kernelDriverLoaded_;
+
+    CLOG(INFO) << " Kernel driver candidates:";
+    for (const auto& line : driverDiagnostics_) {
+      CLOG(INFO) << line;
+    }
+
     CLOG(INFO) << "====================================";
     CLOG(INFO) << "";
+
+    driverDiagnostics_.clear();
   }
 
   static StartupDiagnostics& GetInstance() {
@@ -32,18 +38,31 @@ class StartupDiagnostics : public IDiagnostics {
   }
 
   void ConnectedToSensor() { connectedToSensor_ = true; }
-  void KernelDriverDownloaded() { kernelDriverDownloaded_ = true; }
-  void KernelDriverLoaded() { kernelDriverLoaded_ = true; }
+
+  void DriverUnavailable(const std::string& candidate) {
+    std::stringstream line;
+    line << "  " << candidate << " (unavailable)";
+    driverDiagnostics_.push_back(line.str());
+  }
+  void DriverAvailable(const std::string& candidate) {
+    std::stringstream line;
+    line << "  " << candidate << " (available)";
+    driverDiagnostics_.push_back(line.str());
+  }
+
+  void DriverSuccess(const std::string& candidate) {
+    std::stringstream line;
+    line << " Driver loaded into kernel: " << candidate;
+    driverDiagnostics_.push_back(line.str());
+  }
 
  private:
   bool connectedToSensor_;
-  bool kernelDriverDownloaded_;
-  bool kernelDriverLoaded_;
+  std::vector<std::string> driverDiagnostics_;
 
   StartupDiagnostics()
       : connectedToSensor_(false),
-        kernelDriverDownloaded_(false),
-        kernelDriverLoaded_(false) {}
+        driverDiagnostics_() {}
 };
 
 }  // namespace collector

--- a/collector/lib/Diagnostics.h
+++ b/collector/lib/Diagnostics.h
@@ -15,11 +15,6 @@ class IDiagnostics {
 
 class StartupDiagnostics : public IDiagnostics {
  public:
-  StartupDiagnostics()
-      : connectedToSensor_(false),
-        kernelDriverDownloaded_(false),
-        kernelDriverLoaded_(false) {}
-
   void Log() {
     CLOG(INFO) << "";
     CLOG(INFO) << "== Collector Startup Diagnostics: ==";
@@ -30,6 +25,12 @@ class StartupDiagnostics : public IDiagnostics {
     CLOG(INFO) << "";
   }
 
+  static StartupDiagnostics& GetInstance() {
+    static StartupDiagnostics instance;
+
+    return instance;
+  }
+
   void ConnectedToSensor() { connectedToSensor_ = true; }
   void KernelDriverDownloaded() { kernelDriverDownloaded_ = true; }
   void KernelDriverLoaded() { kernelDriverLoaded_ = true; }
@@ -38,6 +39,11 @@ class StartupDiagnostics : public IDiagnostics {
   bool connectedToSensor_;
   bool kernelDriverDownloaded_;
   bool kernelDriverLoaded_;
+
+  StartupDiagnostics()
+      : connectedToSensor_(false),
+        kernelDriverDownloaded_(false),
+        kernelDriverLoaded_(false) {}
 };
 
 }  // namespace collector

--- a/collector/lib/Diagnostics.h
+++ b/collector/lib/Diagnostics.h
@@ -41,12 +41,12 @@ class StartupDiagnostics : public IDiagnostics {
 
   void DriverUnavailable(const std::string& candidate) {
     std::stringstream line;
-    line << "  " << candidate << " (unavailable)";
+    line << "   " << candidate << " (unavailable)";
     driverDiagnostics_.push_back(line.str());
   }
   void DriverAvailable(const std::string& candidate) {
     std::stringstream line;
-    line << "  " << candidate << " (available)";
+    line << "   " << candidate << " (available)";
     driverDiagnostics_.push_back(line.str());
   }
 

--- a/collector/lib/DriverCandidates.cpp
+++ b/collector/lib/DriverCandidates.cpp
@@ -164,7 +164,7 @@ DriverCandidate getUserDriverCandidate(const char* full_name, bool useEbpf) {
 }
 }  // namespace
 
-std::vector<DriverCandidate> GetKernelCandidates(collectionMethod cm) {
+std::vector<DriverCandidate> GetKernelCandidates(CollectionMethod cm) {
   std::vector<DriverCandidate> candidates;
   bool useEbpf = cm == EBPF || cm == CORE_BPF;
 

--- a/collector/lib/DriverCandidates.h
+++ b/collector/lib/DriverCandidates.h
@@ -27,18 +27,13 @@ You should have received a copy of the GNU General Public License along with thi
 #include <string>
 #include <vector>
 
-#include "KernelDriver.h"
+#include "CollectionMethod.h"
 
 namespace collector {
 
 class DriverCandidate {
  public:
-  DriverCandidate(const std::string& name, bool useEbpf, bool downloadable = true, const std::string& path = "/kernel-modules") : name_(name), path_(path), downloadable_(downloadable) {
-    if (useEbpf) {
-      collection_method_ = EBPF;
-    } else {
-      collection_method_ = KERNEL_MODULE;
-    }
+  DriverCandidate(const std::string& name, collectionMethod cm, bool downloadable = true, const std::string& path = "/kernel-modules") : name_(name), path_(path), downloadable_(downloadable), collection_method_(cm) {
   }
 
   inline const std::string& GetPath() const { return path_; }
@@ -57,7 +52,7 @@ class DriverCandidate {
 };
 
 // Get kernel candidates
-std::vector<DriverCandidate> GetKernelCandidates(bool useEbpf);
+std::vector<DriverCandidate> GetKernelCandidates(collectionMethod cm);
 
 }  // namespace collector
 #endif  // _DRIVER_CANDIDATES_H_

--- a/collector/lib/DriverCandidates.h
+++ b/collector/lib/DriverCandidates.h
@@ -33,7 +33,7 @@ namespace collector {
 
 class DriverCandidate {
  public:
-  DriverCandidate(const std::string& name, collectionMethod cm, bool downloadable = true, const std::string& path = "/kernel-modules") : name_(name), path_(path), downloadable_(downloadable), collection_method_(cm) {
+  DriverCandidate(const std::string& name, CollectionMethod cm, bool downloadable = true, const std::string& path = "/kernel-modules") : name_(name), path_(path), downloadable_(downloadable), collection_method_(cm) {
   }
 
   inline const std::string& GetPath() const { return path_; }
@@ -42,17 +42,17 @@ class DriverCandidate {
 
   inline bool IsDownloadable() const { return downloadable_; }
 
-  inline collectionMethod GetCollectionMethod() const { return collection_method_; }
+  inline CollectionMethod GetCollectionMethod() const { return collection_method_; }
 
  private:
   std::string name_;
   std::string path_;
   bool downloadable_;
-  collectionMethod collection_method_;
+  CollectionMethod collection_method_;
 };
 
 // Get kernel candidates
-std::vector<DriverCandidate> GetKernelCandidates(collectionMethod cm);
+std::vector<DriverCandidate> GetKernelCandidates(CollectionMethod cm);
 
 }  // namespace collector
 #endif  // _DRIVER_CANDIDATES_H_

--- a/collector/lib/DriverCandidates.h
+++ b/collector/lib/DriverCandidates.h
@@ -27,6 +27,8 @@ You should have received a copy of the GNU General Public License along with thi
 #include <string>
 #include <vector>
 
+#include "KernelDriver.h"
+
 namespace collector {
 
 class DriverCandidate {
@@ -45,14 +47,9 @@ class DriverCandidate {
 
   inline bool IsDownloadable() const { return downloadable_; }
 
-  inline bool IsEbpf() const { return collection_method_ == EBPF; }
+  inline collectionMethod GetCollectionMethod() const { return collection_method_; }
 
  private:
-  enum collectionMethod {
-    EBPF = 0,
-    KERNEL_MODULE,
-  };
-
   std::string name_;
   std::string path_;
   bool downloadable_;

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -25,9 +25,6 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <cstring>
 
-#include "KernelDriver.h"
-#include "SysdigService.h"
-
 extern "C" {
 #include <sys/stat.h>
 }
@@ -36,7 +33,9 @@ extern "C" {
 
 #include "FileDownloader.h"
 #include "FileSystem.h"
+#include "KernelDriver.h"
 #include "Logging.h"
+#include "SysdigService.h"
 #include "Utility.h"
 
 namespace collector {
@@ -142,6 +141,12 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
 }
 
 bool GetKernelObject(const std::string& hostname, const Json::Value& tls_config, const DriverCandidate& candidate, bool verbose) {
+  if (candidate.GetCollectionMethod() == CORE_BPF) {
+    // for now CO.RE bpf probes are embedded in the collector binary, nothing
+    // to do here.
+    return true;
+  }
+
   std::string expected_path = candidate.GetPath() + "/" + candidate.GetName();
   std::string expected_path_compressed = expected_path + ".gz";
   std::string module_path = candidate.GetCollectionMethod() == EBPF ? SysdigService::kProbePath : SysdigService::kModulePath;

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -25,6 +25,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <cstring>
 
+#include "KernelDriver.h"
 #include "SysdigService.h"
 
 extern "C" {
@@ -143,7 +144,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
 bool GetKernelObject(const std::string& hostname, const Json::Value& tls_config, const DriverCandidate& candidate, bool verbose) {
   std::string expected_path = candidate.GetPath() + "/" + candidate.GetName();
   std::string expected_path_compressed = expected_path + ".gz";
-  std::string module_path = candidate.IsEbpf() ? SysdigService::kProbePath : SysdigService::kModulePath;
+  std::string module_path = candidate.GetCollectionMethod() == EBPF ? SysdigService::kProbePath : SysdigService::kModulePath;
   struct stat sb;
 
   // first check for an existing compressed kernel object in the

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -31,9 +31,9 @@ extern "C" {
 
 #include <fstream>
 
+#include "CollectionMethod.h"
 #include "FileDownloader.h"
 #include "FileSystem.h"
-#include "KernelDriver.h"
 #include "Logging.h"
 #include "SysdigService.h"
 #include "Utility.h"

--- a/collector/lib/HostConfig.h
+++ b/collector/lib/HostConfig.h
@@ -39,14 +39,14 @@ class HostConfig {
  public:
   HostConfig() = default;
 
-  collector::collectionMethod CollectionMethod() const { return *collection_method_; }
+  collector::CollectionMethod GetCollectionMethod() const { return *collection_method_; }
   bool HasCollectionMethod() const { return collection_method_.has_value(); }
-  void SetCollectionMethod(collector::collectionMethod method) {
+  void SetCollectionMethod(collector::CollectionMethod method) {
     collection_method_ = method;
   }
 
  private:
-  std::optional<collector::collectionMethod> collection_method_;
+  std::optional<collector::CollectionMethod> collection_method_;
 };
 
 #endif  // COLLECTOR_HOSTCONFIG_H

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -53,7 +53,7 @@ class CollectionHeuristic : public Heuristic {
                     << " does not support ebpf based collection.";
       CLOG(WARNING) << "Switching to kernel module based collection, please set "
                     << "collector.collectionMethod=KERNEL_MODULE to remove this message";
-      hconfig->SetCollectionMethod("kernel-module");
+      hconfig->SetCollectionMethod(KERNEL_MODULE);
     }
   }
 };
@@ -74,7 +74,7 @@ class CosHeuristic : public Heuristic {
       if (host.HasEBPFSupport() && !config.ForceKernelModules()) {
         CLOG(WARNING) << "Switching to eBPF based collection, please set "
                       << "collector.collectionMethod=EBPF to remove this message";
-        hconfig->SetCollectionMethod("ebpf");
+        hconfig->SetCollectionMethod(EBPF);
       } else {
         CLOG(FATAL) << "Unable to switch to eBPF collection on " << host.GetDistro();
       }
@@ -93,7 +93,7 @@ class DockerDesktopHeuristic : public Heuristic {
 
     if (config.UseEbpf()) {
       CLOG(WARNING) << host.GetDistro() << " does not support eBPF, switching to kernel module based collection.";
-      hconfig->SetCollectionMethod("kernel-module");
+      hconfig->SetCollectionMethod(KERNEL_MODULE);
     }
   }
 };
@@ -112,7 +112,7 @@ class MinikubeHeuristic : public Heuristic {
     if (!config.UseEbpf()) {
       CLOG(WARNING) << host.GetHostname() << " does not support third-party kernel modules";
       CLOG(WARNING) << "Switching to eBPF based collection, please set collector.collectionMethod=EBPF to remove this message";
-      hconfig->SetCollectionMethod("ebpf");
+      hconfig->SetCollectionMethod(EBPF);
     }
   }
 };
@@ -137,14 +137,14 @@ class SecureBootHeuristic : public Heuristic {
     if (sb_status == SecureBootStatus::ENABLED) {
       CLOG(WARNING) << "SecureBoot is enabled preventing unsigned third-party "
                     << "kernel modules. Switching to eBPF based collection.";
-      hconfig->SetCollectionMethod("ebpf");
+      hconfig->SetCollectionMethod(EBPF);
     }
 
 #ifdef __x86_64__
     if (sb_status == SecureBootStatus::NOT_DETERMINED) {
       CLOG(WARNING) << "SecureBoot status could not be determined. "
                     << "Switching to eBPF based collection.";
-      hconfig->SetCollectionMethod("ebpf");
+      hconfig->SetCollectionMethod(EBPF);
     }
 #endif
   }
@@ -181,7 +181,7 @@ class GardenLinuxHeuristic : public Heuristic {
       CLOG(WARNING) << distro << " does not support kernel module based collection. "
                     << "Switching to eBPF based collection, set "
                     << "collector.collectionMethod=EBPF to remove this message";
-      hconfig->SetCollectionMethod("ebpf");
+      hconfig->SetCollectionMethod(EBPF);
       return;
     }
   }

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -2,6 +2,7 @@
 #define COLLECTOR_KERNEL_DRIVER_H
 
 #include <string>
+
 extern "C" {
 #include <cap-ng.h>
 #include <stdio.h>

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -19,6 +19,11 @@ extern "C" {
 extern unsigned char g_bpf_drop_syscalls[];
 
 namespace collector {
+enum collectionMethod {
+  EBPF = 0,
+  CORE_BPF,
+  KERNEL_MODULE,
+};
 
 class IKernelDriver {
  public:
@@ -102,6 +107,13 @@ class KernelDriverEBPF : public IKernelDriver {
   }
 };
 
+class KernelDriverCOREEBPF : public IKernelDriver {
+ public:
+  bool Setup(const CollectorConfig& config, std::string path) override {
+    // TODO: implement CO.RE ebpf setup if needed
+    return false;
+  }
+};
 }  // namespace collector
 
 #endif

--- a/collector/lib/Sysdig.h
+++ b/collector/lib/Sysdig.h
@@ -31,6 +31,7 @@ You should have received a copy of the GNU General Public License along with thi
 #include "CollectorConfig.h"
 #include "ConnTracker.h"
 #include "Control.h"
+#include "DriverCandidates.h"
 #include "ppm_events_public.h"
 
 namespace collector {
@@ -67,7 +68,7 @@ class Sysdig {
   virtual ~Sysdig() = default;
 
   virtual void Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) = 0;
-  virtual bool InitKernel(const CollectorConfig& config) = 0;
+  virtual bool InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) = 0;
   virtual void Start() = 0;
   virtual void Run(const std::atomic<ControlValue>& control) = 0;
   virtual void CleanUp() = 0;

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -68,19 +68,19 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
   use_chisel_cache_ = config.UseChiselCache();
 }
 
-bool SysdigService::InitKernel(const CollectorConfig& config) {
+bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) {
   if (inspector_) {
     throw CollectorException("Invalid state: SysdigService kernel components are already initialized");
   }
 
   inspector_.reset(new_inspector());
-  inspector_->set_snaplen(config.SnapLen());
+  inspector_->set_snaplen(0);
 
   if (logging::GetLogLevel() == logging::LogLevel::TRACE) {
     inspector_->set_log_stderr();
   }
 
-  if (config.UseEbpf()) {
+  if (candidate.GetCollectionMethod() == EBPF) {
     useEbpf_ = true;
     KernelDriverEBPF driver;
     if (!driver.Setup(config, SysdigService::kProbePath)) {

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -72,6 +72,8 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
 bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) {
   if (!inspector_) {
     inspector_.reset(new_inspector());
+
+    // peeking into arguments has a big overhead, so we prevent it from happening
     inspector_->set_snaplen(0);
 
     if (logging::GetLogLevel() == logging::LogLevel::TRACE) {

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -33,6 +33,7 @@ You should have received a copy of the GNU General Public License along with thi
 // clang-format off
 // sinsp.h needs to be included before chisel.h
 #include "libsinsp/sinsp.h"
+#include "DriverCandidates.h"
 #include "chisel.h"
 // clang-format on
 
@@ -61,7 +62,7 @@ class SysdigService : public Sysdig {
 
   bool GetStats(SysdigStats* stats) const override;
 
-  bool InitKernel(const CollectorConfig& config) override;
+  bool InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) override;
 
   typedef std::weak_ptr<std::function<void(threadinfo_map_t::ptr_t)>> ProcessInfoCallbackRef;
 

--- a/collector/test/DriverCandidatesTest.cpp
+++ b/collector/test/DriverCandidatesTest.cpp
@@ -24,9 +24,9 @@ You should have received a copy of the GNU General Public License along with thi
 #include <gmock/gmock-actions.h>
 #include <gmock/gmock-spec-builders.h>
 
+#include "CollectionMethod.h"
 #include "DriverCandidates.cpp"
 #include "HostInfo.h"
-#include "KernelDriver.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/collector/test/DriverCandidatesTest.cpp
+++ b/collector/test/DriverCandidatesTest.cpp
@@ -26,6 +26,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include "DriverCandidates.cpp"
 #include "HostInfo.h"
+#include "KernelDriver.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -61,7 +62,7 @@ TEST(getGardenLinuxCandidateTest, Garden576_1) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -80,7 +81,7 @@ TEST(getGardenLinuxCandidateTest, Garden318) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -101,7 +102,7 @@ TEST(getMinikubeCandidateTest, v1_27_1) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -122,7 +123,7 @@ TEST(getMinikubeCandidateTest, v1_24_0) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_TRUE(candidate->IsEbpf());
+  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -150,7 +151,7 @@ TEST(getUserDriverCandidate, RelativePath) {
   EXPECT_EQ(candidate.GetName(), expected_name);
   EXPECT_EQ(candidate.GetPath(), expected_path);
   EXPECT_FALSE(candidate.IsDownloadable());
-  EXPECT_TRUE(candidate.IsEbpf());
+  EXPECT_EQ(candidate.GetCollectionMethod(), EBPF);
 }
 
 TEST(getUserDriverCandidate, FullPath) {
@@ -163,7 +164,7 @@ TEST(getUserDriverCandidate, FullPath) {
   EXPECT_EQ(candidate.GetName(), expected_name);
   EXPECT_EQ(candidate.GetPath(), expected_path);
   EXPECT_FALSE(candidate.IsDownloadable());
-  EXPECT_FALSE(candidate.IsEbpf());
+  EXPECT_EQ(candidate.GetCollectionMethod(), KERNEL_MODULE);
 }
 
 TEST(normalizeReleaseStringTest, FedoraKernel) {

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -75,7 +75,7 @@ TEST(HostHeuristicsTest, TestSecureBootEnabled) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), EBPF);
 }
 
 // The SecureBoot feature is undetermined and could be enabled, triggering
@@ -97,11 +97,11 @@ TEST(HostHeuristicsTest, TestSecureBootNotDetermined) {
   secureBootHeuristics.Process(host, config, &hconfig);
 
 #ifdef __x86_64__
-  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), EBPF);
 #else
   // for non-x86 architectures we don't modify the collection method
   // if secure boot not determined.
-  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), KERNEL_MODULE);
 #endif
 }
 
@@ -122,7 +122,7 @@ TEST(HostHeuristicsTest, TestSecureBootKernelModuleForced) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), KERNEL_MODULE);
 }
 
 // Booted in the legacy mode
@@ -140,7 +140,7 @@ TEST(HostHeuristicsTest, TestSecureBootLegacyBIOS) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), KERNEL_MODULE);
 }
 
 // Garbage value is read from boot_param
@@ -160,7 +160,7 @@ TEST(HostHeuristicsTest, TestSecureBootIncorrect) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), KERNEL_MODULE);
 }
 
 class MockGardenLinuxHeuristic : public GardenLinuxHeuristic {
@@ -180,7 +180,7 @@ TEST(GardenLinuxHeuristicsTest, NotGardenLinux) {
 
   gardenLinuxHeuristic.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), KERNEL_MODULE);
 }
 
 TEST(GardenLinuxHeuristicsTest, UsingEBPF) {
@@ -196,15 +196,15 @@ TEST(GardenLinuxHeuristicsTest, UsingEBPF) {
 
   gardenLinuxHeuristic.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
+  EXPECT_EQ(hconfig.GetCollectionMethod(), EBPF);
 }
 
 struct GardenLinuxTestCase {
-  GardenLinuxTestCase(const std::string& release, collectionMethod collection_method)
+  GardenLinuxTestCase(const std::string& release, CollectionMethod collection_method)
       : release(release), collection_method(collection_method) {}
 
   std::string release;
-  collectionMethod collection_method;
+  CollectionMethod collection_method;
 };
 
 TEST(GardenLinuxHeuristicsTest, TestReleases) {
@@ -228,7 +228,7 @@ TEST(GardenLinuxHeuristicsTest, TestReleases) {
 
     gardenLinuxHeuristic.Process(host, config, &hconfig);
 
-    EXPECT_EQ(hconfig.CollectionMethod(), test_case.collection_method);
+    EXPECT_EQ(hconfig.GetCollectionMethod(), test_case.collection_method);
   }
 }
 

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -66,7 +66,7 @@ TEST(HostHeuristicsTest, TestSecureBootEnabled) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(host, IsUEFI()).WillOnce(Return(true));
   EXPECT_CALL(host, GetSecureBootStatus())
       .WillOnce(Return(SecureBootStatus::ENABLED));
@@ -75,7 +75,7 @@ TEST(HostHeuristicsTest, TestSecureBootEnabled) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "ebpf");
+  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
 }
 
 // The SecureBoot feature is undetermined and could be enabled, triggering
@@ -87,7 +87,7 @@ TEST(HostHeuristicsTest, TestSecureBootNotDetermined) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(host, IsUEFI()).WillOnce(Return(true));
   EXPECT_CALL(host, GetSecureBootStatus())
       .WillOnce(Return(SecureBootStatus::NOT_DETERMINED));
@@ -97,11 +97,11 @@ TEST(HostHeuristicsTest, TestSecureBootNotDetermined) {
   secureBootHeuristics.Process(host, config, &hconfig);
 
 #ifdef __x86_64__
-  EXPECT_EQ(hconfig.CollectionMethod(), "ebpf");
+  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
 #else
   // for non-x86 architectures we don't modify the collection method
   // if secure boot not determined.
-  EXPECT_EQ(hconfig.CollectionMethod(), "kernel-module");
+  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
 #endif
 }
 
@@ -116,13 +116,13 @@ TEST(HostHeuristicsTest, TestSecureBootKernelModuleForced) {
 
   // In this constellation neither IsUEFI nor GetSecureBootStatus are called,
   // as ForceKernelModules makes the decision earlier
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(config, UseEbpf()).WillRepeatedly(Return(false));
   EXPECT_CALL(config, ForceKernelModules()).WillOnce(Return(true));
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "kernel-module");
+  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
 }
 
 // Booted in the legacy mode
@@ -133,14 +133,14 @@ TEST(HostHeuristicsTest, TestSecureBootLegacyBIOS) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(host, IsUEFI()).WillOnce(Return(false));
   EXPECT_CALL(config, UseEbpf()).WillRepeatedly(Return(false));
   EXPECT_CALL(config, ForceKernelModules()).WillOnce(Return(false));
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "kernel-module");
+  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
 }
 
 // Garbage value is read from boot_param
@@ -151,7 +151,7 @@ TEST(HostHeuristicsTest, TestSecureBootIncorrect) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(host, IsUEFI()).WillOnce(Return(true));
   EXPECT_CALL(host, GetSecureBootStatus())
       .WillOnce(Return(static_cast<SecureBootStatus>(-1)));
@@ -160,7 +160,7 @@ TEST(HostHeuristicsTest, TestSecureBootIncorrect) {
 
   secureBootHeuristics.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "kernel-module");
+  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
 }
 
 class MockGardenLinuxHeuristic : public GardenLinuxHeuristic {
@@ -175,12 +175,12 @@ TEST(GardenLinuxHeuristicsTest, NotGardenLinux) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("kernel-module");
+  hconfig.SetCollectionMethod(KERNEL_MODULE);
   EXPECT_CALL(host, IsGarden()).WillOnce(Return(false));
 
   gardenLinuxHeuristic.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "kernel-module");
+  EXPECT_EQ(hconfig.CollectionMethod(), KERNEL_MODULE);
 }
 
 TEST(GardenLinuxHeuristicsTest, UsingEBPF) {
@@ -190,21 +190,21 @@ TEST(GardenLinuxHeuristicsTest, UsingEBPF) {
   MockCollectorConfig config(args);
   HostConfig hconfig;
 
-  hconfig.SetCollectionMethod("ebpf");
+  hconfig.SetCollectionMethod(EBPF);
   EXPECT_CALL(host, IsGarden()).WillOnce(Return(true));
   EXPECT_CALL(config, UseEbpf()).WillOnce(Return(true));
 
   gardenLinuxHeuristic.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.CollectionMethod(), "ebpf");
+  EXPECT_EQ(hconfig.CollectionMethod(), EBPF);
 }
 
 struct GardenLinuxTestCase {
-  GardenLinuxTestCase(const std::string& release, const std::string& collection_method)
+  GardenLinuxTestCase(const std::string& release, collectionMethod collection_method)
       : release(release), collection_method(collection_method) {}
 
   std::string release;
-  std::string collection_method;
+  collectionMethod collection_method;
 };
 
 TEST(GardenLinuxHeuristicsTest, TestReleases) {
@@ -215,13 +215,13 @@ TEST(GardenLinuxHeuristicsTest, TestReleases) {
   HostConfig hconfig;
 
   std::vector<GardenLinuxTestCase> test_cases = {
-      {"Garden Linux 318.9", "kernel_module"},
-      {"Garden Linux 576.2", "kernel_module"},
-      {"Garden Linux 576.3", "ebpf"},
-      {"Garden Linux 576.5", "ebpf"}};
+      {"Garden Linux 318.9", KERNEL_MODULE},
+      {"Garden Linux 576.2", KERNEL_MODULE},
+      {"Garden Linux 576.3", EBPF},
+      {"Garden Linux 576.5", EBPF}};
 
   for (auto test_case : test_cases) {
-    hconfig.SetCollectionMethod("kernel_module");
+    hconfig.SetCollectionMethod(KERNEL_MODULE);
     EXPECT_CALL(host, IsGarden()).WillOnce(Return(true));
     EXPECT_CALL(config, UseEbpf()).WillOnce(Return(false));
     EXPECT_CALL(host, GetDistro()).WillOnce(ReturnRef(test_case.release));


### PR DESCRIPTION
## Description

These changes should make it relatively easy to wire in the CO.RE eBPF probe for loading. They also put in place a fallback mechanism, allowing to try regular eBPF probes in case the CO.RE probe fails.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run locally setting `COLLECTION_METHOD` to `CORE_BPF` and it fallsback to regular eBPF.
