### PR TITLE
Jv mock grpc server should report multiple connections

### DIFF
--- a/integration-tests/images.yml
+++ b/integration-tests/images.yml
@@ -1,5 +1,5 @@
 images:
-  grpc-server: quay.io/rhacs-eng/grpc-server:3.73.x-95-gd43176a427
+  grpc-server: quay.io/rhacs-eng/grpc-server:4.0.x-658-g2922c23f34
 
   performance-phoronix: quay.io/rhacs-eng/collector-performance:phoronix
   performance-json-label: quay.io/rhacs-eng/collector-performance:json-label

--- a/integration-tests/suites/connections-and-endpoints.go
+++ b/integration-tests/suites/connections-and-endpoints.go
@@ -132,8 +132,8 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 		}
 		lastNetwork := serverNetworks[nNetwork-1]
 		lastExpectedNetwork := s.Server.ExpectedNetwork[nExpectedNetwork-1]
-		expectedLocalAddress := strings.Replace(lastExpectedNetwork.LocalAddress, "CLIENT_IP", s.Server.IP, -1)
-		expectedRemoteAddress := strings.Replace(lastExpectedNetwork.RemoteAddress, "SERVER_IP", s.Server.IP, -1)
+		expectedLocalAddress := strings.Replace(lastExpectedNetwork.LocalAddress, "SERVER_IP", s.Server.IP, -1)
+		expectedRemoteAddress := strings.Replace(lastExpectedNetwork.RemoteAddress, "CLIENT_IP", s.Client.IP, -1)
 		assert.Equal(s.T(), expectedLocalAddress, lastNetwork.LocalAddress)
 		assert.Equal(s.T(), expectedRemoteAddress, lastNetwork.RemoteAddress)
 		assert.Equal(s.T(), "ROLE_SERVER", lastNetwork.Role)

--- a/integration-tests/suites/connections-and-endpoints.go
+++ b/integration-tests/suites/connections-and-endpoints.go
@@ -98,7 +98,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 		s.Require().NoError(err)
 		nNetwork := len(clientNetworks)
 		nExpectedNetwork := len(s.Client.ExpectedNetwork)
-		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection
+		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection. https://issues.redhat.com/browse/ROX-17964
 		// assert.Equal(s.T(), nClientNetwork, nExpectedClientNetwork)
 		if nExpectedNetwork != nNetwork {
 			fmt.Println("WARNING: Expected " + strconv.Itoa(nExpectedNetwork) + " client network connections but found " + strconv.Itoa(nNetwork))
@@ -125,7 +125,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 		s.Require().NoError(err)
 		nNetwork := len(serverNetworks)
 		nExpectedNetwork := len(s.Server.ExpectedNetwork)
-		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection
+		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection. https://issues.redhat.com/browse/ROX-18803
 		// assert.Equal(s.T(), nServerNetwork, nExpectedServerNetwork)
 		if nExpectedNetwork != nNetwork {
 			fmt.Println("WARNING: Expected " + strconv.Itoa(nExpectedNetwork) + " server network connections but found " + strconv.Itoa(nNetwork))


### PR DESCRIPTION
## Description

Currently the mock grpc server only reports the latest connection that it sees for each container. We should have tests were multiple connections are seen per container. We should also make sure that when we expect to see one connection reported for a container, that there is only one connection for that container and not multiple connections. This PR updates the mock grpc server image to one that reports multiple connections per container and makes changes to the integration tests so that they get an array of connections rather than just a string representing one connection. Currently asserting that we see the expected number of connection and that all of the connections are ones that we expect to see causes many of the tests to become flaky or fail. For now we just do logging when the expected number of connections does not match with the actual number of connections and compare just the last connection that we see with the last expected connection. This will be fixed in a future PR. repeated_network_flow.go was already looking at multiple connections per container, by reading the grpc server logs, and this method of getting the connections was not changed for it.

See the corresponding PR in stackrox/stackrox https://github.com/stackrox/stackrox/pull/6308

## Checklist
- [x] Investigated and inspected CI test results
- [x] Ran integration tests locally

## Testing Performed

Ran integration tests locally. Ran the following script for a couple of hours

#!/usr/bin/env bash
set -eou pipefail

while true; do
        sudo make -C integration-tests TestConnectionsAndEndpointsNormal COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsHighLowPorts COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsServerHigh COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsSourcePort COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsUDPNormal COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsUDPNoReuseaddr COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        sudo make -C integration-tests TestConnectionsAndEndpointsUDPNoFork COLLECTOR_TAG=3.15.x-92-g26a65a7bdf
        echo 
        echo 
        echo 
        echo 
done

Also ran `make` and `sudo make -C integration-tests TestRepeatedNetworkFlow` a few times.

## Future work

Change the existing tests so that they have asserts on all expected connections and the number of expected connections. A couple of Jira tickets were created for this


https://issues.redhat.com/browse/ROX-17964
https://issues.redhat.com/browse/ROX-18803