### PR TITLE
Add --nobest for building on rhel8

### DIFF
--- a/kernel-modules/build/rhel8.Dockerfile
+++ b/kernel-modules/build/rhel8.Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream8 AS rhel-8-base
 ENV DISTRO=rhel8
 
 RUN dnf -y update && \
-    dnf -y install \
+    dnf -y install --nobest \
         make \
         cmake \
         gcc-c++ \


### PR DESCRIPTION
## Description

rhel8 dockerfile shows issues with installing packages like:

    Problem: package elfutils-libelf-devel-0.188-3.el8.x86_64 requires elfutils-libelf(x86-64) = 0.188-3.el8, but none of the providers can be installed
      - cannot install both elfutils-libelf-0.188-3.el8.x86_64 and elfutils-libelf-0.189-1.el8.x86_64
      - cannot install the best candidate for the job

Address this via adding --nobest option to pick up a package candidate.

## Testing Performed

CI run is enough.