### PR TITLE
[WIP] Build multi-arch collector-slim images

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -18,11 +18,18 @@ env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
   DEFAULT_BUILDER_TAG: cache
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+  ARCH: linux/amd64,linux/ppc64le
 
 jobs:
   build-collector-image:
+
     name: Build the collector slim image
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - uses: actions/checkout@v3
@@ -59,9 +66,17 @@ jobs:
             echo "ADDRESS_SANITIZER=true" >> "$GITHUB_ENV"
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build images
         run: |
           make image
+
+      # - name: Push multiarch image to stackrox-io and rhacs-eng
 
       - name: Retag and push stackrox-io -slim
         uses: ./.github/actions/retag-and-push

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ container-dockerfile-dev:
 .PHONY: builder
 builder:
 ifdef BUILD_BUILDER_IMAGE
-	docker-buildx build --push --platform ${ARCH} \
+	docker buildx build --push --platform ${ARCH} \
 		--build-arg NPROCS=$(NPROCS) \
 		--cache-from quay.io/stackrox-io/collector-builder:cache \
 		--cache-from quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
@@ -64,7 +64,7 @@ build-drivers:
 
 image: collector unittest
 	make -C collector txt-files
-	docker-buildx build --push --platform ${ARCH} \
+	docker buildx build --push --platform ${ARCH} \
 		--build-arg COLLECTOR_VERSION="$(COLLECTOR_TAG)" \
 		--build-arg MODULE_VERSION="$(MODULE_VERSION)" \
 		-f collector/container/Dockerfile \


### PR DESCRIPTION
## Description

This PR intends to add support for building multi-arch collector images with the use of docker buildx. It is part of a broader effort in enabling OSCI for IBM Power.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests