### PR TITLE
Refactors GHA to reduce wait times for testing

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -73,7 +73,7 @@ jobs:
             --target=probe-layer-${{ inputs.max-layer-depth }} \
             --tag "${COLLECTOR_IMAGE}" \
             --build-arg collector_repo=quay.io/stackrox-io/collector \
-            --build-arg collector_version=${{ inputs.collector-tag }} \
+            --build-arg collector_version=${{ inputs.collector-tag }}-amd64 \
             --build-arg module_version="${DRIVER_VERSION}" \
             --build-arg max_layer_size=300 \
             --build-arg max_layer_depth=${{ inputs.max-layer-depth }} \

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.build-full-image
     env:
-      COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+      COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
 
     steps:
       - uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.build-full-image }}
     env:
-      COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
+      COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-slim
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -13,6 +13,11 @@ on:
         required: true
         description: |
           Basic stackrox-io image built
+      arch:
+        type: string
+        required: true
+        description: |
+          The architecture to build for
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -58,14 +63,11 @@ jobs:
     name: Build the collector slim image
     needs: set-environment
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64, ppc64le]
 
     env:
       BUILD_BUILDER_IMAGE: ${{ needs.set-environment.outputs.build-builder-image }}
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
-      PLATFORM: linux/${{ matrix.arch }}
+      PLATFORM: linux/${{ inputs.arch }}
 
     steps:
       - uses: actions/checkout@v3
@@ -86,7 +88,7 @@ jobs:
         uses: ./.github/actions/retag-and-push
         with:
           src-image: ${{ inputs.collector-image }}
-          dst-image: ${{ inputs.collector-image }}-${{ matrix.arch }}-slim
+          dst-image: ${{ inputs.collector-image }}-${{ inputs.arch }}-slim
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
@@ -94,21 +96,21 @@ jobs:
         uses: ./.github/actions/retag-and-push
         with:
           src-image: ${{ inputs.collector-image }}
-          dst-image: ${{ inputs.collector-image }}-${{ matrix.arch }}-base
+          dst-image: ${{ inputs.collector-image }}-${{ inputs.arch }}-base
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Push builder to stackrox-io
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
-          docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ matrix.arch }}"
-          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ matrix.arch }}"
+          docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ inputs.arch }}"
+          docker push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ inputs.arch }}"
 
       - name: Retag and push rhacs-eng -slim
         uses: ./.github/actions/retag-and-push
         with:
           src-image: ${{ inputs.collector-image }}
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}-${{ matrix.arch }}-slim
+          dst-image: ${{ env.RHACS_ENG_IMAGE }}-${{ inputs.arch }}-slim
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
@@ -116,90 +118,13 @@ jobs:
         uses: ./.github/actions/retag-and-push
         with:
           src-image: ${{ inputs.collector-image }}
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}-${{ matrix.arch }}-base
+          dst-image: ${{ env.RHACS_ENG_IMAGE }}-${{ inputs.arch }}-base
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
       - name: Push builder to rhacs-eng
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
-          docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ matrix.arch }}"
-          docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ matrix.arch }}"
+          docker tag "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ inputs.arch }}"
+          docker push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${{ inputs.arch }}"
 
-  create-multiarch-manifest:
-    needs:
-    - set-environment
-    - build-collector-image
-    name: Create Multiarch manifest
-    runs-on: ubuntu-latest
-    env:
-      BUILD_BUILDER_IMAGE: ${{ needs.set-environment.outputs.build-builder-image }}
-      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
-
-    steps:
-
-      - name: Login to quay.io/stackrox-io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-
-      - name: Create and push multiarch manifest for stackrox-io -slim
-        run: |
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-slim \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-slim
-
-          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
-
-      - name: Create and push multiarch manifest for stackrox-io -base
-        run: |
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-base \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-base
-
-          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base
-
-      - name: Create and push multiarch manifest for builder to stackrox-io
-        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        run: |
-          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" \
-                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
-                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le"
-
-          docker manifest push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
-
-      - name: Login to quay.io/rhacs-eng
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-
-      - name: Create and push multiarch manifest for rhacs-eng -slim
-        run: |
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-slim \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-slim
-
-          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim
-
-      - name: Create and push multiarch manifest for rhacs-eng -base
-        run: |
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-base \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-base
-
-          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base
-
-      - name: Create and push multiarch manifest for builder to rhacs-eng
-        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        run: |
-          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" \
-                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
-                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le"
-
-          docker manifest push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -27,12 +27,32 @@ jobs:
       logs-artifact:
         drivers-build-failures
 
-  build-collector-slim:
+  build-collector-slim-amd64:
     uses: ./.github/workflows/collector-slim.yml
     needs: init
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       collector-image: ${{ needs.init.outputs.collector-image }}-cpaas
+      arch: amd64
+    secrets: inherit
+
+  build-collector-slim-ppc64le:
+    uses: ./.github/workflows/collector-slim.yml
+    needs: init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+      collector-image: ${{ needs.init.outputs.collector-image }}-cpaas
+      arch: ppc64le
+    secrets: inherit
+
+  multiarch-manifest:
+    uses: ./.github/workflows/multiarch-manifest.yml
+    needs:
+      - init
+      - build-collector-slim-amd64
+      - build-collector-slim-ppc64le
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
     secrets: inherit
 
   build-collector-full:
@@ -46,7 +66,9 @@ jobs:
     secrets: inherit
     needs:
     - init
-    - build-collector-slim
+    - build-collector-slim-amd64
+    - build-collector-slim-ppc64le
+    - multiarch-manifest
     - sync-drivers-and-support-packages
 
   integration-tests:
@@ -75,7 +97,9 @@ jobs:
     needs:
     - init
     - sync-drivers-and-support-packages
-    - build-collector-slim
+    - build-collector-slim-amd64
+    - build-collector-slim-ppc64le
+    - multiarch-manifest
     - build-collector-full
     - integration-tests
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,7 @@ jobs:
 
   build-collector-slim-ppc64le:
     uses: ./.github/workflows/collector-slim.yml
-    needs:
-      - init
-      - build-collector-slim-amd64
+    needs: init
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,9 @@ jobs:
 
   build-collector-slim-ppc64le:
     uses: ./.github/workflows/collector-slim.yml
-    needs: init
+    needs:
+      - init
+      - build-collector-slim-amd64
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,12 +47,22 @@ jobs:
     with:
       logs-artifact: driver-build-failures
 
-  build-collector-slim:
+  build-collector-slim-amd64:
     uses: ./.github/workflows/collector-slim.yml
     needs: init
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}
+      arch: amd64
+    secrets: inherit
+
+  build-collector-slim-ppc64le:
+    uses: ./.github/workflows/collector-slim.yml
+    needs: init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+      collector-image: ${{ needs.init.outputs.collector-image }}
+      arch: ppc64le
     secrets: inherit
 
   build-collector-full:
@@ -65,7 +75,7 @@ jobs:
     secrets: inherit
     needs:
     - init
-    - build-collector-slim
+    - build-collector-slim-amd64
     - build-drivers
 
   integration-tests:
@@ -75,7 +85,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
     needs:
     - init
-    - build-collector-slim
+    - build-collector-slim-amd64
     - build-collector-full
     secrets: inherit
 
@@ -86,8 +96,18 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
     needs:
     - init
-    - build-collector-slim
+    - build-collector-slim-amd64
     - build-collector-full
+    secrets: inherit
+
+  multiarch-manifest:
+    uses: ./.github/workflows/multiarch-manifest.yml
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+    needs:
+      - init
+      - build-collector-slim-amd64
+      - build-collector-slim-ppc64le
     secrets: inherit
 
   build-support-packages:

--- a/.github/workflows/multiarch-manifest.yml
+++ b/.github/workflows/multiarch-manifest.yml
@@ -1,0 +1,116 @@
+name: Create Multi-arch Manifest
+
+on:
+  workflow_call:
+    inputs:
+      collector-tag:
+        type: string
+        required: true
+        description: |
+          The tag used to build the collector image
+
+jobs:
+  set-environment:
+    name: Set environment variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-builder-image: ${{ steps.set-env.outputs.build-builder-image }}
+      collector-builder-tag: ${{ steps.set-env.outputs.collector-builder-tag }}
+
+    steps:
+      - name: Checks PR, main and release branches
+        id: set-env
+        run: |
+
+          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
+            echo 'build-builder-image=true' >> "$GITHUB_OUTPUT"
+            echo "collector-builder-tag=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            #We have 2 options:
+            #- We build the builder from scratch and give it a custom tag
+            #- We use the existing cache
+            COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
+              COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
+              echo 'build-builder-image=true' >> "$GITHUB_OUTPUT"
+            fi
+
+            echo "collector-builder-tag=$COLLECTOR_BUILDER_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+  create-multiarch-manifest:
+    needs:
+    - set-environment
+    name: Create Multiarch manifest
+    runs-on: ubuntu-latest
+    env:
+      BUILD_BUILDER_IMAGE: ${{ needs.set-environment.outputs.build-builder-image }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
+
+    steps:
+
+      - name: Login to quay.io/stackrox-io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+
+      - name: Create and push multiarch manifest for stackrox-io -slim
+        run: |
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim \
+                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-slim \
+                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-slim
+
+          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
+
+      - name: Create and push multiarch manifest for stackrox-io -base
+        run: |
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base \
+                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-base \
+                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-base
+
+          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base
+
+      - name: Create and push multiarch manifest for builder to stackrox-io
+        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
+        run: |
+          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" \
+                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
+                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le"
+
+          docker manifest push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
+
+      - name: Login to quay.io/rhacs-eng
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+
+      - name: Create and push multiarch manifest for rhacs-eng -slim
+        run: |
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim \
+                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-slim \
+                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-slim
+
+          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim
+
+      - name: Create and push multiarch manifest for rhacs-eng -base
+        run: |
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base \
+                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-base \
+                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-base
+
+          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base
+
+      - name: Create and push multiarch manifest for builder to rhacs-eng
+        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
+        run: |
+          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" \
+                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
+                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le"
+
+          docker manifest push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"


### PR DESCRIPTION
## Description

Makes the ppc64le build and multi-arch manifest step into separate workflows, to allow tests to run while the slow ppc64le build runs. We currently only test x86 upstream, and only build amd64 full images upstream. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
