### PR TITLE
Auto cancel concurrent jobs in PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   init:
     uses: ./.github/workflows/init.yml


### PR DESCRIPTION
## Description

When working in PRs, we some times need to iterate fast and that means pushing multiple times to a branch. This causes CI to be triggered multiple times and we may need to cancel previous runs manually. This small change makes it so previous CI jobs are cancelled when a new commit is pushed to a PR (pushes to master and scheduled workflows should be unaffected).

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency for more information.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed
- [ ] Try pushing several commits so CI cancels properly.