### PR TITLE
Move unsupported versions

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -7,14 +7,7 @@
 # now-unsupported releases.
 # IMPORTANT: THIS FILE ALWAYS NEEDS TO END WITH A NEWLINE CHARACTER
 
-3.9.0 3.71.0  # Rox release 3.71.0 by roxbot at Thu Jul 21 09:58:32 UTC 2022
-3.11.0 3.72.0  # Rox release 3.72.0 by roxbot at Mon Sep 26 10:21:46 UTC 2022
-3.9.1 3.71.2  # Rox release 3.71.2 by roxbot at Thu Oct 13 20:24:23 UTC 2022
-3.11.1 3.72.1  # Rox release 3.72.1 by roxbot at Tue Oct 18 17:09:49 UTC 2022
-3.11.2 3.72.2  # Rox release 3.72.2 by roxbot at Wed Nov  9 17:41:06 UTC 2022
 3.12.0 3.73.0  # Rox release 3.73.0 by roxbot at Wed Nov 30 16:32:40 UTC 2022
-3.11.2 3.72.3  # Rox release 3.72.3 by roxbot at Thu Jan 12 22:05:44 UTC 2023
-3.9.2 3.71.3  # Rox release 3.71.3 by roxbot at Tue Dec 13 18:19:01 UTC 2022
 3.12.0 3.73.1  # Rox release 3.73.1 by roxbot at Wed Dec 19 11:38:00 UTC 2022
 3.12.1 3.73.2  # Rox release 3.73.2 by roxbot at Mon Feb  6 13:41:53 UTC 2023
 3.13.0 3.74.0  # Rox release 3.74.0 by roxbot at Mon Feb 27 17:15:27 UTC 2023

--- a/RELEASED_VERSIONS.unsupported
+++ b/RELEASED_VERSIONS.unsupported
@@ -134,3 +134,10 @@
 3.8.2 3.70.1  # Rox release 3.70.1 by JoukoVirtanen at Fri Jun 17 22:43:18 UTC 2022
 3.7.6 3.69.2  # Rox release 3.69.2 by JoukoVirtanen at Tue Jun 21 17:02:21 UTC 2022
 3.8.3 3.70.2  # Rox release 3.70.2 by 0x656b694d at Wed Oct  5 15:38:12 UTC 2022
+3.9.0 3.71.0  # Rox release 3.71.0 by roxbot at Thu Jul 21 09:58:32 UTC 2022
+3.11.0 3.72.0  # Rox release 3.72.0 by roxbot at Mon Sep 26 10:21:46 UTC 2022
+3.9.1 3.71.2  # Rox release 3.71.2 by roxbot at Thu Oct 13 20:24:23 UTC 2022
+3.11.1 3.72.1  # Rox release 3.72.1 by roxbot at Tue Oct 18 17:09:49 UTC 2022
+3.11.2 3.72.2  # Rox release 3.72.2 by roxbot at Wed Nov  9 17:41:06 UTC 2022
+3.11.2 3.72.3  # Rox release 3.72.3 by roxbot at Thu Jan 12 22:05:44 UTC 2023
+3.9.2 3.71.3  # Rox release 3.71.3 by roxbot at Tue Dec 13 18:19:01 UTC 2022


### PR DESCRIPTION
## Description

Stackrox versions 3.72 and 3.71 have hit EOL, we can move the corresponding versions of collector to the unsupported list of versions. This will also stop CI from building drivers for new kernels with module versions `2.0.1` and `2.1.0`.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Run CI with `build-legacy-probes` and `test-support-packages` labels, ensure the driver versions mentioned don't show up.