### PR TITLE
ROX-16705: Block the build of all drivers against 6.4

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -64,8 +64,9 @@
 6.2.* 2.2.0 *
 6.2.* 2.1.0 *
 6.2.* 2.0.1 *
-# TODO(ROX-16705) - 6.3 kernel compilation errors
+# TODO(ROX-16705) - 6.3/6.4 kernel compilation errors
 6.3.*
+6.4.*
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod


### PR DESCRIPTION
## Description

6.3 was already blocked, but the same build issue exists with 6.4; so extending the block rule until we pull the fixes from upstream.

## Checklist
- [ ] Investigated and inspected CI test results

CI has:
```
Blocked kernel: 6.4.0-0-amd64 2.5.0 mod
Blocked kernel: 6.4.0-0-amd64 2.5.0 bpf
Blocked kernel: 6.4.0-0-cloud-amd64 2.5.0 mod
Blocked kernel: 6.4.0-0-cloud-amd64 2.5.0 bpf
```
