### PR TITLE
Add the ability to run tests with variable collection methods

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -103,6 +103,10 @@ jobs:
             echo "COLLECTOR_LOG_LEVEL=trace" | tee -a "$GITHUB_ENV"
           fi
 
+          if [[ '${{ contains(github.event.pull_request.labels.*.name, 'run-corebpf-tests') }}' == 'true' ]]; then
+            echo "COLLECTION_METHODS=ebpf,kernel-module,core_bpf" | tee -a "$GITHUB_ENV"
+          fi
+
       - name: Create VMs
         if: ${{ ! inputs.run-benchmarks }}
         run: |

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -104,7 +104,7 @@ jobs:
           fi
 
           if [[ '${{ contains(github.event.pull_request.labels.*.name, 'run-corebpf-tests') }}' == 'true' ]]; then
-            echo "COLLECTION_METHODS=ebpf,kernel-module,core_bpf" | tee -a "$GITHUB_ENV"
+            echo "COLLECTION_METHODS=ebpf,kernel_module,core_bpf" | tee -a "$GITHUB_ENV"
           fi
 
       - name: Create VMs

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,4 +3,4 @@ stdout_callback=debug
 stderr_callback=debug
 host_key_checking=False
 remote_tmp = /tmp/ansible
-forks = 10
+forks = 20

--- a/ansible/benchmarks.yml
+++ b/ansible/benchmarks.yml
@@ -21,8 +21,7 @@
         # create-all-vms will populate the name and labels which we
         # can then filter on later, to only run when we match a certain
         # collection method
-        - ebpf
-        - kernel-module
+        "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel_module') | split(',') }}"
       loop_control:
         # use a custom loop variable because ansible variables
         # are global and "item" may be overwritten later on

--- a/ansible/integration-tests.yml
+++ b/ansible/integration-tests.yml
@@ -11,7 +11,7 @@
       vars:
         vm_list: "{{ virtual_machines }}"
         collection_method: "{{ method }}"
-      loop: "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel-module') | split(',') }}"
+      loop: "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel_module') | split(',') }}"
       loop_control:
         loop_var: method
   post_tasks:

--- a/ansible/integration-tests.yml
+++ b/ansible/integration-tests.yml
@@ -11,9 +11,7 @@
       vars:
         vm_list: "{{ virtual_machines }}"
         collection_method: "{{ method }}"
-      loop:
-        - ebpf
-        - kernel-module
+      loop: "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel-module') | split(',') }}"
       loop_control:
         loop_var: method
   post_tasks:

--- a/ansible/roles/create-all-vms/tasks/main.yml
+++ b/ansible/roles/create-all-vms/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel-module', 'ko') }}"
+    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel-module', 'ko') | replace('core_bpf', 'core' }}"
 
 - name: Create VMs From Family
   include_tasks: by-family.yml

--- a/ansible/roles/create-all-vms/tasks/main.yml
+++ b/ansible/roles/create-all-vms/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel-module', 'ko') | replace('core_bpf', 'core') }}"
+    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel_module', 'ko') | replace('core_bpf', 'core') }}"
 
 - name: Create VMs From Family
   include_tasks: by-family.yml

--- a/ansible/roles/create-all-vms/tasks/main.yml
+++ b/ansible/roles/create-all-vms/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel-module', 'ko') | replace('core_bpf', 'core' }}"
+    normalized_collection_method: "{{ collection_method | default('any') | replace('kernel-module', 'ko') | replace('core_bpf', 'core') }}"
 
 - name: Create VMs From Family
   include_tasks: by-family.yml

--- a/ansible/roles/run-test-target/tasks/main.yml
+++ b/ansible/roles/run-test-target/tasks/main.yml
@@ -26,7 +26,7 @@
   vars:
     collection_method: "{{ item }}"
   with_items:
-    "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel-module') | split(',') }}"
+    "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel_module') | split(',') }}"
 
 - name: Check results
   ansible.builtin.fail:

--- a/ansible/roles/run-test-target/tasks/main.yml
+++ b/ansible/roles/run-test-target/tasks/main.yml
@@ -26,8 +26,7 @@
   vars:
     collection_method: "{{ item }}"
   with_items:
-    - ebpf
-    - kernel_module
+    "{{ lookup('env', 'COLLECTION_METHODS', default='ebpf,kernel-module') | split(',') }}"
 
 - name: Check results
   ansible.builtin.fail:

--- a/integration-tests/scripts/baseline/main.py
+++ b/integration-tests/scripts/baseline/main.py
@@ -194,6 +194,8 @@ def normalize_collection_method(method):
         return 'module'
     if 'ebpf' in method:
         return 'ebpf'
+    if 'core' in method:
+        return 'core-bpf'
     raise Exception(f'Invalid collection method: {method}')
 
 


### PR DESCRIPTION
## Description

More importantly, this allows to set the collection method to include the new core_bpf driver. This collection method and now be added for PRs using the 'run-corebpf-tests' label.

Fixes #1067 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Ensure running CI with `run-corebpf-tests` runs the tests with the `core_bpf` collection method.
- [x] Ensure running CI without `run-corebpf-tests` skips the tests with the `core_bpf` collection method.