### PR TITLE
Consolidate Falco build patches into collector repo

### DIFF
--- a/builder/build/build-collector.sh
+++ b/builder/build/build-collector.sh
@@ -29,9 +29,7 @@ cmake "${cmake_extra_flags[@]}" -S "${SRC_ROOT_DIR}" -B "${CMAKE_BUILD_DIR}"
 cmake --build "${CMAKE_BUILD_DIR}" --target all -- -j "${NPROCS:-2}"
 
 if [ "$CMAKE_BUILD_TYPE" = "Release" ]; then
-    strip --strip-unneeded \
-        "${CMAKE_BUILD_DIR}/collector/collector" \
-        "${CMAKE_BUILD_DIR}/collector/EXCLUDE_FROM_DEFAULT_BUILD/libsinsp/libsinsp-wrapper.so"
+    strip --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector"
 fi
 
 cp -r /THIRD_PARTY_NOTICES "${CMAKE_BUILD_DIR}/"

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -42,10 +42,17 @@ set(DRIVER_HEADERS ${PROJECT_SOURCE_DIR}/falcosecurity-libs/driver/ppm_events_pu
 
 add_definitions(-DUSE_PROTO_ARENAS)
 
+#
+# In order to ensure that the Falco structures we are using
+# are the correct size, we define HAS_CAPTURE which toggles specific
+# structures in libsinsp.
+#
+add_definitions(-DHAS_CAPTURE)
+
 file(GLOB COLLECTOR_LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/lib/*.cpp)
 add_library(collector_lib ${DRIVER_HEADERS} ${COLLECTOR_LIB_SRC_FILES})
-add_dependencies(collector_lib sinsp-wrapper)
-target_link_libraries(collector_lib sinsp-wrapper)
+add_dependencies(collector_lib sinsp)
+target_link_libraries(collector_lib sinsp)
 target_link_libraries(collector_lib stdc++fs) # This is needed for GCC-8 to link against the filesystem library
 target_link_libraries(collector_lib cap-ng)
 target_link_libraries(collector_lib uuid)

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-de
 set(CMAKE_CXX_FLAGS_DEBUG "-g -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
 
+# Ensures that shared and static libraries are built as position
+# independent
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 if(NOT DEFINED ENV{DISABLE_PROFILING})
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOLLECTOR_PROFILING")
 endif()

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -38,7 +38,6 @@ container/bin/collector: cmake-build/collector
 collector: container/bin/collector txt-files
 	mkdir -p container/libs
 	cp -r "$(CMAKE_DIR)"/THIRD_PARTY_NOTICES/* container/THIRD_PARTY_NOTICES/
-	cp "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so" container/libs/libsinsp-wrapper.so
 
 .PHONY: build-connscrape-test
 build-connscrape-test:
@@ -47,14 +46,12 @@ build-connscrape-test:
 connscrape: build-connscrape-test
 	docker rm -fv collector_connscrape || true
 	docker run --rm --name collector_connscrape \
-		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		connscrape-test "$(SRC_MOUNT_DIR)/collector/connscrape-test/connscrape-test.sh"
 
 unittest: collector
 	docker rm -fv collector_unittest || true
 	docker run --rm --name collector_unittest \
-		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) $(COLLECTOR_PRE_ARGUMENTS) "$(SRC_MOUNT_DIR)/$(CMAKE_BASE_DIR)/collector/runUnitTests"
 

--- a/collector/container/Dockerfile.template
+++ b/collector/container/Dockerfile.template
@@ -22,7 +22,6 @@ COPY container/scripts/collector-wrapper.sh /
 COPY container/scripts/bootstrap.sh /
 COPY container/THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 COPY LICENSE-kernel-modules.txt /kernel-modules/LICENSE
-COPY container/libs/libsinsp-wrapper.so /usr/local/lib/
 COPY container/bin/collector /usr/local/bin/
 
 COPY container/${BUILD_TYPE}/final-step.sh /

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -27,8 +27,6 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <linux/ioctl.h>
 
-#include "libsinsp/wrapper.h"
-
 #include "CollectorException.h"
 #include "EventNames.h"
 #include "HostInfo.h"
@@ -73,7 +71,7 @@ bool SysdigService::InitKernel(const CollectorConfig& config) {
     throw CollectorException("Invalid state: SysdigService kernel components are already initialized");
   }
 
-  inspector_.reset(new_inspector());
+  inspector_.reset(new sinsp);
   inspector_->set_snaplen(config.SnapLen());
 
   if (logging::GetLogLevel() == logging::LogLevel::TRACE) {
@@ -308,7 +306,7 @@ void SysdigService::SetChisel(const std::string& chisel) {
   std::lock_guard<std::mutex> lock(libsinsp_mutex_);
   CLOG(DEBUG) << "Updating chisel and flushing chisel cache";
   CLOG(DEBUG) << "New chisel: " << chisel;
-  chisel_.reset(new_chisel(inspector_.get(), chisel, false));
+  chisel_.reset(new sinsp_chisel(inspector_.get(), chisel, false));
   chisel_->on_init();
   chisel_cache_.clear();
 

--- a/collector/test/ProcessSignalFormatterTest.cpp
+++ b/collector/test/ProcessSignalFormatterTest.cpp
@@ -26,7 +26,6 @@ You should have received a copy of the GNU General Public License along with thi
 #include <Utility.h>
 #include "libsinsp/sinsp.h"
 #include "chisel.h"
-#include "libsinsp/wrapper.h"
 // clang-format on
 
 #include "CollectorStats.h"
@@ -40,6 +39,10 @@ using ProcessSignal = ProcessSignalFormatter::ProcessSignal;
 using LineageInfo = ProcessSignalFormatter::LineageInfo;
 
 namespace {
+
+sinsp* SINSP_PUBLIC new_inspector() {
+  return new sinsp;
+}
 
 TEST(ProcessSignalFormatterTest, NoProcessTest) {
   sinsp* inspector = NULL;


### PR DESCRIPTION
## Description

To reduce the difficulty of maintaining the Falco fork, this PR moves some of the build changes into the collector repository. 

- removes the libsinsp-wrapper library in favour of direct calls
- moves -fPIC settings to collector CMakeLists.txt

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally on Ubuntu, with various configurations of settings including alongside the existing patches.
