### PR TITLE
Fix docker-compose example in docs

### DIFF
--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -85,6 +85,10 @@ the host network in privileged mode. Collector in turn will try to download
 probes for your version of Linux kernel and start listening to events happening
 inside the container.
 
+The image `quay.io/rhacs-eng/grpc-server` can be built manually by running 
+`make mock-grpc-server-image` in the `https://github.com/stackrox/stackrox/`
+repository.
+
 ### Development with an IDE (CLion)
 
 #### Setup

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -67,10 +67,12 @@ services:
       - /usr/lib:/host/usr/lib:ro
       - /sys/:/host/sys/:ro
       - /dev:/host/dev:ro
+      - type: tmpfs
+        target: /module
     depends_on:
       - grpc-server-debug
   grpc-server-debug:
-    image: stackrox/grpc-server:latest
+    image: quay.io/rhacs-eng/grpc-server:latest
     container_name: grpc-server
     network_mode: host
     user: 1000:1000


### PR DESCRIPTION
## Description

Updated an example in the docs

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested by running `docker-compose up` using the yaml file in the docs.
