### PR TITLE
Allow to run Collector without grpc connection

### DIFF
--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -126,6 +126,18 @@ bool CollectorArgs::parse(int argc, char** argv, int& exitCode) {
     return false;
   }
 
+  for (int i = 0; i < parse.optionsCount(); ++i) {
+    option::Option& opt = buffer[i];
+    if (opt.index() == UNKNOWN) {
+      stringstream out;
+
+      out << "Unknown option: " << options[UNKNOWN].name;
+      message = out.str();
+      exitCode = 1;
+      return false;
+    }
+  }
+
   exitCode = 0;
   return true;
 }

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -74,7 +74,7 @@ static const option::Descriptor usage[] =
         {COLLECTOR_CONFIG, 0, "", "collector-config", checkCollectorConfig, "  --collector-config    \tREQUIRED: Collector config as a JSON string. Please refer to documentation on the valid JSON format."},
         {COLLECTION_METHOD, 0, "", "collection-method", checkCollectionMethod, "  --collection-method   \tCollection method (kernel_module, ebpf or core_bpf)."},
         {CHISEL, 0, "", "chisel", checkChisel, "  --chisel              \tChisel is a base64 encoded string."},
-        {GRPC_SERVER, 0, "", "grpc-server", checkGRPCServer, "  --grpc-server         \tREQUIRED: GRPC server endpoint string in the form HOST1:PORT1."},
+        {GRPC_SERVER, 0, "", "grpc-server", checkGRPCServer, "  --grpc-server         \tGRPC server endpoint string in the form HOST1:PORT1."},
         {UNKNOWN, 0, "", "", option::Arg::None,
          "\nExamples:\n"
          "  collector --grpc-server=\"172.16.0.5:443\"\n"},

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -126,16 +126,8 @@ bool CollectorArgs::parse(int argc, char** argv, int& exitCode) {
     return false;
   }
 
-  if (options[GRPC_SERVER]) {
-    exitCode = 0;
-    return true;
-  }
-
-  stringstream out;
-  out << "Unknown option: " << options[UNKNOWN].name;
-  message = out.str();
-  exitCode = 1;
-  return false;
+  exitCode = 0;
+  return true;
 }
 
 option::ArgStatus

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -88,24 +88,27 @@ void CollectorService::RunForever() {
       return;
     }
     CLOG(INFO) << "Sensor connectivity is successful";
+  }
 
-    if (!config_.DisableNetworkFlows()) {
-      std::shared_ptr<ProcessStore> process_store;
-      if (config_.IsProcessesListeningOnPortsEnabled()) {
-        process_store = std::make_shared<ProcessStore>(&sysdig_);
-      }
-      std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
-      conn_tracker = std::make_shared<ConnectionTracker>();
-      UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
-      conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
-
-      auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
-
-      net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
-                                                              conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
-                                                              network_connection_info_service_comm);
-      net_status_notifier->Start();
+  if (!config_.grpc_channel || !config_.DisableNetworkFlows()) {
+    // In case if no GRPC is used, continue to setup networking infrasturcture
+    // with empty grpc_channel. NetworkConnectionInfoServiceComm will pick it
+    // up and use stdout instead.
+    std::shared_ptr<ProcessStore> process_store;
+    if (config_.IsProcessesListeningOnPortsEnabled()) {
+      process_store = std::make_shared<ProcessStore>(&sysdig_);
     }
+    std::shared_ptr<IConnScraper> conn_scraper = std::make_shared<ConnScraper>(config_.HostProc(), process_store);
+    conn_tracker = std::make_shared<ConnectionTracker>();
+    UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
+    conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
+
+    auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
+
+    net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
+                                                            conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
+                                                            network_connection_info_service_comm);
+    net_status_notifier->Start();
   }
 
   CollectorStatsExporter exporter(registry, &config_, &sysdig_);

--- a/collector/lib/ProcessSignalHandler.cpp
+++ b/collector/lib/ProcessSignalHandler.cpp
@@ -44,12 +44,12 @@ std::string compute_process_key(const ::storage::ProcessSignal& s) {
 }
 
 bool ProcessSignalHandler::Start() {
-  client_.Start();
+  client_->Start();
   return true;
 }
 
 bool ProcessSignalHandler::Stop() {
-  client_.Stop();
+  client_->Stop();
   rate_limiter_.ResetRateLimitCache();
   return true;
 }
@@ -66,14 +66,14 @@ SignalHandler::Result ProcessSignalHandler::HandleSignal(sinsp_evt* evt) {
     return IGNORED;
   }
 
-  auto result = client_.PushSignals(*signal_msg);
+  auto result = client_->PushSignals(*signal_msg);
   if (result == SignalHandler::PROCESSED) {
     ++(stats_->nProcessSent);
   } else if (result == SignalHandler::ERROR) {
     ++(stats_->nProcessSendFailures);
   }
 
-  return result;
+  return SignalHandler::PROCESSED;
 }
 
 SignalHandler::Result ProcessSignalHandler::HandleExistingProcess(sinsp_threadinfo* tinfo) {
@@ -88,14 +88,14 @@ SignalHandler::Result ProcessSignalHandler::HandleExistingProcess(sinsp_threadin
     return IGNORED;
   }
 
-  auto result = client_.PushSignals(*signal_msg);
+  auto result = client_->PushSignals(*signal_msg);
   if (result == SignalHandler::PROCESSED) {
     ++(stats_->nProcessSent);
   } else if (result == SignalHandler::ERROR) {
     ++(stats_->nProcessSendFailures);
   }
 
-  return result;
+  return SignalHandler::PROCESSED;
 }
 
 std::vector<std::string> ProcessSignalHandler::GetRelevantEvents() {

--- a/collector/lib/ProcessSignalHandler.cpp
+++ b/collector/lib/ProcessSignalHandler.cpp
@@ -73,7 +73,7 @@ SignalHandler::Result ProcessSignalHandler::HandleSignal(sinsp_evt* evt) {
     ++(stats_->nProcessSendFailures);
   }
 
-  return SignalHandler::PROCESSED;
+  return result;
 }
 
 SignalHandler::Result ProcessSignalHandler::HandleExistingProcess(sinsp_threadinfo* tinfo) {
@@ -95,7 +95,7 @@ SignalHandler::Result ProcessSignalHandler::HandleExistingProcess(sinsp_threadin
     ++(stats_->nProcessSendFailures);
   }
 
-  return SignalHandler::PROCESSED;
+  return result;
 }
 
 std::vector<std::string> ProcessSignalHandler::GetRelevantEvents() {

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -33,15 +33,14 @@ You should have received a copy of the GNU General Public License along with thi
 #include "ProcessSignalFormatter.h"
 #include "RateLimit.h"
 #include "SignalHandler.h"
-#include "SignalServiceClient.h"
 #include "SysdigService.h"
 
 namespace collector {
 
 class ProcessSignalHandler : public SignalHandler {
  public:
-  ProcessSignalHandler(sinsp* inspector, std::shared_ptr<grpc::Channel> channel, SysdigStats* stats)
-      : client_(std::move(channel)), formatter_(inspector), stats_(stats) {}
+  ProcessSignalHandler(sinsp* inspector, ISignalServiceClient* client, SysdigStats* stats)
+      : client_(client), formatter_(inspector), stats_(stats) {}
 
   bool Start() override;
   bool Stop() override;
@@ -51,7 +50,7 @@ class ProcessSignalHandler : public SignalHandler {
   std::vector<std::string> GetRelevantEvents() override;
 
  private:
-  SignalServiceClient client_;
+  ISignalServiceClient* client_;
   ProcessSignalFormatter formatter_;
   SysdigStats* stats_;
   RateLimitCache rate_limiter_;

--- a/collector/lib/SignalServiceClient.cpp
+++ b/collector/lib/SignalServiceClient.cpp
@@ -110,4 +110,11 @@ SignalHandler::Result SignalServiceClient::PushSignals(const SignalStreamMessage
   return SignalHandler::PROCESSED;
 }
 
+SignalHandler::Result StdoutSignalServiceClient::PushSignals(const SignalStreamMessage& msg) {
+  std::string output;
+  google::protobuf::util::MessageToJsonString(msg, &output, google::protobuf::util::JsonPrintOptions{});
+  CLOG(DEBUG) << "GRPC: " << output;
+  return SignalHandler::PROCESSED;
+}
+
 }  // namespace collector

--- a/collector/lib/SignalServiceClient.h
+++ b/collector/lib/SignalServiceClient.h
@@ -36,14 +36,24 @@ You should have received a copy of the GNU General Public License along with thi
 #include "api/v1/signal.pb.h"
 #include "internalapi/sensor/signal_iservice.grpc.pb.h"
 
-#include "CollectorService.h"
 #include "DuplexGRPC.h"
 #include "SignalHandler.h"
 #include "StoppableThread.h"
 
 namespace collector {
 
-class SignalServiceClient {
+class ISignalServiceClient {
+ public:
+  using SignalStreamMessage = sensor::SignalStreamMessage;
+
+  virtual void Start() = 0;
+  virtual void Stop() = 0;
+  virtual SignalHandler::Result PushSignals(const SignalStreamMessage& msg) = 0;
+
+  virtual ~ISignalServiceClient() {}
+};
+
+class SignalServiceClient : public ISignalServiceClient {
  public:
   using SignalService = sensor::SignalService;
   using SignalStreamMessage = sensor::SignalStreamMessage;
@@ -71,6 +81,18 @@ class SignalServiceClient {
   std::unique_ptr<IDuplexClientWriter<SignalStreamMessage>> writer_;
 
   bool first_write_;
+};
+
+class StdoutSignalServiceClient : public ISignalServiceClient {
+ public:
+  using SignalStreamMessage = sensor::SignalStreamMessage;
+
+  explicit StdoutSignalServiceClient() {}
+
+  void Start(){};
+  void Stop(){};
+
+  SignalHandler::Result PushSignals(const SignalStreamMessage& msg);
 };
 
 }  // namespace collector

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -67,8 +67,13 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
   }
 
   if (config.grpc_channel) {
-    AddSignalHandler(MakeUnique<ProcessSignalHandler>(inspector_.get(), config.grpc_channel, &userspace_stats_));
+    grpc_client_.reset(new SignalServiceClient(std::move(config.grpc_channel)));
+  } else {
+    grpc_client_.reset(new StdoutSignalServiceClient());
   }
+  AddSignalHandler(MakeUnique<ProcessSignalHandler>(inspector_.get(),
+                                                    grpc_client_.get(),
+                                                    &userspace_stats_));
 
   if (signal_handlers_.size() == 2) {
     // self-check handlers do not count towards this check, because they

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -67,12 +67,12 @@ void SysdigService::Init(const CollectorConfig& config, std::shared_ptr<Connecti
   }
 
   if (config.grpc_channel) {
-    grpc_client_.reset(new SignalServiceClient(std::move(config.grpc_channel)));
+    signal_client_.reset(new SignalServiceClient(std::move(config.grpc_channel)));
   } else {
-    grpc_client_.reset(new StdoutSignalServiceClient());
+    signal_client_.reset(new StdoutSignalServiceClient());
   }
   AddSignalHandler(MakeUnique<ProcessSignalHandler>(inspector_.get(),
-                                                    grpc_client_.get(),
+                                                    signal_client_.get(),
                                                     &userspace_stats_));
 
   if (signal_handlers_.size() == 2) {

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -99,7 +99,7 @@ class SysdigService : public Sysdig {
   std::unique_ptr<sinsp> inspector_;
   std::unique_ptr<sinsp_evt_formatter> default_formatter_;
   std::unique_ptr<sinsp_chisel> chisel_;
-  std::unique_ptr<ISignalServiceClient> grpc_client_;
+  std::unique_ptr<ISignalServiceClient> signal_client_;
   std::vector<SignalHandlerEntry> signal_handlers_;
   SysdigStats userspace_stats_;
   std::bitset<PPM_EVENT_MAX> global_event_filter_;

--- a/collector/lib/SysdigService.h
+++ b/collector/lib/SysdigService.h
@@ -39,6 +39,7 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include "Control.h"
 #include "SignalHandler.h"
+#include "SignalServiceClient.h"
 #include "Sysdig.h"
 
 namespace collector {
@@ -98,6 +99,7 @@ class SysdigService : public Sysdig {
   std::unique_ptr<sinsp> inspector_;
   std::unique_ptr<sinsp_evt_formatter> default_formatter_;
   std::unique_ptr<sinsp_chisel> chisel_;
+  std::unique_ptr<ISignalServiceClient> grpc_client_;
   std::vector<SignalHandlerEntry> signal_handlers_;
   SysdigStats userspace_stats_;
   std::bitset<PPM_EVENT_MAX> global_event_filter_;

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -89,6 +89,26 @@ The image `quay.io/rhacs-eng/grpc-server` can be built manually by running
 `make mock-grpc-server-image` in the `https://github.com/stackrox/stackrox/`
 repository.
 
+## Run in the standalone mode
+
+Collector supports the standalone mode, when it does not require a GRPC server
+to connect to. In this mode it will start up as normally, and output all the
+GRPC messages in json format into stdout. To use this mode, specify an empty
+`GRPC_SERVER` environment variable, i.e. in docker compose:
+
+```yaml
+    environment:
+      # note no quotes or such, they will be interpreted
+      # as a string with two characters in it.
+      - GRPC_SERVER=
+```
+
+Or similarly via a CLI parameter:
+
+```bash
+$ collector --grpc-server=
+```
+
 ### Development with an IDE (CLion)
 
 #### Setup


### PR DESCRIPTION
## Description

First step towards standalone Collector for development. Replace SignalServiceClient for ProcessSignalHandler with an interface and allow passing a dummy implementation to dump everything into stdout. Having this in place, one can remove --grpc-server argument when building an image, and Collector will not try to connect anywhere.

The result looks like this:

```
[DEBUG   2023/06/16 14:05:47] (ProcessSignalFormatter.cpp:168) Process (104759): ls --coreutils-prog-shebang=ls /usr/bin/ls
[DEBUG   2023/06/16 14:05:47] (SignalServiceClient.cpp:116) GRPC: {"signal":{"processSignal":{"id":"e43115e4-0c4e-11ee-9beb-0242ac120003","containerId":"8d809b26986d","time":"2023-06-16T16:05:49.482254981Z","name":"ls","args":"--coreutils-prog-shebang=ls /usr/bin/ls","execFilePath":"/usr/bin/ls","pid":104759,"lineageInfo":[{"parentExecFilePath":"/usr/bin/bash"}]}}}
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

## Testing Performed

Local testing.