### PR TITLE
ROX-14231: Enable building Oracle Linux 7 kernels

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
       - name: Create a mock cache
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
         run: |
@@ -139,6 +142,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Authenticate with GCP
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
 
       - name: Restore tasks and sources
         uses: actions/download-artifact@v3

--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -60,10 +60,6 @@
 4.18.0-372.9.1.rt7.166.el8.x86_64 * mod
 # We no longer support docker desktop as a dev environment
 *-dockerdesktop-*
-# Oracle Linux kernel modules require `libdtrace-ctf`,
-# which is unavailable in UBI/RHEL, we could add a
-# dedicated builder if need be
-*.el7uek.* * mod
 6.2.* 2.3.0 *
 6.2.* 2.2.0 *
 6.2.* 2.1.0 *

--- a/kernel-modules/build/kernel-splitter.py
+++ b/kernel-modules/build/kernel-splitter.py
@@ -107,11 +107,13 @@ class ModBuilder(Builder):
 
 
 def main(task_file):
+    oracle_kernels = r"(?:.*el7uek.*)"
     fc36_kernels = r"(?:(?:5\.[1-9]\d+\..*)|(:?[6-9]\.\d+\..*))"
     rhel8_kernels = r"(?:(?:4|5)\.\d+\..*)"
     rhel7_kernels = r"(?:3\.\d+\..*)"
     rhel7_ebpf_kernels = r"(?:(?:3|4|5)\.\d+\..*)"
 
+    oracle = Builder("oracle", rf"^{oracle_kernels}", {})
     fc36 = Builder("fc36", rf"^{fc36_kernels}", {})
     rhel7_ebpf = EBPFBuilder("rhel7", rf"^{rhel7_ebpf_kernels}", {})
     rhel8 = Builder("rhel8", rf"^{rhel8_kernels}", {})
@@ -119,6 +121,7 @@ def main(task_file):
     unknown = Builder("unknown", r".*", {})
 
     builders = [
+        oracle,
         fc36,
         rhel7_ebpf,
         rhel8,
@@ -148,12 +151,14 @@ def main(task_file):
 
     driver_builders = int(os.environ.get('DRIVER_BUILDERS', 1))
 
+    oracle_builders = oracle.split(driver_builders)
     rhel8_builders = rhel8.split(driver_builders)
     rhel7_ebpf_builders = rhel7_ebpf.split(driver_builders)
     rhel7_builders = rhel7.split(driver_builders)
     fc36_builders = fc36.split(driver_builders)
 
     builders = [
+        *oracle_builders,
         *fc36_builders,
         *rhel8_builders,
         *rhel7_ebpf_builders,

--- a/kernel-modules/build/oracle.Dockerfile
+++ b/kernel-modules/build/oracle.Dockerfile
@@ -1,0 +1,20 @@
+FROM oraclelinux:7
+
+RUN yum -y update && yum -y install yum-utils && \
+    yum-config-manager --enable ol7_UEKR6 && \
+    yum -y install \
+    gcc \
+    gcc-c++ \
+    autoconf \
+    make \
+    cmake \
+    libdtrace-ctf \
+    elfutils-libelf-devel && \
+    yum-config-manager --add-repo=http://yum.oracle.com/public-yum-ol7.repo && \
+    yum-config-manager --enable ol7_developer --enable ol7_developer_EPEL && \
+    yum install -y rh-dotnet20-clang rh-dotnet20-llvm
+
+COPY build-kos /scripts/
+COPY build-wrapper.sh /scripts/compile.sh
+
+ENTRYPOINT ["scl", "enable", "rh-dotnet20", "/scripts/compile.sh"]


### PR DESCRIPTION
## Description

Before migrating to OSCI, we used to support building OL7UEK5 kernels, we had to get rid of this due to the unavailability of the image we used for the builder in that system. Since we are now building drivers on GHA and we don't have the limitation for the image, we should be able to support it again.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Ensure crawled kernels for OL7 UEK5 and 6 build drivers correctly.