### PR TITLE
Jv rox 17099 add gperftools library to the collector image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,7 @@
 	path = third_party/libbpf
 	url = https://github.com/libbpf/libbpf
 	branch = v1.1.0
+[submodule "third_party/gperftools"]
+	path = third_party/gperftools
+	url = https://github.com/gperftools/gperftools
+	branch = master

--- a/builder/install/00-gperftools.sh
+++ b/builder/install/00-gperftools.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd third_party/gperftools
+
+./autogen.sh
+./configure
+make
+make install

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -64,7 +64,7 @@ add_executable(collector collector.cpp)
 target_link_libraries(collector collector_lib)
 
 if(NOT DEFINED ENV{DISABLE_PROFILING})
-	target_link_libraries(collector profiler tcmalloc)
+	target_link_libraries(collector libprofiler.a libtcmalloc.a)
 endif()
 
 target_link_libraries(collector libprometheus-cpp-pull.a)

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-de
 set(CMAKE_CXX_FLAGS_DEBUG "-g -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fno-strict-aliasing -DNDEBUG")
 
-if(NOT DEFINED ENV{DISABLE_PROFILING})
+if(NOT DEFINED ENV{DISABLE_PROFILING} OR NOT "$ENV{DISABLE_PROFILING}")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOLLECTOR_PROFILING")
 endif()
 
@@ -63,7 +63,7 @@ target_link_libraries(collector_lib z ssl crypto curl bpf)
 add_executable(collector collector.cpp)
 target_link_libraries(collector collector_lib)
 
-if(NOT DEFINED ENV{DISABLE_PROFILING})
+if(NOT DEFINED ENV{DISABLE_PROFILING} OR NOT "$ENV{DISABLE_PROFILING}")
 	target_link_libraries(collector libprofiler.a libtcmalloc.a)
 endif()
 
@@ -82,7 +82,7 @@ enable_testing()
 file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cpp)
 add_executable(runUnitTests ${TEST_SRC_FILES})
 
-if(NOT DEFINED ENV{DISABLE_PROFILING} AND (NOT DEFINED ENV{USE_VALGRIND} OR NOT "$ENV{USE_VALGRIND}"))
+if((NOT DEFINED ENV{DISABLE_PROFILING} OR NOT "$ENV{DISABLE_PROFILING}") AND (NOT DEFINED ENV{USE_VALGRIND} OR NOT "$ENV{USE_VALGRIND}"))
 	target_link_libraries(runUnitTests profiler tcmalloc)
 endif()
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -27,7 +27,7 @@ cmake-build/collector: $(COLLECTOR_BUILD_DEPS)
 		-e USE_VALGRIND=$(USE_VALGRIND) \
 		-e ADDRESS_SANITIZER=$(ADDRESS_SANITIZER) \
 		-e COLLECTOR_APPEND_CID=$(COLLECTOR_APPEND_CID) \
-		-e DISABLE_PROFILING="true" \
+		-e DISABLE_PROFILING=$(DISABLE_PROFILING) \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) "$(SRC_MOUNT_DIR)/builder/build/build-collector.sh"
 
 container/bin/collector: cmake-build/collector

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -27,7 +27,7 @@ cmake-build/collector: $(COLLECTOR_BUILD_DEPS)
 		-e USE_VALGRIND=$(USE_VALGRIND) \
 		-e ADDRESS_SANITIZER=$(ADDRESS_SANITIZER) \
 		-e COLLECTOR_APPEND_CID=$(COLLECTOR_APPEND_CID) \
-		-e DISABLE_PROFILING=false \
+		-e DISABLE_PROFILING="false" \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) "$(SRC_MOUNT_DIR)/builder/build/build-collector.sh"
 
 container/bin/collector: cmake-build/collector

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -27,7 +27,7 @@ cmake-build/collector: $(COLLECTOR_BUILD_DEPS)
 		-e USE_VALGRIND=$(USE_VALGRIND) \
 		-e ADDRESS_SANITIZER=$(ADDRESS_SANITIZER) \
 		-e COLLECTOR_APPEND_CID=$(COLLECTOR_APPEND_CID) \
-		-e DISABLE_PROFILING=$(DISABLE_PROFILING) \
+		-e DISABLE_PROFILING=false \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) "$(SRC_MOUNT_DIR)/builder/build/build-collector.sh"
 
 container/bin/collector: cmake-build/collector

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -100,7 +100,16 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     driver = std::make_unique<KernelDriverCOREEBPF>(KernelDriverCOREEBPF());
   }
 
-  if (!driver->Setup(config, *inspector_)) {
+  bool driver_success = false;
+  for (int i = 0; i < 5; i++) {
+    if (driver->Setup(config, *inspector_)) {
+      driver_success = true;
+      break;
+    } else if (i < 4) {
+      CLOG(WARNING) << "Failed to setup " << candidate.GetName() << ". Trying again.";
+    }
+  }
+  if (!driver_success) {
     CLOG(ERROR) << "Failed to setup " << candidate.GetName();
     return false;
   }

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -79,7 +79,7 @@ func TestRepeatedNetworkFlowThreeCurlsNoAfterglow(t *testing.T) {
 // endpoints opened before collector is turned on. There is another test
 // in which scraping is turned off and we expect that we will not see
 // endpoint opened before collector is turned on.
-func TestProcfsScraper(t *testing.T) {
+func TestProcfsScraperEnabled(t *testing.T) {
 	connScraperTestSuite := &suites.ProcfsScraperTestSuite{
 		TurnOffScrape:               false,
 		RoxProcessesListeningOnPort: true,

--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -45,6 +45,7 @@ func NewCollectorManager(e Executor, name string) *CollectorManager {
 		"COLLECTION_METHOD":       collectionMethod,
 		"COLLECTOR_PRE_ARGUMENTS": collectorPreArguments,
 		"ENABLE_CORE_DUMP":        "false",
+		"CPUPROFILE":              "/tmp/collector.prof",
 	}
 	if !offlineMode {
 		env["MODULE_DOWNLOAD_BASE_URL"] = "https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656"

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -38,10 +38,10 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(10 * time.Second)
+	time.Sleep(100 * time.Second)
 
 	s.cleanupContainer([]string{"nginx"})
-	time.Sleep(10 * time.Second)
+	time.Sleep(100 * time.Second)
 
 	err = s.collector.TearDown()
 	s.Require().NoError(err)

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -38,10 +38,10 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 
 	err = s.collector.Launch()
 	s.Require().NoError(err)
-	time.Sleep(100 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	s.cleanupContainer([]string{"nginx"})
-	time.Sleep(100 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	err = s.collector.TearDown()
 	s.Require().NoError(err)

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -35,9 +35,6 @@ func (s *SocatTestSuite) SetupSuite() {
 
 	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
 	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
-	s.collector.Env["COLLECTION_METHOD"] = "ebpf"
-	s.collector.Env["HEAPCHECK"] = "normal"
-	s.collector.Env["HEAPPROFILE"] = "/tmp/collector.heap"
 
 	err := s.collector.Setup()
 	s.Require().NoError(err)

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -35,6 +35,9 @@ func (s *SocatTestSuite) SetupSuite() {
 
 	s.collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
 	s.collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
+	s.collector.Env["COLLECTION_METHOD"] = "ebpf"
+	s.collector.Env["HEAPCHECK"] = "normal"
+	s.collector.Env["HEAPPROFILE"] = "/tmp/collector.heap"
 
 	err := s.collector.Setup()
 	s.Require().NoError(err)


### PR DESCRIPTION
## Description

The builder install gperftools and that is linked to collector when it is built.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Used gperftools on collector
- [x] Ran locally with DISABLE_PROFILING=true
- [x] Ran locally without setting DISABLE_PROFILING
- [x] Rand locally with DISABLE_PROFILING=false

## Testing Performed

See above
