### PR TITLE
Disable the import-users flag

### DIFF
--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -91,6 +91,8 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     if (logging::GetLogLevel() == logging::LogLevel::TRACE) {
       inspector_->set_log_stderr();
     }
+
+    inspector_->set_import_users(false);
   }
 
   std::unique_ptr<IKernelDriver> driver;


### PR DESCRIPTION

## Description

When the CRI is not available, the containers are never declared destroyed; and the user-manager keeps user information forever.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

The memory allocation growth can be accelerated with:
```
while true; do kubectl run temp -i -t --image=debian:bookworm --rm --restart=Never --command -- sleep 1; done
```
