### PR TITLE
Bump Garden Linux VM to version 934.6

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -83,4 +83,4 @@ virtual_machines:
   garden-linux:
     project: sap-se-gcp-gardenlinux
     images:
-      - gardenlinux-gcp-gardener-prod-amd64-934-5-59b6440
+      - gardenlinux-gcp-gardener-prod-amd64-934-6-76ea662


### PR DESCRIPTION
## Description

Bumping the Garden Linux VM version used for testing to the latest (934.6).

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Green CI with `all-integration-tests` label.
