### PR TITLE
Only build support packages for release versions

### DIFF
--- a/kernel-modules/support-packages/01-collector-to-rox-version-map.py
+++ b/kernel-modules/support-packages/01-collector-to-rox-version-map.py
@@ -8,7 +8,7 @@ import subprocess
 
 strip_comment_re = re.compile(r'\s*(#.*)?$')
 space_re = re.compile(r'\s+')
-version_re = re.compile(r'(\d+)\.(\d+)\.(\d+)')
+version_re = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
 
 
 def parse_released_versions(f):


### PR DESCRIPTION
## Description

We are currently building support packages for driver version `1.0.0` because a regex used when mapping collector versions is matching an `-rc` tag. This makes is so the regex matches release versions only

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Check support packages for version `1.0.0` are not pushed to GCP.
