### PR TITLE
Minor logging reorder for clarity of collection method behavior

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -152,6 +152,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
     if (args->GetCollectionMethod().length() > 0) {
       const auto& cm = args->GetCollectionMethod();
 
+      CLOG(INFO) << "User configured collection-method=" << cm;
       if (cm == "ebpf") {
         collection_method_ = EBPF;
       } else if (cm == "core_bpf") {
@@ -160,8 +161,6 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
         CLOG(WARNING) << "Invalid collection-method (" << cm << "), using eBPF";
         collection_method_ = EBPF;
       }
-
-      CLOG(INFO) << "User configured collection-method=" << cm;
     }
 
     if (!config["tlsConfig"].empty()) {


### PR DESCRIPTION
## Description

Currently, the logs can be slightly confusing when switching from kernel-module to ebpf collection (post removal of kernel module collection):

```
[WARNING ...] Invalid collection-method (kernel_module), using eBPF
[INFO ...  ] User configured collection-method=kernel_module
```

This is slightly confusing and implies that kernel_module is still being used.

This PR reverses the order to make the behavior clearer.

```
[INFO ...   ] User configured collection-method=kernel_module
[WARNING ...] Invalid collection-method (kernel_module), using eBPF
```
