### PR TITLE
Add MODULE_VERSION into image-dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ image-dev: collector unittest container-dockerfile-dev
 	make -C collector txt-files
 	docker build --build-arg collector_version="$(COLLECTOR_TAG)" \
 		--build-arg BUILD_TYPE=devel \
+		--build-arg MODULE_VERSION="$(MODULE_VERSION)" \
 		-f collector/container/Dockerfile.dev \
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \
 		$(COLLECTOR_BUILD_CONTEXT)


### PR DESCRIPTION
## Description

Otherwise it will produce an image with an empty MODULE_VERSION

## Checklist
~- [ ] Investigated and inspected CI test results~
~- [ ] Updated documentation accordingly~

**Automated testing**
~  - [ ] Added unit tests~
~  - [ ] Added integration tests~
~  - [ ] Added regression tests~

The change concerns only development target.

## Testing Performed

TODO(replace-me)

Local testing.