### PR TITLE
New environment variable for control set_import_users()

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -57,6 +57,8 @@ BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", C
 
 BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", true);
 
+BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kUseChiselCache;
@@ -79,6 +81,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   collection_method_ = kCollectionMethod;
   enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
   core_bpf_hardfail_ = core_bpf_hardfail.value();
+  import_users_ = set_import_users.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);
@@ -282,7 +285,8 @@ std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
          << ", turn_off_scrape:" << c.TurnOffScrape()
          << ", hostname:" << c.Hostname()
          << ", processesListeningOnPorts:" << c.IsProcessesListeningOnPortsEnabled()
-         << ", logLevel:" << c.LogLevel();
+         << ", logLevel:" << c.LogLevel()
+         << ", set_import_users:" << c.ImportUsers();
 }
 
 }  // namespace collector

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -107,6 +107,7 @@ end
   Json::Value TLSConfiguration() const { return tls_config_; }
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
   bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
+  bool ImportUsers() const { return import_users_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -130,6 +131,7 @@ end
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
   bool core_bpf_hardfail_;
+  bool import_users_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -92,7 +92,7 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
       inspector_->set_log_stderr();
     }
 
-    inspector_->set_import_users(false);
+    inspector_->set_import_users(config.ImportUsers());
   }
 
   std::unique_ptr<IKernelDriver> driver;


### PR DESCRIPTION
## Description

ROX_COLLECTOR_SET_IMPORT_USERS defaults to false, and is used to configure sinsp and its user-mgmt subsystem.

This is intended as a safeguard in case we would need to reenable it; and was deactivated to circumvent a memory management issue (CRI not available => containers never freed in user.cpp)
A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Setting the env var changes the config and can be seen in the logs