### PR TITLE
Improve compatibility with podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ builder:
 ifdef BUILD_BUILDER_IMAGE
 	docker buildx build --load --platform ${PLATFORM} \
 		--build-arg NPROCS=$(NPROCS) \
-		--cache-from quay.io/stackrox-io/collector-builder:cache \
-		--cache-from quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
 		-t quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
 		-f "$(CURDIR)/builder/Dockerfile" \
 		.

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -20,21 +20,23 @@ if(COLLECTOR_APPEND_CID)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOLLECTOR_APPEND_CID")
 endif()
 
+set(FALCO_DIR ${PROJECT_SOURCE_DIR}/../falcosecurity-libs)
+
 add_subdirectory(${PROJECT_SOURCE_DIR}/proto)
 
 include_directories(${PROJECT_SOURCE_DIR}/lib)
-include_directories(${PROJECT_SOURCE_DIR}/falcosecurity-libs/driver)
-include_directories(${PROJECT_SOURCE_DIR}/falcosecurity-libs/userspace)
-include_directories(${PROJECT_SOURCE_DIR}/falcosecurity-libs/userspace/libscap)
-include_directories(${PROJECT_SOURCE_DIR}/falcosecurity-libs/userspace/libsinsp)
-include_directories(${PROJECT_SOURCE_DIR}/falcosecurity-libs/userspace/chisel)
+include_directories(${FALCO_DIR}/driver)
+include_directories(${FALCO_DIR}/userspace)
+include_directories(${FALCO_DIR}/userspace/libscap)
+include_directories(${FALCO_DIR}/userspace/libsinsp)
+include_directories(${FALCO_DIR}/userspace/chisel)
 include_directories(${PROJECT_BINARY_DIR}/EXCLUDE_FROM_DEFAULT_BUILD/common)
 include_directories(/usr/local/include)
 include_directories(/usr/local/include/tbb)
 include_directories(/usr/local/include/jsoncpp)
 include_directories(/usr/local/include/civetweb)
 include_directories(/usr/local/include/prometheus)
-set(DRIVER_HEADERS ${PROJECT_SOURCE_DIR}/falcosecurity-libs/driver/ppm_events_public.h ${PROJECT_SOURCE_DIR}/falcosecurity-libs/driver/ppm_fillers.h)
+set(DRIVER_HEADERS ${FALCO_DIR}/driver/ppm_events_public.h ${FALCO_DIR}/driver/ppm_fillers.h)
 
 add_definitions(-DUSE_PROTO_ARENAS)
 
@@ -122,4 +124,4 @@ endif()
 
 set(MODERN_BPF_EXCLUDE_PROGS "^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$" CACHE STRING "Set of syscalls to exclude from modern bpf engine " FORCE)
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/falcosecurity-libs EXCLUDE_FROM_DEFAULT_BUILD)
+add_subdirectory(${FALCO_DIR} EXCLUDE_FROM_DEFAULT_BUILD)

--- a/collector/falcosecurity-libs
+++ b/collector/falcosecurity-libs
@@ -1,1 +1,0 @@
-../falcosecurity-libs/


### PR DESCRIPTION
## Description

A small set of changes that enables using podman as the build engine via the podman-docker package or by symlinking docker to podman.

The collector/falcosecurity-libs symlink is removed. It is not needed now that we use a global cmake project set at the root of the repository and was causing trouble with podman.

The '--cache-from' argument takes different types of arguments for podman and docker, since the way the builder works makes it relatively hard to actually take advantage of caching, we can directly remove them.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Run with `no-cache` to ensure removing the symlink doesn't affect driver builds.
