### PR TITLE
Add an option to hard fail when the CO-RE bpf probe fails to insert

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -55,6 +55,8 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 // If true, add originator process information in NetworkEndpoint
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
+BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", true);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
@@ -78,6 +80,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   collection_method_ = kCollectionMethod;
   force_kernel_modules_ = kForceKernelModules;
   enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
+  core_bpf_hardfail_ = core_bpf_hardfail.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -108,6 +108,7 @@ end
   bool IsCoreDumpEnabled() const;
   Json::Value TLSConfiguration() const { return tls_config_; }
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
+  bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -131,6 +132,7 @@ end
   bool enable_afterglow_ = true;
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
+  bool core_bpf_hardfail_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -161,8 +161,12 @@ class KernelDriverCOREEBPF : public IKernelDriver {
                                 DEFAULT_CPU_FOR_EACH_BUFFER,
                                 true, ppm_sc, tp_set);
     } catch (const sinsp_exception& ex) {
-      CLOG(WARNING) << ex.what();
-      return false;
+      if (config.CoReBPFHardfail()) {
+        throw ex;
+      } else {
+        CLOG(WARNING) << ex.what();
+        return false;
+      }
     }
 
     return true;


### PR DESCRIPTION
## Description

As we've discussed on some weekly syncs, we should hard fail when the CO-RE bpf probe fails to insert in order to get more visibility on problems that might arise. A configuration option to rollback the behavior to fallback on regular eBPF is added.

Fixes #1137 

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed
CI should be enough.
