### PR TITLE
Jv rox investigate missing udp connection when using recvfrom

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -406,49 +406,48 @@ func TestConnectionsAndEndpointsUDPNoFork(t *testing.T) {
 	suite.Run(t, mixedHighLowPorts)
 }
 
-// TODO Investigate why no connection is reported here
-//  func TestConnectionsAndEndpointsUDPRecvfrom(t *testing.T) {
-//  	socatTest := &suites.ConnectionsAndEndpointsTestSuite{
-//  		IntegrationTestSuiteBase: suites.IntegrationTestSuiteBase{},
-//  		Server: suites.Container{
-//  			Name: "socat-server-0",
-//  			Cmd:  "socat -d -d -v UDP4-RECVFROM:5143,fork - &> /socat-log.txt &",
-//  			ExpectedNetwork: []common.NetworkInfo{
-//  				{
-//  					LocalAddress:   "",
-//  					RemoteAddress:  "",
-//  					Role:           "ROLE_SERVER",
-//  					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
-//  					CloseTimestamp: "(timestamp: nil Timestamp)",
-//  				},
-//  			},
-//  			// TODO UDP listening endpoints should be reported
-//  			ExpectedEndpoints: nil,
-//  		},
-//  		Client: suites.Container{
-//  			Name: "socat-client-0",
-//  			Cmd:  "echo hello | socat -d -d -v - UDP4-DATAGRAM:SERVER_IP:5143 &> /socat-log.txt",
-//  			ExpectedNetwork: []common.NetworkInfo{
-//  				{
-//  					LocalAddress:   "",
-//  					RemoteAddress:  "",
-//  					Role:           "ROLE_CLIENT",
-//  					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
-//  					CloseTimestamp: "(timestamp: nil Timestamp)",
-//  				},
-//  			},
-//  			ExpectedEndpoints: []common.EndpointInfo{
-//  				{
-//  					Protocol: "L4_PROTOCOL_UDP",
-//  					Address: &common.ListenAddress{
-//  						AddressData: `"\000\000\000\001"`,
-//  						Port:        5143,
-//  						IpNetwork:   `"\000\000\000\000 " `,
-//  					},
-//  				},
-//  			},
-//  		},
-//  	}
-//
-//  	suite.Run(t, socatTest)
-//  }
+func TestConnectionsAndEndpointsUDPRecvfrom(t *testing.T) {
+	socatTest := &suites.ConnectionsAndEndpointsTestSuite{
+		IntegrationTestSuiteBase: suites.IntegrationTestSuiteBase{},
+		Server: suites.Container{
+			Name: "socat-server-0",
+			Cmd:  "socat -d -d -v UDP4-RECVFROM:5143,fork - &> /socat-log.txt &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			// TODO UDP listening endpoints should be reported
+			ExpectedEndpoints: nil,
+		},
+		Client: suites.Container{
+			Name: "socat-client-0",
+			Cmd:  "echo hello | socat -d -d -v - UDP4-DATAGRAM:SERVER_IP:5143 &> /socat-log.txt",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: []common.EndpointInfo{
+				{
+					Protocol: "L4_PROTOCOL_UDP",
+					Address: &common.ListenAddress{
+						AddressData: `"\000\000\000\001"`,
+						Port:        5143,
+						IpNetwork:   `"\000\000\000\000 " `,
+					},
+				},
+			},
+		},
+	}
+
+	suite.Run(t, socatTest)
+}

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -297,3 +297,158 @@ func TestConnectionsAndEndpointsSourcePort(t *testing.T) {
 	}
 	suite.Run(t, mixedHighLowPorts)
 }
+
+func TestConnectionsAndEndpointsUDP(t *testing.T) {
+	// A test for UDP
+	mixedHighLowPorts := &suites.ConnectionsAndEndpointsTestSuite{
+		Server: suites.Container{
+			Name: "socat-server-udp",
+			Cmd:  "socat UDP-LISTEN:53,reuseaddr,fork - &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   ":53",
+					RemoteAddress:  "CLIENT_IP",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			// TODO UDP listening endpoints should be reported
+			ExpectedEndpoints: nil,
+		},
+		Client: suites.Container{
+			Name: "socat-client-udp",
+			Cmd:  "echo hello | socat - UDP:SERVER_IP:53",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "SERVER_IP:53",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+	}
+	suite.Run(t, mixedHighLowPorts)
+}
+
+func TestConnectionsAndEndpointsUDPNoReuseaddr(t *testing.T) {
+	// A test for UDP without reuseaddr
+	mixedHighLowPorts := &suites.ConnectionsAndEndpointsTestSuite{
+		Server: suites.Container{
+			Name: "socat-server-udp",
+			Cmd:  "socat UDP-LISTEN:53,fork - &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   ":53",
+					RemoteAddress:  "CLIENT_IP",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			// TODO UDP listening endpoints should be reported
+			ExpectedEndpoints: nil,
+		},
+		Client: suites.Container{
+			Name: "socat-client-udp",
+			Cmd:  "echo hello | socat - UDP:SERVER_IP:53",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "SERVER_IP:53",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+	}
+	suite.Run(t, mixedHighLowPorts)
+}
+
+func TestConnectionsAndEndpointsUDPNoFork(t *testing.T) {
+	// A test for UDP without fork or reuseaddr
+	mixedHighLowPorts := &suites.ConnectionsAndEndpointsTestSuite{
+		Server: suites.Container{
+			Name: "socat-server-udp",
+			Cmd:  "socat UDP-LISTEN:53 - &",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   ":53",
+					RemoteAddress:  "CLIENT_IP",
+					Role:           "ROLE_SERVER",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			// TODO UDP listening endpoints should be reported
+			ExpectedEndpoints: nil,
+		},
+		Client: suites.Container{
+			Name: "socat-client-udp",
+			Cmd:  "echo hello | socat - UDP:SERVER_IP:53",
+			ExpectedNetwork: []common.NetworkInfo{
+				{
+					LocalAddress:   "",
+					RemoteAddress:  "SERVER_IP:53",
+					Role:           "ROLE_CLIENT",
+					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+					CloseTimestamp: "(timestamp: nil Timestamp)",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+	}
+	suite.Run(t, mixedHighLowPorts)
+}
+
+// TODO Investigate why no connection is reported here
+//  func TestConnectionsAndEndpointsUDPRecvfrom(t *testing.T) {
+//  	socatTest := &suites.ConnectionsAndEndpointsTestSuite{
+//  		IntegrationTestSuiteBase: suites.IntegrationTestSuiteBase{},
+//  		Server: suites.Container{
+//  			Name: "socat-server-0",
+//  			Cmd:  "socat -d -d -v UDP4-RECVFROM:5143,fork - &> /socat-log.txt &",
+//  			ExpectedNetwork: []common.NetworkInfo{
+//  				{
+//  					LocalAddress:   "",
+//  					RemoteAddress:  "",
+//  					Role:           "ROLE_SERVER",
+//  					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+//  					CloseTimestamp: "(timestamp: nil Timestamp)",
+//  				},
+//  			},
+//  			// TODO UDP listening endpoints should be reported
+//  			ExpectedEndpoints: nil,
+//  		},
+//  		Client: suites.Container{
+//  			Name: "socat-client-0",
+//  			Cmd:  "echo hello | socat -d -d -v - UDP4-DATAGRAM:SERVER_IP:5143 &> /socat-log.txt",
+//  			ExpectedNetwork: []common.NetworkInfo{
+//  				{
+//  					LocalAddress:   "",
+//  					RemoteAddress:  "",
+//  					Role:           "ROLE_CLIENT",
+//  					SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+//  					CloseTimestamp: "(timestamp: nil Timestamp)",
+//  				},
+//  			},
+//  			ExpectedEndpoints: []common.EndpointInfo{
+//  				{
+//  					Protocol: "L4_PROTOCOL_UDP",
+//  					Address: &common.ListenAddress{
+//  						AddressData: `"\000\000\000\001"`,
+//  						Port:        5143,
+//  						IpNetwork:   `"\000\000\000\000 " `,
+//  					},
+//  				},
+//  			},
+//  		},
+//  	}
+//
+//  	suite.Run(t, socatTest)
+//  }


### PR DESCRIPTION
## Description

When the following commands are run in two different docker containers

```
socat -d -d -v UDP4-RECVFROM:5143,fork - &> /socat-log.txt &
echo hello | socat -d -d -v - UDP4-DATAGRAM:SERVER_IP:5143 &> /socat-log.txt
```
the message hello is sent, but collector does not report any connection. This PR adds an integration test for this case.

## Checklist
- [ ] Investigated and inspected CI test results

**Automated testing**
  - [ ] Added integration tests

## Testing Performed

CI is sufficient
