### PR TITLE
Bump base image to ubi:8.8

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ARG BUILD_TYPE=rhel
 ARG ROOT_DIR=.

--- a/collector/container/Dockerfile.ubi
+++ b/collector/container/Dockerfile.ubi
@@ -7,7 +7,7 @@ ARG ADDRESS_SANITIZER=false
 # This builds a collector container based on UBI with a reliance on Red Hat
 # subscription entitlements. Subscription registration is only needed to install
 # RHEL packages if on a non-RHEL host. (See https://access.redhat.com/solutions/5558771)
-FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
+FROM registry.access.redhat.com/ubi8/ubi:8.8 AS builder
 
 ARG REDHAT_SUBSCRIPTION_ORG_ID
 ARG REDHAT_SUBSCRIPTION_ACTIVATION_KEY
@@ -86,7 +86,7 @@ RUN ./builder/install/install-dependencies.sh && \
     "${CMAKE_BUILD_DIR}/collector/runUnitTests"
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 WORKDIR /
 


### PR DESCRIPTION
## Description

Required to pull a CVE fix on python packages

https://quay.io/repository/stackrox-io/collector/manifest/sha256:97a17401335821ef8a5d083e20f2e5db0fad06912f5d5ffea3ab2b4b60607257?tab=vulnerabilities&fixable=true

## Checklist
- [ ] Investigated and inspected CI test results
