### PR TITLE
Revert to using a dedicated image for repeated_network_flow

### DIFF
--- a/integration-tests/container/schedule-curls/Dockerfile
+++ b/integration-tests/container/schedule-curls/Dockerfile
@@ -1,0 +1,3 @@
+FROM pstauffer/curl:latest
+
+COPY schedule-curls.sh /usr/bin/schedule-curls.sh 

--- a/integration-tests/container/schedule-curls/Makefile
+++ b/integration-tests/container/schedule-curls/Makefile
@@ -1,0 +1,15 @@
+.DEFAULT_GOAL = all
+
+COLLECTOR_QA_SCHEDULE_CURLS_TAG := collector-schedule-curls
+
+ifneq ($(COLLECTOR_QA_TAG),)
+COLLECTOR_QA_SCHEDULE_CURLS_TAG=collector-schedule-curls-$(COLLECTOR_QA_TAG)
+endif
+
+.PHONY: all
+all:
+	@docker build -t quay.io/rhacs-eng/qa:$(COLLECTOR_QA_SCHEDULE_CURLS_TAG) .
+
+.PHONY: push
+push:
+	@docker push quay.io/rhacs-eng/qa:$(COLLECTOR_QA_SCHEDULE_CURLS_TAG)

--- a/integration-tests/container/schedule-curls/schedule-curls.sh
+++ b/integration-tests/container/schedule-curls/schedule-curls.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+num_meta_iter=$1
+num_iter=$2
+sleep_between_curl_time=$3
+sleep_between_iterations=$4
+url=$5
+
+i=0
+j=0
+
+while [ "$i" -lt "$num_meta_iter" ]; do
+    while [ "$j" -lt "$num_iter" ]; do
+        curl "$url"
+        sleep "$sleep_between_curl_time"
+        j=$((j + 1))
+    done
+    sleep "$sleep_between_iterations"
+    i=$((i + 1))
+done

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -51,7 +51,7 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	err = s.collector.Launch()
 	s.Require().NoError(err)
 
-	scheduled_curls_image := common.QaImage("pstauffer/curl", "latest")
+	scheduled_curls_image := common.QaImage("quay.io/rhacs-eng/qa", "collector-schedule-curls")
 
 	images := []string{
 		"nginx:1.14-alpine",
@@ -88,31 +88,7 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	numIter := strconv.Itoa(s.NumIter)
 	sleepBetweenCurlTime := strconv.Itoa(s.SleepBetweenCurlTime)
 	sleepBetweenIterations := strconv.Itoa(s.SleepBetweenIterations)
-	_, err = s.execContainerShellScript("nginx-curl",
-		"/bin/sh",
-		`
-		#!/usr/bin/env sh
-
-		num_meta_iter=$1
-		num_iter=$2
-		sleep_between_curl_time=$3
-		sleep_between_iterations=$4
-		url=$5
-
-		i=0
-		j=0
-
-		while [ "$i" -lt "$num_meta_iter" ]; do
-		    while [ "$j" -lt "$num_iter" ]; do
-		        curl "$url"
-		        sleep "$sleep_between_curl_time"
-		        j=$((j + 1))
-		    done
-		    sleep "$sleep_between_iterations"
-		    i=$((i + 1))
-		done
-		`,
-		numMetaIter, numIter, sleepBetweenCurlTime, sleepBetweenIterations, serverAddress)
+	_, err = s.execContainer("nginx-curl", []string{"/usr/bin/schedule-curls.sh", numMetaIter, numIter, sleepBetweenCurlTime, sleepBetweenIterations, serverAddress})
 
 	s.ClientIP, err = s.getIPAddress("nginx-curl")
 	s.Require().NoError(err)


### PR DESCRIPTION
## Description

Until we understand what makes the pipe mechanism flaky.

A new mechanism to pipe shell scripts into containers has been introduced by https://github.com/stackrox/collector/pull/1047. It basically works but seemingly made master flaky.

We plan to reenable this in https://github.com/stackrox/collector/pull/1149

## Checklist
- [x] Investigated and inspected CI test results