### PR TITLE
Convert cp command to more robust find + cp in prepare-src

### DIFF
--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -40,7 +40,9 @@ archive_dockerized() {
         cp bpf/*.c bpf/*.h bpf/Makefile "$source_archive"/bpf
         if [[ -d "./collector-probe" ]]; then
             mkdir "$source_archive"/collector-probe
-            cp collector-probe/*.{c,h} collector-probe/Makefile "$source_archive"/collector-probe
+            find collector-probe -type f \
+                \( -name 'Makefile' -o -name '*.c' -o -name '*.h' \) \
+                -exec cp '{}' "$source_archive"/collector-probe \;
         fi
         echo "Driver source archive - $source_archive"
         # recursive ls to verify contents of all files in the archive


### PR DESCRIPTION
## Description

The previous fix did not behave correctly on all shells, so this replaces the command with a crafted `find` version, which handles the expected differences between module versions.