### PR TITLE
[testing] Use the readiness probe to wait for collector

### DIFF
--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -73,7 +73,7 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -72,7 +72,9 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(30 * time.Second)
+
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
 
 	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")
 

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -28,7 +28,7 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	processImage := getProcessListeningOnPortsImage()

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -27,7 +27,9 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(30 * time.Second)
+
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
 
 	processImage := getProcessListeningOnPortsImage()
 

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -37,7 +37,7 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	images := []string{

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -37,6 +37,9 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
+
 	images := []string{
 		"nginx:1.14-alpine",
 		"pstauffer/curl:latest",

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -38,7 +38,9 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(10 * time.Second)
+
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
 
 	s.cleanupContainer([]string{"nginx"})
 	time.Sleep(10 * time.Second)

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -39,7 +39,7 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	s.cleanupContainer([]string{"nginx"})

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -51,7 +51,7 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	scheduled_curls_image := common.QaImage("quay.io/rhacs-eng/qa", "collector-schedule-curls")

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -51,6 +51,9 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
+
 	scheduled_curls_image := common.QaImage("quay.io/rhacs-eng/qa", "collector-schedule-curls")
 
 	images := []string{

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -41,7 +41,9 @@ func (s *SocatTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(30 * time.Second)
+
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
 
 	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")
 

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -42,7 +42,7 @@ func (s *SocatTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	processImage := common.QaImage("quay.io/rhacs-eng/qa", "socat")

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -28,7 +28,9 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(30 * time.Second)
+
+	err = s.collector.WaitForCollector(30)
+	s.Require().NoError(err)
 
 	processImage := getProcessListeningOnPortsImage()
 

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -29,7 +29,7 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	err = s.collector.WaitForCollector(30)
+	err = s.collector.WaitForCollector(60)
 	s.Require().NoError(err)
 
 	processImage := getProcessListeningOnPortsImage()


### PR DESCRIPTION
## Description

Up to now, in tests, we have been making use of sleep time to wait for Collector to start. This PR proposes to contact the readiness probe instead.

This should shorten slightly the test execution time, lower the flackyness and make it clearer when Collector fails to start.

## Checklist
- [ ] Investigated and inspected CI test results