### PR TITLE
Allow a base set of GHA checks to run on external PRs

### DIFF
--- a/.github/actions/retag-and-push/action.yml
+++ b/.github/actions/retag-and-push/action.yml
@@ -20,13 +20,17 @@ inputs:
     description: |
       Password used to login to the repository the push is aimed at
     required: true
+  registry:
+    description:
+      Registry used for pushing the image
+    default: quay.io
 
 runs:
   using: "composite"
   steps:
     - uses: docker/login-action@v2
       with:
-        registry: quay.io
+        registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -91,7 +91,7 @@ jobs:
 
           BUILT_DRIVERS_DIR="/tmp/built-drivers/${DRIVER_VERSION}/"
 
-          ls -la "${BUILT_DRIVERS_DIR}"
+          ls -la /tmp/**
 
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
             find "${BUILT_DRIVERS_DIR}" -type f -exec mv -t "${CONTEXT_DRIVERS_DIR}" {} +

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -61,8 +61,8 @@ jobs:
             echo "COLLECTOR_REGISTRY=quay.io/stackrox-io/collector" >> "$GITHUB_ENV"
             echo "COLLECTOR_IMAGE=quay.io/stackrox-io/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
           else
-            echo "COLLECTOR_REGISTRY=ghcr.io/${{ github.repository }}" >> "$GITHUB_ENV"
-            echo "COLLECTOR_IMAGE=ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
+            echo "COLLECTOR_REGISTRY=ghcr.io/${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_ENV"
+            echo "COLLECTOR_IMAGE=ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
           fi
 
       - name: Download drivers from GCP

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -61,8 +61,8 @@ jobs:
             echo "COLLECTOR_REGISTRY=quay.io/stackrox-io/collector" >> "$GITHUB_ENV"
             echo "COLLECTOR_IMAGE=quay.io/stackrox-io/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
           else
-            echo "COLLECTOR_REGISTRY=ghcr.io/stackrox/collector" >> "$GITHUB_ENV"
-            echo "COLLECTOR_IMAGE=ghcr.io/stackrox/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
+            echo "COLLECTOR_REGISTRY=ghcr.io/${{ github.repository }}" >> "$GITHUB_ENV"
+            echo "COLLECTOR_IMAGE=ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
           fi
 
       - name: Download drivers from GCP

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -30,7 +30,7 @@ on:
         description: |
           Max layer the drivers will be split into
       is-external:
-        type: boolean
+        type: string
         description: |
           Signals whether CI is running from a fork
         default: false
@@ -38,7 +38,7 @@ on:
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
-    if: inputs.build-full-image || inputs.is-external
+    if: inputs.build-full-image || inputs.is-external == 'true'
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Download drivers from GCP
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         run: |
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
@@ -98,20 +98,20 @@ jobs:
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Push stackrox-io full image
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         run: |
           docker push "${COLLECTOR_IMAGE}"
 
       - name: Retag and push stackrox-io -latest
         uses: ./.github/actions/retag-and-push
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-latest
@@ -120,7 +120,7 @@ jobs:
 
       - name: Retag and push rhacs-eng
         uses: ./.github/actions/retag-and-push
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Retag and push rhacs-eng -latest
         uses: ./.github/actions/retag-and-push
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-latest
@@ -138,12 +138,16 @@ jobs:
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'true' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push ghcr.io full image
+        if: ${{ inputs.is-external == 'true' }}
+        run: |
+          docker push "${COLLECTOR_IMAGE}"
 
   retag-collector-full:
     runs-on: ubuntu-latest

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Restore slim image
         if: inputs.is-external == 'true'
         run: |
-          docker load -i /tmp/collector.tar
+          docker load -i /tmp/collector-slim.tar
 
       - name: Pull slim image and build full image
         run: |
@@ -141,18 +141,20 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Login to ghcr.io
-        uses: docker/login-action@v2
-        if: ${{ inputs.is-external == 'true' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push ghcr.io full image
-        if: ${{ inputs.is-external == 'true' }}
+      # For PRs coming from a fork, we cheat a little, we just create a blob
+      # from the image and upload it as an artifact
+      - name: Save image
+        if: inputs.is-external == 'true'
         run: |
-          docker push "${COLLECTOR_IMAGE}"
+          docker save -o /tmp/collector-full.tar ${{ env.COLLECTOR_IMAGE }}
+
+      - name: Store built image
+        if: inputs.is-external == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: collector-full
+          path: /tmp/collector-full.tar
+          retention-days: 7
 
   retag-collector-full:
     runs-on: ubuntu-latest

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -41,6 +41,7 @@ jobs:
     if: inputs.build-full-image || inputs.is-external == 'true'
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+      COLLECTOR_REGISTRY: quay.io/stackrox-io/collector
 
     steps:
       - uses: actions/checkout@v3
@@ -52,18 +53,17 @@ jobs:
           name: built-drivers
           path: /tmp/built-drivers/
 
+      - name: Download slim collector image blob
+        uses: actions/download-artifact@v3
+        if: ${{ inputs.is-external == 'true' }}
+        with:
+          name: collector-slim
+          path: /tmp/collector-slim.tar
+
       - name: Set environment variables
         run: |
           echo "DRIVER_VERSION=$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)" >> "$GITHUB_ENV"
           echo "CONTEXT_DRIVERS_DIR=${{ github.workspace }}/kernel-modules/container/kernel-modules" >> "$GITHUB_ENV"
-
-          if [[ "${{ inputs.is-external }}" == false ]]; then
-            echo "COLLECTOR_REGISTRY=quay.io/stackrox-io/collector" >> "$GITHUB_ENV"
-            echo "COLLECTOR_IMAGE=quay.io/stackrox-io/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
-          else
-            echo "COLLECTOR_REGISTRY=ghcr.io/${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_ENV"
-            echo "COLLECTOR_IMAGE=ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
-          fi
 
       - name: Download drivers from GCP
         if: ${{ inputs.is-external == 'false' }}
@@ -83,6 +83,11 @@ jobs:
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
             find "${BUILT_DRIVERS_DIR}" -type f -exec mv -t "${CONTEXT_DRIVERS_DIR}" {} +
           fi
+
+      - name: Restore slim image
+        if: inputs.is-external == 'true'
+        run: |
+          docker load -i /tmp/collector.tar
 
       - name: Pull slim image and build full image
         run: |

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -84,14 +84,20 @@ jobs:
 
       - name: Add built drivers
         run: |
+          set -x
+
           # Create the directory again, in case we are running from a fork
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
           BUILT_DRIVERS_DIR="/tmp/built-drivers/${DRIVER_VERSION}/"
 
+          ls -la "${BUILT_DRIVERS_DIR}"
+
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
             find "${BUILT_DRIVERS_DIR}" -type f -exec mv -t "${CONTEXT_DRIVERS_DIR}" {} +
           fi
+
+          ls -la "${CONTEXT_DRIVERS_DIR}"
 
       - name: Restore slim image
         if: inputs.is-external == 'true'

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -29,11 +29,16 @@ on:
         default: "5"
         description: |
           Max layer the drivers will be split into
+      is-external:
+        type: boolean
+        description: |
+          Signals whether CI is running from a fork
+        default: false
 
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
-    if: inputs.build-full-image
+    if: inputs.build-full-image || inputs.is-external
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
@@ -52,7 +57,16 @@ jobs:
           echo "DRIVER_VERSION=$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)" >> "$GITHUB_ENV"
           echo "CONTEXT_DRIVERS_DIR=${{ github.workspace }}/kernel-modules/container/kernel-modules" >> "$GITHUB_ENV"
 
+          if [[ "${{ inputs.is-external }}" == false ]]; then
+            echo "COLLECTOR_REGISTRY=quay.io/stackrox-io/collector" >> "$GITHUB_ENV"
+            echo "COLLECTOR_IMAGE=quay.io/stackrox-io/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
+          else
+            echo "COLLECTOR_REGISTRY=ghcr.io/stackrox/collector" >> "$GITHUB_ENV"
+            echo "COLLECTOR_IMAGE=ghcr.io/stackrox/collector:${{ inputs.collector-tag }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Download drivers from GCP
+        if: ${{ !inputs.is-external }}
         run: |
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
@@ -61,6 +75,9 @@ jobs:
 
       - name: Add built drivers
         run: |
+          # Create the directory again, in case we are running from a fork
+          mkdir -p "${CONTEXT_DRIVERS_DIR}"
+
           BUILT_DRIVERS_DIR="/tmp/built-drivers/${DRIVER_VERSION}/"
 
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
@@ -72,7 +89,7 @@ jobs:
           docker build \
             --target=probe-layer-${{ inputs.max-layer-depth }} \
             --tag "${COLLECTOR_IMAGE}" \
-            --build-arg collector_repo=quay.io/stackrox-io/collector \
+            --build-arg "collector_repo=${COLLECTOR_REGISTRY}" \
             --build-arg collector_version=${{ inputs.collector-tag }} \
             --build-arg module_version="${DRIVER_VERSION}" \
             --build-arg max_layer_size=300 \
@@ -81,17 +98,20 @@ jobs:
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2
+        if: ${{ !inputs.is-external }}
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Push stackrox-io full image
+        if: ${{ !inputs.is-external }}
         run: |
           docker push "${COLLECTOR_IMAGE}"
 
       - name: Retag and push stackrox-io -latest
         uses: ./.github/actions/retag-and-push
+        if: ${{ !inputs.is-external }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-latest
@@ -100,6 +120,7 @@ jobs:
 
       - name: Retag and push rhacs-eng
         uses: ./.github/actions/retag-and-push
+        if: ${{ !inputs.is-external }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
@@ -108,15 +129,25 @@ jobs:
 
       - name: Retag and push rhacs-eng -latest
         uses: ./.github/actions/retag-and-push
+        if: ${{ !inputs.is-external }}
         with:
           src-image: ${{ env.COLLECTOR_IMAGE }}
           dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-latest
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        if: ${{ !inputs.is-external }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
   retag-collector-full:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.build-full-image }}
+    if: ${{ !inputs.build-full-image && !inputs.is-external }}
     env:
       COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Restore built drivers
         uses: actions/download-artifact@v3
-        if: ${{ !inputs.skip-built-drivers }}
+        if: ${{ !inputs.skip-built-drivers || inputs.is-external == 'true' }}
         with:
           name: built-drivers
           path: /tmp/built-drivers/

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ inputs.is-external == 'true' }}
         with:
           name: collector-slim
-          path: /tmp/collector-slim.tar
+          path: /tmp
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -91,7 +91,7 @@ jobs:
 
           BUILT_DRIVERS_DIR="/tmp/built-drivers/${DRIVER_VERSION}/"
 
-          ls -la /tmp/**
+          ls -la /tmp/built-drivers
 
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
             find "${BUILT_DRIVERS_DIR}" -type f -exec mv -t "${CONTEXT_DRIVERS_DIR}" {} +

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -65,6 +65,15 @@ jobs:
           echo "DRIVER_VERSION=$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)" >> "$GITHUB_ENV"
           echo "CONTEXT_DRIVERS_DIR=${{ github.workspace }}/kernel-modules/container/kernel-modules" >> "$GITHUB_ENV"
 
+          if [[ "${{ inputs.is-external }}" == "false" ]]; then
+            MAX_LAYER_DEPTH=5
+          else
+            MAX_LAYER_DEPTH=1
+          fi
+
+          echo "MAX_LAYER_DEPTH=${MAX_LAYER_DEPTH}" >> "$GITHUB_ENV"
+          echo "TARGET_LAYER=probe-layer-${MAX_LAYER_DEPTH}" >> "$GITHUB_ENV"
+
       - name: Download drivers from GCP
         if: ${{ inputs.is-external == 'false' }}
         run: |
@@ -92,13 +101,13 @@ jobs:
       - name: Pull slim image and build full image
         run: |
           docker build \
-            --target=probe-layer-${{ inputs.max-layer-depth }} \
+            --target="${TARGET_LAYER}" \
             --tag "${COLLECTOR_IMAGE}" \
             --build-arg "collector_repo=${COLLECTOR_REGISTRY}" \
             --build-arg collector_version=${{ inputs.collector-tag }} \
             --build-arg module_version="${DRIVER_VERSION}" \
             --build-arg max_layer_size=300 \
-            --build-arg max_layer_depth=${{ inputs.max-layer-depth }} \
+            --build-arg max_layer_depth="${MAX_LAYER_DEPTH}" \
             "${{ github.workspace }}/kernel-modules/container"
 
       - name: Login to quay.io/stackrox-io

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -14,7 +14,7 @@ on:
         description: |
           Basic stackrox-io image built
       is-external:
-        type: boolean
+        type: string
         description: |
           Signals whether CI is running from a fork
         default: false
@@ -75,7 +75,7 @@ jobs:
           dst-image: ${{ inputs.collector-image }}-slim
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
 
       - name: Retag and push stackrox-io -base
         uses: ./.github/actions/retag-and-push
@@ -84,10 +84,10 @@ jobs:
           dst-image: ${{ inputs.collector-image }}-base
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
 
       - name: Push builder to stackrox-io
-        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external
+        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external == 'false'
         run: |
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
@@ -98,7 +98,7 @@ jobs:
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-slim
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
 
       - name: Retag and push rhacs-eng -base
         uses: ./.github/actions/retag-and-push
@@ -107,10 +107,10 @@ jobs:
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-base
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
 
       - name: Push builder to rhacs-eng
-        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external
+        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external == 'false'
         run: |
           docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Retag and push to ghcr.io
         uses: ./.github/actions/retag-and-push
         with:
+          registry: ghcr.io
           src-image: ${{ inputs.collector-image }}
           dst-image: ghcr.io/stackrox/collector:${{ inputs.collector-tag }}-slim
           username: ${{ github.actor }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -115,11 +115,17 @@ jobs:
           docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
-      - name: Retag and push to ghcr.io
-        uses: ./.github/actions/retag-and-push
+      # For PRs coming from a fork, we cheat a little, we just create a blob
+      # from the image and upload it as an artifact
+      - name: Save slim image
+        if: inputs.is-external == 'true'
+        run: |
+          docker tag ${{ inputs.collector-image }} ${{ inputs.collector-image }}-slim
+          docker save -o /tmp/collector-slim.tar ${{ inputs.collector-image }}-slim
+
+      - name: Store built image
+        uses: actions/upload-artifact@v3
         with:
-          registry: ghcr.io
-          src-image: ${{ inputs.collector-image }}
-          dst-image: ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}-slim
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: collector-slim
+          path: /tmp/collector-slim.tar
+          retention-days: 7

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -13,6 +13,11 @@ on:
         required: true
         description: |
           Basic stackrox-io image built
+      is-external:
+        type: boolean
+        description: |
+          Signals whether CI is running from a fork
+        default: false
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -70,6 +75,7 @@ jobs:
           dst-image: ${{ inputs.collector-image }}-slim
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+        if: ${{ !inputs.is-external }}
 
       - name: Retag and push stackrox-io -base
         uses: ./.github/actions/retag-and-push
@@ -78,9 +84,10 @@ jobs:
           dst-image: ${{ inputs.collector-image }}-base
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+        if: ${{ !inputs.is-external }}
 
       - name: Push builder to stackrox-io
-        if: github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG
+        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external
         run: |
           docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
@@ -91,6 +98,7 @@ jobs:
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-slim
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+        if: ${{ !inputs.is-external }}
 
       - name: Retag and push rhacs-eng -base
         uses: ./.github/actions/retag-and-push
@@ -99,9 +107,18 @@ jobs:
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-base
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+        if: ${{ !inputs.is-external }}
 
       - name: Push builder to rhacs-eng
-        if: github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG
+        if: (github.event_name == 'push' || steps.pr-checks.outputs.builder-tag != env.DEFAULT_BUILDER_TAG) && !inputs.is-external
         run: |
           docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
           docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
+
+      - name: Retag and push to ghcr.io
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: ${{ inputs.collector-image }}
+          dst-image: ghcr.io/stackrox/collector:${{ inputs.collector-tag }}-slim
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -120,6 +120,6 @@ jobs:
         with:
           registry: ghcr.io
           src-image: ${{ inputs.collector-image }}
-          dst-image: ghcr.io/stackrox/collector:${{ inputs.collector-tag }}-slim
+          dst-image: ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}-slim
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -120,6 +120,6 @@ jobs:
         with:
           registry: ghcr.io
           src-image: ${{ inputs.collector-image }}
-          dst-image: ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}-slim
+          dst-image: ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}-slim
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -124,6 +124,7 @@ jobs:
           docker save -o /tmp/collector-slim.tar ${{ inputs.collector-image }}-slim
 
       - name: Store built image
+        if: inputs.is-external == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: collector-slim

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
         description: Branch CI is running on
+      is-external:
+        type: boolean
+        description: Signals whether CI is running from a fork
+        default: false
     outputs:
       parallel-jobs:
         description: |
@@ -60,9 +64,10 @@ jobs:
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+        if: ${{ !inputs.is-external }}
 
       - name: Create a mock cache
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
+        if: ${{ !inputs.is-external && !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
         run: |
           ${{ github.workspace }}/kernel-modules/build/mock-cache.sh
 
@@ -76,6 +81,14 @@ jobs:
           SCRIPTS_DIR: ${{ github.workspace }}/kernel-modules/build
 
         run: |
+          if [[ "${{ inputs.is-external }}" == "false" ]]; then
+            export KERNELS_FILE="${{ github.workspace }}/kernel-modules/KERNEL_VERSIONS"
+          else
+            # for external PRs, we only build the driver for the GHA VM
+            uname -r >> /tmp/KERNELS_FILE
+            export KERNELS_FILE=/tmp/KERNELS_FILE
+          fi
+
           ${{ github.workspace }}/kernel-modules/build/get-build-tasks.sh
 
           mkdir -p /tmp/tasks

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -250,6 +250,8 @@ jobs:
 
       - name: Build the driver for the GHA VM
         run: |
+          mkdir -p ${{ github.workspace }}/kernel-modules/container/kernel-modules
+
           make -C ${{ github.workspace }}/kernel-modules drivers
 
           OUTPUT_DIR="/tmp/kernel-modules/$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -16,7 +16,7 @@ on:
         required: true
         description: Branch CI is running on
       is-external:
-        type: boolean
+        type: string
         description: Signals whether CI is running from a fork
         default: false
     outputs:
@@ -64,10 +64,10 @@ jobs:
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
-        if: ${{ !inputs.is-external }}
+        if: ${{ inputs.is-external == 'false' }}
 
       - name: Create a mock cache
-        if: ${{ !inputs.is-external && !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
+        if: ${{ inputs.is-external == 'false' && !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
         run: |
           ${{ github.workspace }}/kernel-modules/build/mock-cache.sh
 

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -242,7 +242,7 @@ jobs:
 
   simplified-driver-build:
     runs-on: ubuntu-22.04
-    if: inputs.is-external == 'false'
+    if: inputs.is-external == 'true'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -252,9 +252,15 @@ jobs:
         run: |
           make -C ${{ github.workspace }}/kernel-modules drivers
 
+          OUTPUT_DIR="/tmp/kernel-modules/$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
+          echo "OUTPUT_DIR=${OUTPUT_DIR}" >> "$GITHUB_ENV"
+
+          mkdir -p "${OUTPUT_DIR}"
+          mv ${{ github.workspace }}/kernel-modules/container/kernel-modules/* "${OUTPUT_DIR}"
+
       - name: Store built drivers
         uses: actions/upload-artifact@v3
         with:
           name: built-drivers
-          path: ${{ github.workspace }}/kernel-modules/container/kernel-modules/
+          path: ${{ env.OUTPUT_DIR }}
           retention-days: 1

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -250,12 +250,12 @@ jobs:
 
       - name: Build the driver for the GHA VM
         run: |
-          mkdir -p ${{ github.workspace }}/kernel-modules/container/kernel-modules
+          DRIVERS_DIR="${{ github.workspace }}/kernel-modules/container/kernel-modules"
+          mkdir -p "${DRIVERS_DIR}"
 
           make -C ${{ github.workspace }}/kernel-modules drivers
 
           OUTPUT_DIR="/tmp/kernel-modules/$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)"
-          echo "OUTPUT_DIR=${OUTPUT_DIR}" >> "$GITHUB_ENV"
 
           mkdir -p "${OUTPUT_DIR}"
           mv ${{ github.workspace }}/kernel-modules/container/kernel-modules/* "${OUTPUT_DIR}"

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -264,5 +264,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: built-drivers
-          path: ${{ env.OUTPUT_DIR }}
+          path: /tmp/kernel-modules
           retention-days: 1

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   split-tasks:
     runs-on: ubuntu-latest
+    if: inputs.is-external == 'false'
     outputs:
       parallel-jobs: ${{ steps.set-parallel.outputs.parallel-jobs }}
       parallel-array: ${{ steps.set-parallel.outputs.parallel-array }}
@@ -237,4 +238,23 @@ jobs:
           name: driver-build-failures
           path: /tmp/FAILURES
           if-no-files-found: ignore
+          retention-days: 1
+
+  simplified-driver-build:
+    runs-on: ubuntu-22.04
+    if: inputs.is-external == 'false'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Build the driver for the GHA VM
+        run: |
+          make -C ${{ github.workspace }}/kernel-modules drivers
+
+      - name: Store built drivers
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-drivers
+          path: ${{ github.workspace }}/kernel-modules/container/kernel-modules/
           retention-days: 1

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -134,6 +134,8 @@ jobs:
       - name: Check for external PR
         id: external-pr
         run: |
+          echo "head.repo = ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "github.repository = ${{ github.repository }}"
           IS_EXTERNAL="${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}"
 
           echo "is-external=${IS_EXTERNAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -134,8 +134,6 @@ jobs:
       - name: Check for external PR
         id: external-pr
         run: |
-          echo "head.repo = ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "github.repository = ${{ github.repository }}"
-          IS_EXTERNAL="${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}"
+          IS_EXTERNAL="${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor != 'dependabot[bot]' }}"
 
           echo "is-external=${IS_EXTERNAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -44,6 +44,10 @@ on:
         description: |
           Bucket to push the generated support-packages index file into
         value: ${{ jobs.common-variables.outputs.support-packages-index-bucket }}
+      is-external:
+        description: |
+          Signals whether the current CI is running in a fork
+        value: ${{ jobs.common-variables.outputs.is-external }}
 
 jobs:
   common-variables:
@@ -60,6 +64,7 @@ jobs:
       cpaas-drivers-bucket: ${{ steps.gcp-buckets.outputs.cpaas-drivers-bucket }}
       cpaas-support-packages-bucket: ${{ steps.gcp-buckets.outputs.cpaas-support-packages-bucket }}
       support-packages-index-bucket: ${{ steps.gcp-buckets.outputs.support-packages-index-bucket }}
+      is-external: ${{ steps.external-pr.outputs.is-external }}
 
     steps:
       - uses: actions/checkout@v3
@@ -125,3 +130,10 @@ jobs:
               echo "support-packages-index-bucket=${SUPPORT_PACKAGES_BUCKET}"
             } >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Check for external PR
+        id: external-pr
+        run: |
+          IS_EXTERNAL="${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}"
+
+          echo "is-external=${IS_EXTERNAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,6 +96,12 @@ jobs:
       run: |
         docker load -i /tmp/collector-full.tar
 
+    - name: Build auxiliar containers for tests
+      run: |
+        for container_dir in ${{ github.workspace }}/integration-tests/container/*/; do
+          make -C "${container_dir}"
+        done
+
     - name: Run integration tests locally
       run: |
         make -C ${{ github.workspace }}/integration-tests ci-integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
         - ebpf
         - kernel_module
     env:
-      COLLECTOR_IMAGE: ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}
+      COLLECTOR_IMAGE: ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}
       COLLECTION_METHOD: ${{ matrix.collection-method }}
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,10 +8,16 @@ on:
           Tag used for running the integration tests
         type: string
         required: true
+      is-external:
+        type: string
+        description: |
+          Signals whether CI is running from a fork
+        default: false
 
 jobs:
   required-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
+    if: inputs.is-external == 'false'
     strategy:
       # ensure that if one part of the matrix fails, the
       # rest will continue
@@ -27,7 +33,7 @@ jobs:
 
   all-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: contains(github.event.pull_request.labels.*.name, 'all-integration-tests') || github.event_name == 'push'
+    if: (contains(github.event.pull_request.labels.*.name, 'all-integration-tests') || github.event_name == 'push') && inputs.is-external == 'false'
     strategy:
       # ensure that if one part of the matrix fails, the
       # rest will continue
@@ -63,3 +69,33 @@ jobs:
           MSG_MINIMAL: actions url,commit
           SLACK_MESSAGE: |
             @acs-collector-team
+
+  external-integration-tests:
+    runs-on: ubuntu-22.04
+    if: inputs.is-external == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        collection-method:
+        - ebpf
+        - kernel_module
+    env:
+      COLLECTOR_IMAGE: ghcr.io/stackrox/collector:${{ inputs.collector-tag }}
+      COLLECTION_METHOD: ${{ matrix.collection-method }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run integration tests locally
+      run: |
+        make -C ${{ github.workspace }}/integration-tests ci-integration-tests
+
+    - name: Store artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.collection-method }}-logs
+        path: |
+          ${{ github.workspace }}/integration-tests/container-logs/**/*
+          ${{ github.workspace }}/integration-tests/perf.json
+          ${{ github.workspace }}/integration-tests/performance-logs/**/*

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,11 +80,21 @@ jobs:
         - ebpf
         - kernel_module
     env:
-      COLLECTOR_IMAGE: ghcr.io/${{ github.event.pull_request.head.repo.full_name }}:${{ inputs.collector-tag }}
+      COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
       COLLECTION_METHOD: ${{ matrix.collection-method }}
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Download collector image blob
+      uses: actions/download-artifact@v3
+      with:
+        name: collector-full
+        path: /tmp/collector-full.tar
+
+    - name: Restore collector image
+      run: |
+        docker load -i /tmp/collector-full.tar
 
     - name: Run integration tests locally
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,7 +90,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: collector-full
-        path: /tmp/collector-full.tar
+        path: /tmp
 
     - name: Restore collector image
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
         - ebpf
         - kernel_module
     env:
-      COLLECTOR_IMAGE: ghcr.io/stackrox/collector:${{ inputs.collector-tag }}
+      COLLECTOR_IMAGE: ghcr.io/${{ github.repository }}:${{ inputs.collector-tag }}
       COLLECTION_METHOD: ${{ matrix.collection-method }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
+      is-external: ${{ needs.init.outputs.is-external }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && needs.init.outputs.is-external == 'false' }}
     needs:
     - init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/upload-drivers.yml
     with:
       gcp-bucket: ${{ needs.init.outputs.push-drivers-bucket }}
-    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 && !needs.init.outputs.is-external  }}
+    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 && needs.init.outputs.is-external == 'false' }}
     needs:
     - init
     - build-drivers
@@ -71,7 +71,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && !needs.init.outputs.is-external }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && needs.init.outputs.is-external == 'false' }}
     needs:
     - init
     - build-collector-slim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       is-external: ${{ needs.init.outputs.is-external }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && needs.init.outputs.is-external == 'false' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
     needs:
     - init
     - build-collector-slim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       bundles-bucket: ${{ needs.init.outputs.bundles-bucket }}
       branch-name: ${{ needs.init.outputs.branch-name }}
+      is-external: ${{ needs.init.outputs.is-external }}
     needs: init
     secrets: inherit
 
@@ -29,7 +30,7 @@ jobs:
     uses: ./.github/workflows/upload-drivers.yml
     with:
       gcp-bucket: ${{ needs.init.outputs.push-drivers-bucket }}
-    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
+    if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 && !needs.init.outputs.is-external  }}
     needs:
     - init
     - build-drivers
@@ -49,6 +50,7 @@ jobs:
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}
+      is-external: ${{ needs.init.outputs.is-external }}
     secrets: inherit
 
   build-collector-full:
@@ -58,6 +60,7 @@ jobs:
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
       build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
+      is-external: ${{ needs.init.outputs.is-external }}
     secrets: inherit
     needs:
     - init
@@ -68,7 +71,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && !needs.init.outputs.is-external }}
     needs:
     - init
     - build-collector-slim


### PR DESCRIPTION
## Description

This PR replaces #951, which was closed when the base branch was merged to master.

The basic idea is to provide a simplified workflow for building and testing collector when a PR is coming from a fork, which doesn't have access to our GHA secrets.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

TBD.
