### PR TITLE
Fix connscraper capabilities

### DIFF
--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -76,13 +76,6 @@ class KernelDriverModule : public IKernelDriver {
       return false;
     }
 
-    // Drop DAC_OVERRIDE capability after opening the device files.
-    capng_updatev(CAPNG_DROP, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_DAC_OVERRIDE, -1);
-    if (capng_apply(CAPNG_SELECT_BOTH) != 0) {
-      CLOG(WARNING) << "Failed to drop DAC_OVERRIDE capability: " << StrError();
-      return false;
-    }
-
     return true;
   }
 

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -192,6 +192,14 @@ void SysdigService::Start() {
 
   inspector_->start_capture();
 
+  if (!useEbpf_) {
+    // Drop DAC_OVERRIDE capability after opening the device files.
+    capng_updatev(CAPNG_DROP, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_DAC_OVERRIDE, -1);
+    if (capng_apply(CAPNG_SELECT_BOTH) != 0) {
+      CLOG(WARNING) << "Failed to drop DAC_OVERRIDE capability: " << StrError();
+    }
+  }
+
   std::lock_guard<std::mutex> running_lock(running_mutex_);
   running_ = true;
 }


### PR DESCRIPTION
## Description

connscraper needs DAC_OVERRIDE in order to read /proc correctly, so when using kernel modules we drop the capability after connscraper spawns.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Test the image in the main repo.
