### PR TITLE
Use a scoped enumeration for CollectionMethod

### DIFF
--- a/collector/lib/CollectionMethod.cpp
+++ b/collector/lib/CollectionMethod.cpp
@@ -21,20 +21,19 @@ You should have received a copy of the GNU General Public License along with thi
 * version.
 */
 
-#ifndef COLLECTION_METHOD_H
-#define COLLECTION_METHOD_H
-
-#include <ostream>
+#include "CollectionMethod.h"
 
 namespace collector {
-enum class CollectionMethod : uint8_t {
-  EBPF = 0,
-  CORE_BPF,
 
-};
-
-std::ostream& operator<<(std::ostream& os, CollectionMethod method);
+std::ostream& operator<<(std::ostream& os, CollectionMethod method) {
+  switch (method) {
+    case CollectionMethod::EBPF:
+      return os << "ebpf";
+    case CollectionMethod::CORE_BPF:
+      return os << "core_bpf";
+    default:
+      return os << "unknown(" << static_cast<uint8_t>(method) << ")";
+  }
+}
 
 }  // namespace collector
-
-#endif  // COLLECTION_METHOD_H

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -154,12 +154,12 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
 
       CLOG(INFO) << "User configured collection-method=" << cm;
       if (cm == "ebpf") {
-        collection_method_ = EBPF;
+        collection_method_ = CollectionMethod::EBPF;
       } else if (cm == "core_bpf") {
-        collection_method_ = CORE_BPF;
+        collection_method_ = CollectionMethod::CORE_BPF;
       } else {
         CLOG(WARNING) << "Invalid collection-method (" << cm << "), using eBPF";
-        collection_method_ = EBPF;
+        collection_method_ = CollectionMethod::EBPF;
       }
     }
 
@@ -228,7 +228,7 @@ bool CollectorConfig::UseChiselCache() const {
 
 bool CollectorConfig::UseEbpf() const {
   CollectionMethod cm = GetCollectionMethod();
-  return (cm == EBPF || cm == CORE_BPF);
+  return (cm == CollectionMethod::EBPF || cm == CollectionMethod::CORE_BPF);
 }
 
 bool CollectorConfig::TurnOffScrape() const {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -44,7 +44,7 @@ class CollectorConfig {
   static constexpr bool kUseChiselCache = true;
   static constexpr bool kTurnOffScrape = false;
   static constexpr int kScrapeInterval = 30;
-  static constexpr CollectionMethod kCollectionMethod = EBPF;
+  static constexpr CollectionMethod kCollectionMethod = CollectionMethod::EBPF;
   static constexpr const char* kSyscalls[] = {
       "accept",
       "chdir",

--- a/collector/lib/DriverCandidates.cpp
+++ b/collector/lib/DriverCandidates.cpp
@@ -53,7 +53,7 @@ std::optional<DriverCandidate> getUbuntuBackport(HostInfo& host) {
     if (kernel.version.find(candidate) != std::string::npos) {
       std::string backport = kernel.release + candidate;
       std::string name = driverFullName(backport);
-      return DriverCandidate(std::move(name), EBPF);
+      return DriverCandidate(std::move(name), CollectionMethod::EBPF);
     }
   }
 
@@ -80,7 +80,7 @@ std::optional<DriverCandidate> getGardenLinuxCandidate(HostInfo& host) {
   std::string shortName = kernel.release + "-gl-" + match.str();
   std::string name = driverFullName(shortName);
 
-  return DriverCandidate(name, EBPF);
+  return DriverCandidate(name, CollectionMethod::EBPF);
 }
 
 // The kvm driver for minikube uses a custom kernel built from
@@ -99,7 +99,7 @@ std::optional<DriverCandidate> getMinikubeCandidate(HostInfo& host) {
 
   std::string shortName = kernel.ShortRelease() + "-minikube-" + minikube_version;
   std::string name = driverFullName(shortName);
-  return DriverCandidate(name, EBPF);
+  return DriverCandidate(name, CollectionMethod::EBPF);
 }
 
 // Normalizes this host's release string into something collector can use
@@ -140,24 +140,24 @@ std::string normalizeReleaseString(HostInfo& host) {
 }
 
 DriverCandidate getCoreBpfCandidate() {
-  return DriverCandidate("CO.RE eBPF probe", CORE_BPF, false);
+  return DriverCandidate("CO.RE eBPF probe", CollectionMethod::CORE_BPF, false);
 }
 
 DriverCandidate getHostCandidate(HostInfo& host) {
   std::string hostCandidate = normalizeReleaseString(host);
   std::string hostCandidateFullName = driverFullName(hostCandidate);
 
-  return DriverCandidate(hostCandidateFullName, EBPF);
+  return DriverCandidate(hostCandidateFullName, CollectionMethod::EBPF);
 }
 
 DriverCandidate getUserDriverCandidate(const char* full_name) {
   std::filesystem::path driver_file(full_name);
 
   if (driver_file.is_absolute()) {
-    return DriverCandidate(driver_file.filename(), EBPF, false, driver_file.parent_path());
+    return DriverCandidate(driver_file.filename(), CollectionMethod::EBPF, false, driver_file.parent_path());
   }
 
-  return DriverCandidate(driver_file, EBPF, false);
+  return DriverCandidate(driver_file, CollectionMethod::EBPF, false);
 }
 }  // namespace
 
@@ -170,7 +170,7 @@ std::vector<DriverCandidate> GetKernelCandidates(CollectionMethod cm) {
 
     for (const auto& candidate_name : SplitStringView(sview)) {
       std::string name = driverFullName(candidate_name);
-      candidates.emplace_back(std::move(name), EBPF);
+      candidates.emplace_back(std::move(name), CollectionMethod::EBPF);
     }
 
     return candidates;
@@ -181,7 +181,7 @@ std::vector<DriverCandidate> GetKernelCandidates(CollectionMethod cm) {
     candidates.push_back(getUserDriverCandidate(user_driver));
   }
 
-  if (cm == CORE_BPF) {
+  if (cm == CollectionMethod::CORE_BPF) {
     candidates.push_back(getCoreBpfCandidate());
   }
 

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -145,7 +145,7 @@ bool DownloadKernelObject(const std::string& hostname, const Json::Value& tls_co
 }
 
 bool GetKernelObject(const std::string& hostname, const Json::Value& tls_config, const DriverCandidate& candidate, bool verbose) {
-  if (candidate.GetCollectionMethod() == CORE_BPF) {
+  if (candidate.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
     // for now CO.RE bpf probes are embedded in the collector binary, nothing
     // to do here.
     return true;
@@ -153,7 +153,7 @@ bool GetKernelObject(const std::string& hostname, const Json::Value& tls_config,
 
   std::string expected_path = candidate.GetPath() + "/" + candidate.GetName();
   std::string expected_path_compressed = expected_path + ".gz";
-  std::string module_path = candidate.GetCollectionMethod() == EBPF ? SysdigService::kProbePath : SysdigService::kModulePath;
+  std::string module_path = candidate.GetCollectionMethod() == CollectionMethod::EBPF ? SysdigService::kProbePath : SysdigService::kModulePath;
   struct stat sb;
 
   // first check for an existing compressed kernel object in the

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -42,7 +42,7 @@ class CollectionHeuristic : public Heuristic {
   void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
     // If we're configured to use eBPF with BTF, we try to be conservative
     // and fail instead of falling-back to other methods.
-    if (config.GetCollectionMethod() == CORE_BPF) {
+    if (config.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
       if (!host.HasEBPFSupport()) {
         CLOG(FATAL) << host.GetDistro() << " " << host.GetKernelVersion().release
                     << " does not support eBPF, which is a requirement for core_bpf collection.";
@@ -72,7 +72,7 @@ class CollectionHeuristic : public Heuristic {
     // does not support it, we can try to use kernel modules instead.
     // The exception to this is COS, where third party modules are not
     // supported, so there is nothing we can do and must exit.
-    if ((config.GetCollectionMethod() == EBPF) && !host.HasEBPFSupport()) {
+    if ((config.GetCollectionMethod() == CollectionMethod::EBPF) && !host.HasEBPFSupport()) {
       CLOG(FATAL) << host.GetDistro() << " " << host.GetKernelVersion().release
                   << " does not support ebpf based collection.";
     }

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -94,9 +94,9 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
   }
 
   std::unique_ptr<IKernelDriver> driver;
-  if (candidate.GetCollectionMethod() == EBPF) {
+  if (candidate.GetCollectionMethod() == CollectionMethod::EBPF) {
     driver = std::make_unique<KernelDriverEBPF>(KernelDriverEBPF());
-  } else if (candidate.GetCollectionMethod() == CORE_BPF) {
+  } else if (candidate.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
     driver = std::make_unique<KernelDriverCOREEBPF>(KernelDriverCOREEBPF());
   }
 

--- a/collector/test/DriverCandidatesTest.cpp
+++ b/collector/test/DriverCandidatesTest.cpp
@@ -62,7 +62,7 @@ TEST(getGardenLinuxCandidateTest, Garden576_1) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate->GetCollectionMethod(), CollectionMethod::EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -81,7 +81,7 @@ TEST(getGardenLinuxCandidateTest, Garden318) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate->GetCollectionMethod(), CollectionMethod::EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -102,7 +102,7 @@ TEST(getMinikubeCandidateTest, v1_27_1) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate->GetCollectionMethod(), CollectionMethod::EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -123,7 +123,7 @@ TEST(getMinikubeCandidateTest, v1_24_0) {
   EXPECT_TRUE(candidate);
   EXPECT_EQ(candidate->GetName(), expected_driver);
   EXPECT_EQ(candidate->GetPath(), expected_path);
-  EXPECT_EQ(candidate->GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate->GetCollectionMethod(), CollectionMethod::EBPF);
   EXPECT_TRUE(candidate->IsDownloadable());
 }
 
@@ -151,7 +151,7 @@ TEST(getUserDriverCandidate, RelativePath) {
   EXPECT_EQ(candidate.GetName(), expected_name);
   EXPECT_EQ(candidate.GetPath(), expected_path);
   EXPECT_FALSE(candidate.IsDownloadable());
-  EXPECT_EQ(candidate.GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate.GetCollectionMethod(), CollectionMethod::EBPF);
 }
 
 TEST(getUserDriverCandidate, FullPath) {
@@ -164,7 +164,7 @@ TEST(getUserDriverCandidate, FullPath) {
   EXPECT_EQ(candidate.GetName(), expected_name);
   EXPECT_EQ(candidate.GetPath(), expected_path);
   EXPECT_FALSE(candidate.IsDownloadable());
-  EXPECT_EQ(candidate.GetCollectionMethod(), EBPF);
+  EXPECT_EQ(candidate.GetCollectionMethod(), CollectionMethod::EBPF);
 }
 
 TEST(normalizeReleaseStringTest, FedoraKernel) {


### PR DESCRIPTION
## Description

This avoids name conflicts by scoping the collector-method identifiers, and eases the conversion to strings.

## Checklist
- [ ] Investigated and inspected CI test results

fixes: #1157 