### PR TITLE
Improves logging in driver builds

### DIFF
--- a/kernel-modules/build/build-kos
+++ b/kernel-modules/build/build-kos
@@ -97,6 +97,8 @@ build_ko() (
         if [[ -d "${module_src_dir}/collector-probe" ]]; then
             collector_probe="${module_src_dir}/collector-probe/probe.o"
             probe_dir="${module_src_dir}/collector-probe"
+            # minor verification of probe directory
+            ls -alh "$probe_dir"
         fi
 
         echo "Building collector eBPF probe for kernel version ${kernel_version} and module version ${module_version}."

--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -43,7 +43,9 @@ archive_dockerized() {
             cp collector-probe/*.c collector-probe/*.h collector-probe/Makefile "$source_archive"/collector-probe
         fi
         echo "Driver source archive - $source_archive"
-        ls -alh "$source_archive"
+        # recursive ls to verify contents of all files in the archive
+        # (specifically collector_probe/)
+        ls -Ralh "$source_archive"
     else
         echo "Duplicate version '${module_version}' detected, skipping..."
     fi


### PR DESCRIPTION
## Description

Improvement to logging of driver build directories to have better visibility on source files, following prepare-src / compile commands. Specifically to help investigate midstream failures. 