### PR TITLE
Remove explicit install of elfutils-libelf in containers building probes.

### DIFF
--- a/kernel-modules/build/fc36.Dockerfile
+++ b/kernel-modules/build/fc36.Dockerfile
@@ -8,7 +8,6 @@ RUN dnf -y install \
         gcc-c++ \
         llvm \
         clang \
-        elfutils-libelf \
         elfutils-libelf-devel \
         kmod  && \
     # We trick Debian builds into thinking they have the required GCC binary

--- a/kernel-modules/build/rhel7.Dockerfile
+++ b/kernel-modules/build/rhel7.Dockerfile
@@ -8,7 +8,6 @@ RUN yum makecache && \
         make \
         gcc-c++ \
         llvm-toolset-7.0 \
-        elfutils-libelf \
         elfutils-libelf-devel \
         kmod
 

--- a/kernel-modules/build/rhel8.Dockerfile
+++ b/kernel-modules/build/rhel8.Dockerfile
@@ -9,7 +9,6 @@ RUN dnf -y update && \
         gcc-c++ \
         llvm \
         clang \
-        elfutils-libelf \
         elfutils-libelf-devel \
         kmod && \
     # We trick Debian builds into thinking they have the required GCC binaries


### PR DESCRIPTION
## Description

The centos8 packages for elfutils-libelf and elfutils-libelf-devel are currently incompatible. It is advised to add --nobest, which was attempted but didn't seem to fix the issue. This is an alternative approach in which we remove the explicit install of the library. We depend only on the `devel` package, and thus trigger a downgrade.

## Checklist
- [x] Investigated and inspected CI test results

The failures in this PR are due to missing modules, which should be provided by a master build, once the PR is merged...