### PR TITLE
[WIP] Build multi-arch collector images 

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
 
       - name: Checks for main and release branches
-#         if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           echo "COLLECTOR_BUILDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: true
 
       - name: Checks for main and release branches
-        if: github.event_name != 'pull_request'
+#         if: github.event_name != 'pull_request'
         run: |
           echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
           echo "COLLECTOR_BUILDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"
@@ -58,6 +58,12 @@ jobs:
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
             echo "ADDRESS_SANITIZER=true" >> "$GITHUB_ENV"
           fi
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build images
         run: |

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -18,6 +18,7 @@ env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
   DEFAULT_BUILDER_TAG: cache
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+  ARCH: linux/ppc64le,linux/amd64
 
 jobs:
   build-collector-image:


### PR DESCRIPTION
## Description

This PR intends to add support for building multi-arch `collector` images with the use of `docker buildx`. It is part of a broader effort in enabling OSCI for IBM Power.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.


## Testing Performed

Tested the changes locally. Green CI with `all-integration-tests` should be enough.

