### PR TITLE
Fixes copy command in prepare-src

### DIFF
--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -40,7 +40,7 @@ archive_dockerized() {
         cp bpf/*.c bpf/*.h bpf/Makefile "$source_archive"/bpf
         if [[ -d "./collector-probe" ]]; then
             mkdir "$source_archive"/collector-probe
-            cp collector-probe/*.c collector-probe/*.h collector-probe/Makefile "$source_archive"/collector-probe
+            cp collector-probe/*.{c,h} collector-probe/Makefile "$source_archive"/collector-probe
         fi
         echo "Driver source archive - $source_archive"
         # recursive ls to verify contents of all files in the archive


### PR DESCRIPTION
## Description

Fixes the prepare-src script when copying probe source files into the necessary locations. The current wildcard fails when collector_probe.h doesn't exist (for legacy module versions) but the new one will succeed even when there are no headers. 

## Testing Performed

Tested locally
