### PR TITLE
Bumps download interval and timeouts

### DIFF
--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -40,8 +40,9 @@ extern "C" {
 
 namespace collector {
 
-const int kNumDownloadRetries = 90;
-const int kMaxDownloadRetriesTime = 90;
+const int kMaxDownloadRetriesTime = 180;
+const int kMaxDownloadRetriesInterval = 5;
+const int kNumDownloadRetries = kMaxDownloadRetriesTime / kMaxDownloadRetriesInterval;
 
 bool DownloadKernelObjectFromURL(FileDownloader& downloader, const std::string& base_url, const std::string& kernel_module, const std::string& module_version) {
   std::string url(base_url + "/" + module_version + "/" + kernel_module + ".gz");
@@ -114,7 +115,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
   }
 
   downloader.IPResolve(FileDownloader::ANY);
-  downloader.SetRetries(kNumDownloadRetries, 1, kMaxDownloadRetriesTime);
+  downloader.SetRetries(kNumDownloadRetries, kMaxDownloadRetriesInterval, kMaxDownloadRetriesTime);
   downloader.SetVerboseMode(verbose);
   downloader.OutputFile(compressed_module_path);
   if (!downloader.SetConnectionTimeout(2)) return false;
@@ -131,7 +132,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
 
   downloader.ResetCURL();
   downloader.IPResolve(FileDownloader::ANY);
-  downloader.SetRetries(kNumDownloadRetries, 1, kMaxDownloadRetriesTime);
+  downloader.SetRetries(kNumDownloadRetries, kMaxDownloadRetriesInterval, kMaxDownloadRetriesTime);
   downloader.SetVerboseMode(verbose);
   downloader.OutputFile(compressed_module_path);
   if (!downloader.SetConnectionTimeout(2)) return false;


### PR DESCRIPTION
## Description

To improve start up robustness, the time out and interval for kernel driver downloads is increased:

- interval (1 second -> 5 seconds)
- Maximum timeout (90 seconds -> 3 minutes)
- Maximum attempts (90 -> 36)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally and observed correct timeout / interval behavior. 
