### PR TITLE
Fixes local default in integration test config

### DIFF
--- a/integration-tests/suites/config/config.go
+++ b/integration-tests/suites/config/config.go
@@ -104,7 +104,7 @@ func StopTimeout() string {
 func HostInfo() *Host {
 	if host_options == nil {
 		host_options = &Host{
-			Kind:    ReadEnvVarWithDefault(envHostType, "default"),
+			Kind:    ReadEnvVarWithDefault(envHostType, "local"),
 			User:    ReadEnvVar(envHostUser),
 			Address: ReadEnvVar(envHostAddress),
 			Options: ReadEnvVar(envHostOptions),


### PR DESCRIPTION
## Description

Correctly sets the default REMOTE_HOST_TYPE. Without this change, the tests will segfault if a REMOTE_HOST_TYPE is not provided. 