### PR TITLE
Fix image builds on MacOS

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -65,7 +65,7 @@ jobs:
     env:
       BUILD_BUILDER_IMAGE: ${{ needs.set-environment.outputs.build-builder-image }}
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
-      ARCH: ${{ matrix.arch }}
+      PLATFORM: linux/${{ matrix.arch }}
 
     steps:
       - uses: actions/checkout@v3
@@ -143,7 +143,7 @@ jobs:
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}  
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
 
       - name: Create and push multiarch manifest for stackrox-io -slim

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ container-dockerfile-dev:
 .PHONY: builder
 builder:
 ifdef BUILD_BUILDER_IMAGE
-	docker buildx build --load --platform ${ARCH} \
+	docker buildx build --load --platform ${PLATFORM} \
 		--build-arg NPROCS=$(NPROCS) \
 		--cache-from quay.io/stackrox-io/collector-builder:cache \
 		--cache-from quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
@@ -38,7 +38,7 @@ ifdef BUILD_BUILDER_IMAGE
 		-f "$(CURDIR)/builder/Dockerfile" \
 		.
 else
-	docker pull --platform linux/${ARCH} quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)
+	docker pull --platform ${PLATFORM} quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)
 endif
 
 collector: builder
@@ -62,7 +62,7 @@ build-drivers:
 
 image: collector unittest
 	make -C collector txt-files
-	docker buildx build --load --platform ${ARCH} \
+	docker buildx build --load --platform ${PLATFORM} \
 		--build-arg COLLECTOR_VERSION="$(COLLECTOR_TAG)" \
 		--build-arg MODULE_VERSION="$(MODULE_VERSION)" \
 		-f collector/container/Dockerfile \

--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -15,7 +15,7 @@ USE_VALGRIND ?= false
 ADDRESS_SANITIZER ?= false
 CMAKE_BUILD_TYPE ?= Release
 COLLECTOR_APPEND_CID ?= false
-ARCH ?= amd64
+PLATFORM ?= linux/amd64
 
 COLLECTOR_BUILD_CONTEXT = collector/
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -19,7 +19,7 @@ COLLECTOR_BUILD_DEPS := $(HDRS) $(SRCS) $(shell find falcosecurity-libs -name '*
 
 cmake-build/collector: $(COLLECTOR_BUILD_DEPS)
 	docker rm -fv build_collector || true
-	docker run --rm --platform ${ARCH} --name build_collector \
+	docker run --rm --platform ${PLATFORM} --name build_collector \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		-e NPROCS=$(NPROCS) \
 		-e SRC_ROOT_DIR="$(SRC_MOUNT_DIR)" \
@@ -46,14 +46,14 @@ build-connscrape-test:
 
 connscrape: build-connscrape-test
 	docker rm -fv collector_connscrape || true
-	docker run --rm --platform ${ARCH} --name collector_connscrape \
+	docker run --rm --platform ${PLATFORM} --name collector_connscrape \
 		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		connscrape-test "$(SRC_MOUNT_DIR)/collector/connscrape-test/connscrape-test.sh"
 
 unittest: collector
 	docker rm -fv collector_unittest || true
-	docker run --rm --platform ${ARCH} --name collector_unittest \
+	docker run --rm --platform ${PLATFORM} --name collector_unittest \
 		-v "$(LIBSINSP_BIN_DIR)/libsinsp-wrapper.so:/usr/local/lib/libsinsp-wrapper.so:ro" \
 		-v "$(BASE_PATH):$(SRC_MOUNT_DIR)" \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) $(COLLECTOR_PRE_ARGUMENTS) "$(SRC_MOUNT_DIR)/$(CMAKE_BASE_DIR)/collector/runUnitTests"


### PR DESCRIPTION
## Description

Not specifying the OS to the --platform arguments defaults to darwin on MacOS, this is not the behavior we want, we should always attempt to use linux/amd64 by default.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] Build images locally on a mac.
