### PR TITLE
Block drivers for 6.3 kernels

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -66,3 +66,5 @@
 6.2.* 2.2.0 *
 6.2.* 2.1.0 *
 6.2.* 2.0.1 *
+# TODO(ROX-16705) - 6.3 kernel compilation errors
+6.3.*


### PR DESCRIPTION
## Description

Stop building drivers for the 6.3 kernel version, due to a compilation error that needs to be investigated.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Check the drivers for 6.3 kernels are marked as blocked in CI.
