### PR TITLE
Add missing file command to Oracle builder

### DIFF
--- a/kernel-modules/build/oracle-entrypoint.sh
+++ b/kernel-modules/build/oracle-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-exec scl enable rh-dotnet20 -- "$@"

--- a/kernel-modules/build/oracle.Dockerfile
+++ b/kernel-modules/build/oracle.Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y update && yum -y install yum-utils && \
     gcc \
     gcc-c++ \
     autoconf \
+    file \
     make \
     cmake \
     libdtrace-ctf \


### PR DESCRIPTION
## Description

The command is needed for some legacy probes.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Run CI with the `build-legacy-probes` label.
