### PR TITLE
Automatic update of RELEASED_VERSIONS file for Rox release 3.73.5

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -18,3 +18,4 @@
 3.14.1 4.0.0  # Rox release 4.0.0 by roxbot at Mon Apr 24 14:37:58 UTC 2023
 3.13.1 3.74.3  # Rox release 3.74.3 by roxbot at Tue May  2 08:12:18 UTC 2023
 3.14.1 4.0.1  # Rox release 4.0.1 by roxbot at Mon May 15 13:24:01 UTC 2023
+3.12.4 3.73.5  # Rox release 3.73.5 by roxbot at Wed May 31 08:01:12 UTC 2023


### PR DESCRIPTION
Add entry into the RELEASED_VERSIONS file

--
The changes were generated automatically.
This PR was created manually, because on 3.73 stream we still used the (broken) OSCI automation to create the PR. 