### PR TITLE
Stacktrace improvements

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -3,7 +3,7 @@ project(collector-bin)
 find_package(Threads)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-deprecated-declarations")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-deprecated-declarations -fno-omit-frame-pointer -rdynamic")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
@@ -13,7 +13,7 @@ if(NOT DEFINED ENV{DISABLE_PROFILING})
 endif()
 
 if(ADDRESS_SANITIZER)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 endif()
 
 if(COLLECTOR_APPEND_CID)

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -117,7 +117,7 @@ static void AbortHandler(int signum) {
   size_t max_frames = sizeof(buffer) / sizeof(buffer[0]);
   int message_buffer_size = sizeof(message_buffer);
 
-  for (size_t i = 1; i < n_frames; i++) {
+  for (size_t i = 0; i < n_frames; i++) {
     Dl_info info;
 
     if (dladdr(buffer[i], &info)) {

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -37,6 +37,8 @@ You should have received a copy of the GNU General Public License along with thi
 extern "C" {
 #include <assert.h>
 #include <cap-ng.h>
+#include <cxxabi.h>
+#include <dlfcn.h>
 #include <execinfo.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -81,19 +83,85 @@ ShutdownHandler(int signum) {
   g_control.store(ControlValue::STOP_COLLECTOR);
 }
 
+static void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
+  if (num_bytes > buffer_size) {
+    // the output was truncated, to keep it readable add a new line
+    buffer[buffer_size - 1] = '\n';
+    write(STDERR_FILENO, buffer, buffer_size);
+  } else {
+    write(STDERR_FILENO, buffer, num_bytes);
+  }
+}
+
 static void AbortHandler(int signum) {
-  // Write a stacktrace to stderr
-  void* buffer[32];
-  size_t size = backtrace(buffer, 32);
-  backtrace_symbols_fd(buffer, size, STDERR_FILENO);
+  // Write a stacktrace to stderr. Since the abort handler could be called
+  // after SIGSEGV or some other emergency situations:
+  // * we have to be modest and use little memory (in case if the original
+  //   reason was OOM)
+  // * as the original implementation noted, use reentrant functions
+  //
+  // The latter one was refering to snprintf, although it's not cleat if it is
+  // reentrant. Libc docs says functions using I/O streams are potentially
+  // non-reentrant [1], and it seems under the hood snprintf uses streams.
+  //
+  // [1]: https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Nonreentrancy.html
+
+  void* buffer[32];  // Addresses buffer
+
+  char message_buffer[256];  // Actual text buffer for a single stack trace
+                             // address. Some templated signatures could be
+                             // particularly long.
+  int num_bytes;
+
+  size_t n_frames = backtrace(buffer, 32);
+  size_t max_frames = sizeof(buffer) / sizeof(buffer[0]);
+  int message_buffer_size = sizeof(message_buffer);
+
+  for (size_t i = 1; i < n_frames; i++) {
+    Dl_info info;
+
+    if (dladdr(buffer[i], &info)) {
+      // Try to demangle the stacktrace
+      char* demangled = NULL;
+      int status;
+      size_t shift_from_symbol;
+
+      // NULL as a second argument for the output buffer will make it allocate
+      // new region of memory
+      demangled = abi::__cxa_demangle(info.dli_sname, NULL, NULL, &status);
+      shift_from_symbol = (char*)buffer[i] - (char*)info.dli_saddr;
+
+      // The pattern is:
+      // - file name of the object
+      // - demangled or original name of the obect (or "(null)" if NULL)
+      // - address of the object
+      // - distance to the closest symbol
+      num_bytes = snprintf(message_buffer, message_buffer_size,
+                           "%s %s %p + %zd\n", info.dli_fname,
+                           status == 0 ? demangled : info.dli_sname, buffer[i],
+                           info.dli_saddr != NULL ? shift_from_symbol : 0);
+      free(demangled);
+      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
+
+    } else {
+      // Failed to translate the address into symbolic information,
+      // at least print the raw address value.
+      num_bytes = snprintf(message_buffer, message_buffer_size, "%p\n", buffer[i]);
+      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
+    }
+  }
+
+  if (n_frames == max_frames)
+    write(STDERR_FILENO, "[truncated]\n", 14);
 
   // Write a message to stderr using only reentrant functions.
-  char message_buffer[256];
-  int num_bytes = snprintf(message_buffer, sizeof(message_buffer), "Caught signal %d (%s): %s\n",
-                           signum, SignalName(signum), strsignal(signum));
-  write(STDERR_FILENO, message_buffer, num_bytes);
+  num_bytes = snprintf(message_buffer, message_buffer_size,
+                       "Caught signal %d (%s): %s\n",
+                       signum, SignalName(signum), strsignal(signum));
+  WriteBuffer(message_buffer, num_bytes, message_buffer_size);
 
-  // Re-raise the signal (this time routing it to the default handler) to make sure we get the correct exit code.
+  // Re-raise the signal (this time routing it to the default handler) to make
+  // sure we get the correct exit code.
   signal(signum, SIG_DFL);
   raise(signum);
 }

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -37,8 +37,6 @@ You should have received a copy of the GNU General Public License along with thi
 extern "C" {
 #include <assert.h>
 #include <cap-ng.h>
-#include <cxxabi.h>
-#include <dlfcn.h>
 #include <execinfo.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -50,6 +48,7 @@ extern "C" {
 #include <sys/syscall.h>
 #include <sys/types.h>
 }
+#include "AbortHandler.h"
 #include "CollectorArgs.h"
 #include "CollectorService.h"
 #include "CollectorStatsExporter.h"
@@ -81,89 +80,6 @@ ShutdownHandler(int signum) {
   // Only set the control variable; the collector service will take care of the rest.
   g_signum.store(signum);
   g_control.store(ControlValue::STOP_COLLECTOR);
-}
-
-static void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
-  if (num_bytes > buffer_size) {
-    // the output was truncated, to keep it readable add a new line
-    buffer[buffer_size - 1] = '\n';
-    write(STDERR_FILENO, buffer, buffer_size);
-  } else {
-    write(STDERR_FILENO, buffer, num_bytes);
-  }
-}
-
-static void AbortHandler(int signum) {
-  // Write a stacktrace to stderr. Since the abort handler could be called
-  // after SIGSEGV or some other emergency situations:
-  // * we have to be modest and use little memory (in case if the original
-  //   reason was OOM)
-  // * as the original implementation noted, use reentrant functions
-  //
-  // The latter one was refering to snprintf, although it's not clear if it is
-  // reentrant. Libc docs says functions using I/O streams are potentially
-  // non-reentrant [1], and it seems under the hood snprintf uses streams.
-  //
-  // [1]: https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Nonreentrancy.html
-
-  void* buffer[32];  // Addresses buffer
-
-  char message_buffer[256];  // Actual text buffer for a single stack trace
-                             // address. Some templated signatures could be
-                             // particularly long.
-  int num_bytes;
-
-  size_t n_frames = backtrace(buffer, 32);
-  size_t max_frames = sizeof(buffer) / sizeof(buffer[0]);
-  int message_buffer_size = sizeof(message_buffer);
-
-  for (size_t i = 0; i < n_frames; i++) {
-    Dl_info info;
-
-    if (dladdr(buffer[i], &info)) {
-      // Try to demangle the stacktrace
-      char* demangled = NULL;
-      int status;
-      size_t shift_from_symbol;
-
-      // NULL as a second argument for the output buffer will make it allocate
-      // new region of memory
-      demangled = abi::__cxa_demangle(info.dli_sname, NULL, NULL, &status);
-      shift_from_symbol = (char*)buffer[i] - (char*)info.dli_saddr;
-
-      // The pattern is:
-      // - file name of the object
-      // - demangled or original name of the obect (or "(null)" if NULL)
-      // - address of the object
-      // - distance to the closest symbol
-      num_bytes = snprintf(message_buffer, message_buffer_size,
-                           "%s %s %p + %zd\n", info.dli_fname,
-                           status == 0 ? demangled : info.dli_sname, buffer[i],
-                           info.dli_saddr != NULL ? shift_from_symbol : 0);
-      free(demangled);
-      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
-
-    } else {
-      // Failed to translate the address into symbolic information,
-      // at least print the raw address value.
-      num_bytes = snprintf(message_buffer, message_buffer_size, "%p\n", buffer[i]);
-      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
-    }
-  }
-
-  if (n_frames == max_frames)
-    write(STDERR_FILENO, "[truncated]\n", 14);
-
-  // Write a message to stderr using only reentrant functions.
-  num_bytes = snprintf(message_buffer, message_buffer_size,
-                       "Caught signal %d (%s): %s\n",
-                       signum, SignalName(signum), strsignal(signum));
-  WriteBuffer(message_buffer, num_bytes, message_buffer_size);
-
-  // Re-raise the signal (this time routing it to the default handler) to make
-  // sure we get the correct exit code.
-  signal(signum, SIG_DFL);
-  raise(signum);
 }
 
 // creates a GRPC channel, using the tls configuration provided from the args.

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -100,7 +100,7 @@ static void AbortHandler(int signum) {
   //   reason was OOM)
   // * as the original implementation noted, use reentrant functions
   //
-  // The latter one was refering to snprintf, although it's not cleat if it is
+  // The latter one was refering to snprintf, although it's not clear if it is
   // reentrant. Libc docs says functions using I/O streams are potentially
   // non-reentrant [1], and it seems under the hood snprintf uses streams.
   //

--- a/collector/lib/AbortHandler.cpp
+++ b/collector/lib/AbortHandler.cpp
@@ -33,7 +33,7 @@ void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
     write(STDERR_FILENO, buffer, num_bytes);
   }
 }
-}
+}  // namespace
 
 extern "C" void AbortHandler(int signum) {
   // Write a stacktrace to stderr. Since the abort handler could be called

--- a/collector/lib/AbortHandler.cpp
+++ b/collector/lib/AbortHandler.cpp
@@ -1,0 +1,111 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include "AbortHandler.h"
+
+static void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
+  if (num_bytes > buffer_size) {
+    // the output was truncated, to keep it readable add a new line
+    buffer[buffer_size - 1] = '\n';
+    write(STDERR_FILENO, buffer, buffer_size);
+  } else {
+    write(STDERR_FILENO, buffer, num_bytes);
+  }
+}
+
+extern "C" void AbortHandler(int signum) {
+  // Write a stacktrace to stderr. Since the abort handler could be called
+  // after SIGSEGV or some other emergency situations:
+  // * we have to be modest and use little memory (in case if the original
+  //   reason was OOM)
+  // * as the original implementation noted, use reentrant functions
+  //
+  // The latter one was refering to snprintf, although it's not clear if it is
+  // reentrant. Libc docs says functions using I/O streams are potentially
+  // non-reentrant [1], and it seems under the hood snprintf uses streams.
+  //
+  // XXX: There are portability issues with signal() [2], in the future it
+  // would be better to use sigaction.
+  //
+  // [1]: https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Nonreentrancy.html
+  // [2]: https://man7.org/linux/man-pages/man2/signal.2.html
+
+  void* buffer[32];  // Addresses buffer
+
+  char message_buffer[256];  // Actual text buffer for a single stack trace
+                             // address. Some templated signatures could be
+                             // particularly long.
+  int num_bytes;
+
+  size_t n_frames = backtrace(buffer, 32);
+  size_t max_frames = sizeof(buffer) / sizeof(buffer[0]);
+  int message_buffer_size = sizeof(message_buffer);
+
+  for (size_t i = 0; i < n_frames; i++) {
+    Dl_info info;
+
+    if (dladdr(buffer[i], &info)) {
+      // Try to demangle the stacktrace
+      char* demangled = NULL;
+      int status;
+      size_t shift_from_symbol;
+
+      // NULL as a second argument for the output buffer will make it allocate
+      // new region of memory
+      demangled = abi::__cxa_demangle(info.dli_sname, NULL, NULL, &status);
+      shift_from_symbol = (char*)buffer[i] - (char*)info.dli_saddr;
+
+      // The pattern is:
+      // - file name of the object
+      // - demangled or original name of the obect (or "(null)" if NULL)
+      // - address of the object
+      // - distance to the closest symbol
+      num_bytes = snprintf(message_buffer, message_buffer_size,
+                           "%s %s %p + %zd\n", info.dli_fname,
+                           status == 0 ? demangled : info.dli_sname, buffer[i],
+                           info.dli_saddr != NULL ? shift_from_symbol : 0);
+      free(demangled);
+      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
+
+    } else {
+      // Failed to translate the address into symbolic information,
+      // at least print the raw address value.
+      num_bytes = snprintf(message_buffer, message_buffer_size, "%p\n", buffer[i]);
+      WriteBuffer(message_buffer, num_bytes, message_buffer_size);
+    }
+  }
+
+  if (n_frames == max_frames)
+    write(STDERR_FILENO, "[truncated]\n", 14);
+
+  // Write a message to stderr using only reentrant functions.
+  num_bytes = snprintf(message_buffer, message_buffer_size,
+                       "Caught signal %d (%s): %s\n",
+                       signum, collector::SignalName(signum), strsignal(signum));
+  WriteBuffer(message_buffer, num_bytes, message_buffer_size);
+
+  // Re-raise the signal (this time routing it to the default handler) to make
+  // sure we get the correct exit code.
+  signal(signum, SIG_DFL);
+  raise(signum);
+}

--- a/collector/lib/AbortHandler.cpp
+++ b/collector/lib/AbortHandler.cpp
@@ -23,7 +23,8 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include "AbortHandler.h"
 
-static void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
+namespace {
+void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
   if (num_bytes > buffer_size) {
     // the output was truncated, to keep it readable add a new line
     buffer[buffer_size - 1] = '\n';
@@ -31,6 +32,7 @@ static void WriteBuffer(char* buffer, int num_bytes, int buffer_size) {
   } else {
     write(STDERR_FILENO, buffer, num_bytes);
   }
+}
 }
 
 extern "C" void AbortHandler(int signum) {

--- a/collector/lib/AbortHandler.h
+++ b/collector/lib/AbortHandler.h
@@ -1,0 +1,51 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+#ifndef _ABORT_HANDLER_H_
+#define _ABORT_HANDLER_H_
+
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <string.h>
+#include <unistd.h>
+}
+
+#include "Utility.h"
+
+// Standards before C++17 [1] specify that a signal handler installed via
+// std::signal should have a C language linkage, otherwise resulting in
+// undefined behavior. We use C++17, which relax this to only being
+// signal-safe, plus it's not clear to me if using std::signal and ANSI C
+// signal is equivalent in this sense, but it probably wont hurt to stick to C
+// linkage anyway.
+//
+// [1]: https://en.cppreference.com/w/cpp/utility/program/signal
+extern "C" void AbortHandler(int signum);
+
+#endif  // _ABORT_H_

--- a/collector/test/AbortHandler_test.cpp
+++ b/collector/test/AbortHandler_test.cpp
@@ -31,9 +31,6 @@ void test_crash() {
 }
 
 TEST(AbortHandler, Crash) {
-  using namespace collector;
-  using ::testing::StartsWith;
-
   // Install the AbortHandler, and verify that the stderr output will contain
   // something that looks like a stacktrace with AbortHander & Crash_Test frames.
   signal(SIGSEGV, AbortHandler);

--- a/collector/test/AbortHandler_test.cpp
+++ b/collector/test/AbortHandler_test.cpp
@@ -1,0 +1,42 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include "AbortHandler.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+void test_crash() {
+  raise(SIGSEGV);
+}
+
+TEST(AbortHandler, Crash) {
+  using namespace collector;
+  using ::testing::StartsWith;
+
+  // Install the AbortHandler, and verify that the stderr output will contain
+  // something that looks like a stacktrace with AbortHander & Crash_Test frames.
+  signal(SIGSEGV, AbortHandler);
+  ASSERT_EXIT(test_crash(), ::testing::KilledBySignal(SIGSEGV),
+              ".*AbortHandler.*AbortHandler_Crash_Test.*");
+}


### PR DESCRIPTION
## Description

Collector already uses a signal handler to report the stacktrace in case of failures, but doesn't report all the symbols because:

* Collector is build without `-rdynamic`, missing some set of symbols in the dynamic symbols table [[1]]. Adding it means the binary will become bigger on the amount of added symbols (5.9 Mb vs 4.7 Mb without it). Worth noting that those are not debugging symbols.

* Collector is build without `-fno-omit-frame-pointer`, potentially missing some part of the stacktrace [[2]]. Adding it means a slight performance overhead, but it's well known that it's negligible. E.g. Fedora project recently switched to use it by default [[3]].

Adding those two options will give more readable stacktrace, that contains reasonable symbolic names for functions. But the C++ parts are going to be mangled and less readable. To address this, use `Dl_info` and `abi::__cxa_demangle` [[4]] if possible.

Here is how the new stacktrace would look like:

```
    /lib64/libc.so.6 (null) 0x7f8b3df4bb80 + 0
    /usr/local/lib/libsinsp-wrapper.so check_api_compatibility 0x7f8b40c36373 + 12
    /usr/local/lib/libsinsp-wrapper.so (null) 0x7f8b40c344e9 + 0
    /usr/local/lib/libsinsp-wrapper.so scap_open_live_int 0x7f8b40c1be01 + 413
    /usr/local/lib/libsinsp-wrapper.so scap_open 0x7f8b40c1c969 + 279
    /usr/local/lib/libsinsp-wrapper.so sinsp::open_common(scap_open_args*) 0x7f8b40931a34 + 236
    /usr/local/lib/libsinsp-wrapper.so sinsp::open_bpf(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, std::unordered_set<unsigned int, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator
    collector collector::SysdigService::Start() 0x75467b + 1155
    collector collector::CollectorService::RunForever() 0x6ccc86 + 2396
    collector main 0x6bb0d8 + 1593
    /lib64/libc.so.6 __libc_start_main 0x7f8b3df37d85 + 229
    collector _start 0x6b916e + 46
```

[1]: https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html
[2]: https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Optimize-Options.html
[3]: https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer
[4]: https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Local testing on the various types of traces, forced to truncate the stack, the message buffer, or failed to translate the address.