### PR TITLE
Use regular UBI as base for dev images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea/
 .rox/
 
-collector/container/Dockerfile.gen
 integration-tests/container-logs/
 integration-tests/*.log
 integration-tests/*.logs

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ container-dockerfile:
 		< $(CURDIR)/collector/container/Dockerfile.template > \
 		$(CURDIR)/collector/container/Dockerfile.gen
 
+.PHONY: container-dockerfile-dev
+container-dockerfile-dev: container-dockerfile
+	sed '1s/ubi-minimal/ubi/' $(CURDIR)/collector/container/Dockerfile.gen > \
+		$(CURDIR)/collector/container/Dockerfile.dev
+
 .PHONY: builder
 builder:
 ifdef BUILD_BUILDER_IMAGE
@@ -68,11 +73,11 @@ image: collector unittest container-dockerfile
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \
 		$(COLLECTOR_BUILD_CONTEXT)
 
-image-dev: collector unittest container-dockerfile
+image-dev: collector unittest container-dockerfile-dev
 	make -C collector txt-files
 	docker build --build-arg collector_version="$(COLLECTOR_TAG)" \
 		--build-arg BUILD_TYPE=devel \
-		-f collector/container/Dockerfile.gen \
+		-f collector/container/Dockerfile.dev \
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \
 		$(COLLECTOR_BUILD_CONTEXT)
 
@@ -123,7 +128,6 @@ teardown-dev:
 .PHONY: clean
 clean: teardown-dev
 	rm -rf cmake-build/
-	rm -f collector/container/Dockerfile.gen
 	make -C collector clean
 
 .PHONY: shfmt-check

--- a/collector/.gitignore
+++ b/collector/.gitignore
@@ -14,5 +14,9 @@ cmake-build-rhel/
 generated/
 collector/protoc-*
 
+# Generated dockerfiles
+container/Dockerfile.gen
+container/Dockerfile.dev
+
 # clangd specific files
 .cache/

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -78,6 +78,8 @@ clean:
 	rm -rf container/devel/scripts
 	rm -rf container/devel/bundle.tar.gz
 	rm -rf container/THIRD_PARTY_NOTICES
+	rm -f container/Dockerfile.gen
+	rm -f container/Dockerfile.dev
 
 .PHONY: check
 check:

--- a/collector/container/devel/final-step.sh
+++ b/collector/container/devel/final-step.sh
@@ -6,9 +6,9 @@ echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 
 mv collector-wrapper.sh /usr/local/bin/
 chmod 700 bootstrap.sh
-microdnf upgrade -y
-microdnf install -y kmod
+dnf upgrade -y
+dnf install -y kmod
 
-microdnf install -y libasan
+dnf install -y libasan
 
 echo "${MODULE_VERSION}" > /kernel-modules/MODULE_VERSION.txt


### PR DESCRIPTION
## Description

Non-minimal UBI images come with `gdbserver` pre-installed, so replacing it in the current dockerfile via `sed` seems like the best way to keep it up to date without having to resort to any weird workarounds.

The PR also does some cleanup, moving certain `make clean` commands and `.gitignore` lines to be closer to the place they are actually used.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] Build the dev image and make sure it can be debugged from a k8s deployment.
