### PR TITLE
Drops Ubuntu-1804-lts from test matrix

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -17,6 +17,7 @@ runtime_socket: /var/run/docker.sock
 
 excluded_pairs:
   # e.g. - ['ubuntu-1804-lts', 'core_bpf']
+  -
 
 virtual_machines:
   rhel:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -16,7 +16,7 @@ runtime_as_root: false
 runtime_socket: /var/run/docker.sock
 
 excluded_pairs:
-  - ['ubuntu-1804-lts', 'core_bpf']
+  # e.g. - ['ubuntu-1804-lts', 'core_bpf']
 
 virtual_machines:
   rhel:
@@ -65,7 +65,6 @@ virtual_machines:
   ubuntu-os:
     project: ubuntu-os-cloud
     families:
-      - ubuntu-1804-lts
       - ubuntu-2004-lts
       - ubuntu-2204-lts
 


### PR DESCRIPTION
The image has been dropped from the GCP project, so this simply drops it from out test matrix.