### PR TITLE
Removes kmod development builds

### DIFF
--- a/kernel-modules/Makefile
+++ b/kernel-modules/Makefile
@@ -50,6 +50,7 @@ drivers: build-container-$(DEV_DRIVER_BUILDER)
 		-v $(DEV_SHARED_VOLUME):/collector \
 		-v /lib/modules/:/lib/modules/:ro \
 		-v /usr/src:/usr/src:ro \
+		-e BUILD_KERNEL_MODULE \
 		build-kernel-modules-$(DEV_DRIVER_BUILDER):latest \
 		-c /collector/kernel-modules/dev/build-drivers.sh
 

--- a/kernel-modules/Makefile
+++ b/kernel-modules/Makefile
@@ -43,8 +43,17 @@ push-build-containers: push-build-container $(CUSTOM_FLAVORS:%=push-build-contai
 print-custom-flavors:
 	@printf "%s\n" $(CUSTOM_FLAVORS)
 
-.PHONY: drivers
-drivers: build-container-$(DEV_DRIVER_BUILDER)
+.PHONY: drivers-rhel7
+drivers-rhel7: build-container-rhel7
+	docker run --rm \
+		--entrypoint "/bin/bash" \
+		-v $(DEV_SHARED_VOLUME):/collector \
+		-v /lib/modules/:/lib/modules/:ro \
+		-v /usr/src:/usr/src:ro \
+		build-kernel-modules-rhel7:latest \
+		-c 'scl enable llvm-toolset-7.0 /collector/kernel-modules/dev/build-drivers.sh'
+
+drivers-%: build-container-%
 	docker run --rm \
 		--entrypoint "/bin/bash" \
 		-v $(DEV_SHARED_VOLUME):/collector \
@@ -52,6 +61,9 @@ drivers: build-container-$(DEV_DRIVER_BUILDER)
 		-v /usr/src:/usr/src:ro \
 		build-kernel-modules-$(DEV_DRIVER_BUILDER):latest \
 		-c /collector/kernel-modules/dev/build-drivers.sh
+
+.PHONY: drivers
+drivers: drivers-$(DEV_DRIVER_BUILDER)
 
 .PHONY: clean-drivers
 clean-drivers:

--- a/kernel-modules/Makefile
+++ b/kernel-modules/Makefile
@@ -50,7 +50,6 @@ drivers: build-container-$(DEV_DRIVER_BUILDER)
 		-v $(DEV_SHARED_VOLUME):/collector \
 		-v /lib/modules/:/lib/modules/:ro \
 		-v /usr/src:/usr/src:ro \
-		-e BUILD_KERNEL_MODULE \
 		build-kernel-modules-$(DEV_DRIVER_BUILDER):latest \
 		-c /collector/kernel-modules/dev/build-drivers.sh
 

--- a/kernel-modules/dev/build-drivers.sh
+++ b/kernel-modules/dev/build-drivers.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 OUTPUT_DIR="/collector/kernel-modules/container/kernel-modules"
+BUILD_KERNEL_MODULE="${BUILD_KERNEL_MODULE:-false}"
 
 package_kmod() {
     kernel=$1
@@ -23,27 +24,32 @@ KERNEL_VERSION="$(uname -r)"
 DRIVER_DIR="/collector/falcosecurity-libs"
 PROBE_DIR="/collector/kernel-modules/probe"
 
-mkdir -p "${DRIVER_DIR}/build"
-
-cmake -S ${DRIVER_DIR} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_FLAGS="-fno-pie" \
-    -DDRIVER_NAME=collector \
-    -DDRIVER_DEVICE_NAME=collector \
-    -DBUILD_USERSPACE=OFF \
-    -DBUILD_DRIVER=ON \
-    -DENABLE_DKMS=OFF \
-    -DCREATE_TEST_TARGETS=OFF \
-    -D__MODERN_BPF_DEBUG__=ON \
-    -DBUILD_LIBSCAP_MODERN_BPF=ON \
-    -DMODERN_BPF_EXCLUDE_PROGS='^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$' \
-    -B ${DRIVER_DIR}/build
-make -C ${DRIVER_DIR}/build/driver
-make -C ${PROBE_DIR} FALCO_DIR="${DRIVER_DIR}/driver/bpf"
-
 mkdir -p "${OUTPUT_DIR}"
-package_kmod "$KERNEL_VERSION" "$DRIVER_DIR/build/driver/collector.ko"
+
+make -C ${PROBE_DIR} FALCO_DIR="${DRIVER_DIR}/driver/bpf"
 package_probe "$KERNEL_VERSION" "$PROBE_DIR/probe.o"
 
-# No reason to leave this hanging about
-rm -rf "${DRIVER_DIR}/build"
+if [[ "$BUILD_KERNEL_MODULE" != "false" ]]; then
+    echo "Building kernel module"
+    mkdir -p "${DRIVER_DIR}/build"
+
+    cmake -S ${DRIVER_DIR} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_FLAGS="-fno-pie" \
+        -DDRIVER_NAME=collector \
+        -DDRIVER_DEVICE_NAME=collector \
+        -DBUILD_USERSPACE=OFF \
+        -DBUILD_DRIVER=ON \
+        -DENABLE_DKMS=OFF \
+        -DCREATE_TEST_TARGETS=OFF \
+        -D__MODERN_BPF_DEBUG__=ON \
+        -DBUILD_LIBSCAP_MODERN_BPF=ON \
+        -DMODERN_BPF_EXCLUDE_PROGS='^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$' \
+        -B ${DRIVER_DIR}/build
+
+    make -C ${DRIVER_DIR}/build/driver
+    package_kmod "$KERNEL_VERSION" "$DRIVER_DIR/build/driver/collector.ko"
+
+    # No reason to leave this hanging about
+    rm -rf "${DRIVER_DIR}/build"
+fi

--- a/kernel-modules/dev/build-drivers.sh
+++ b/kernel-modules/dev/build-drivers.sh
@@ -2,15 +2,6 @@
 set -euo pipefail
 
 OUTPUT_DIR="/collector/kernel-modules/container/kernel-modules"
-BUILD_KERNEL_MODULE="${BUILD_KERNEL_MODULE:-false}"
-
-package_kmod() {
-    kernel=$1
-    probe_object=$2
-
-    gzip -c "${probe_object}" \
-        > "${OUTPUT_DIR}/collector-${kernel}.ko.gz"
-}
 
 package_probe() {
     kernel=$1
@@ -28,28 +19,3 @@ mkdir -p "${OUTPUT_DIR}"
 
 make -C ${PROBE_DIR} FALCO_DIR="${DRIVER_DIR}/driver/bpf"
 package_probe "$KERNEL_VERSION" "$PROBE_DIR/probe.o"
-
-if [[ "$BUILD_KERNEL_MODULE" != "false" ]]; then
-    echo "Building kernel module"
-    mkdir -p "${DRIVER_DIR}/build"
-
-    cmake -S ${DRIVER_DIR} \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_FLAGS="-fno-pie" \
-        -DDRIVER_NAME=collector \
-        -DDRIVER_DEVICE_NAME=collector \
-        -DBUILD_USERSPACE=OFF \
-        -DBUILD_DRIVER=ON \
-        -DENABLE_DKMS=OFF \
-        -DCREATE_TEST_TARGETS=OFF \
-        -D__MODERN_BPF_DEBUG__=ON \
-        -DBUILD_LIBSCAP_MODERN_BPF=ON \
-        -DMODERN_BPF_EXCLUDE_PROGS='^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$' \
-        -B ${DRIVER_DIR}/build
-
-    make -C ${DRIVER_DIR}/build/driver
-    package_kmod "$KERNEL_VERSION" "$DRIVER_DIR/build/driver/collector.ko"
-
-    # No reason to leave this hanging about
-    rm -rf "${DRIVER_DIR}/build"
-fi


### PR DESCRIPTION
## Description

Now that kernel modules are no longer supported, this PR removes support for development builds of the falco kernel module. The added advantage of this is that the DEV_DRIVER_BUILDER make variable works with older builders (rhel7) due to reduction in the build dependencies (in particular cmake)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested by building drivers for RHEL 7.
