### PR TITLE
Increases driver download retries

### DIFF
--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -40,6 +40,9 @@ extern "C" {
 
 namespace collector {
 
+const int kNumDownloadRetries = 90;
+const int kMaxDownloadRetriesTime = 90;
+
 bool DownloadKernelObjectFromURL(FileDownloader& downloader, const std::string& base_url, const std::string& kernel_module, const std::string& module_version) {
   std::string url(base_url + "/" + module_version + "/" + kernel_module + ".gz");
 
@@ -111,7 +114,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
   }
 
   downloader.IPResolve(FileDownloader::ANY);
-  downloader.SetRetries(30, 1, 60);
+  downloader.SetRetries(kNumDownloadRetries, 1, kMaxDownloadRetriesTime);
   downloader.SetVerboseMode(verbose);
   downloader.OutputFile(compressed_module_path);
   if (!downloader.SetConnectionTimeout(2)) return false;
@@ -128,7 +131,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
 
   downloader.ResetCURL();
   downloader.IPResolve(FileDownloader::ANY);
-  downloader.SetRetries(30, 1, 60);
+  downloader.SetRetries(kNumDownloadRetries, 1, kMaxDownloadRetriesTime);
   downloader.SetVerboseMode(verbose);
   downloader.OutputFile(compressed_module_path);
   if (!downloader.SetConnectionTimeout(2)) return false;


### PR DESCRIPTION
## Description

Testing has revealed there is a situation where Sensor is up, but Central isn't, and this can result in Collectors restarting due to missing drivers. Whilst being unable to download drivers is an expected behaviour, increasing the timeouts will create a bigger window for components to start without having to restart collector each time.


