### PR TITLE
update RELEASED_VERSIONS for patch releases on 3.73.x

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -11,4 +11,6 @@
 3.12.0 3.73.1  # Rox release 3.73.1 by roxbot at Wed Dec 19 11:38:00 UTC 2022
 3.12.1 3.73.2  # Rox release 3.73.2 by roxbot at Mon Feb  6 13:41:53 UTC 2023
 3.13.0 3.74.0  # Rox release 3.74.0 by roxbot at Mon Feb 27 17:15:27 UTC 2023
+3.12.2 3.73.3  # Rox release 3.73.3 by roxbot at Mon Mar  6 11:18:28 UTC 2023
 3.13.0 3.74.1  # Rox release 3.74.1 by roxbot at Mon Mar 20 09:11:10 UTC 2023
+3.12.3 3.73.4  # Rox release 3.73.4 by roxbot at Tue Apr 11 14:37:38 UTC 2023


### PR DESCRIPTION
Update RELEASED_VERSIONS as part of 3.73.4 release. 

Noticed that 3.73.3 was missing from the list, added it with release 3.12.2 as per https://github.com/stackrox/stackrox/blob/3.73.3/COLLECTOR_VERSION. 