### PR TITLE
Introduce USDT trace points

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -46,6 +46,8 @@ RUN dnf -y update \
         wget \
         which \
         bpftool \
+        # for USDT support
+        systemtap-sdt-devel \
     && dnf clean all
 
 # Build dependencies from source

--- a/collector/lib/ProcessSignalHandler.cpp
+++ b/collector/lib/ProcessSignalHandler.cpp
@@ -25,6 +25,8 @@ You should have received a copy of the GNU General Public License along with thi
 
 #include <sstream>
 
+#include <sys/sdt.h>
+
 #include "storage/process_indicator.pb.h"
 
 #include "RateLimit.h"
@@ -56,6 +58,11 @@ bool ProcessSignalHandler::Stop() {
 
 SignalHandler::Result ProcessSignalHandler::HandleSignal(sinsp_evt* evt) {
   const auto* signal_msg = formatter_.ToProtoMessage(evt);
+  const char* name = signal_msg->signal().process_signal().name().c_str();
+  const int pid = signal_msg->signal().process_signal().pid();
+
+  DTRACE_PROBE2(collector, process_signal_handler, name, pid);
+
   if (!signal_msg) {
     ++(stats_->nProcessResolutionFailuresByEvt);
     return IGNORED;


### PR DESCRIPTION
## Description

Add systemtap into the builder to allow defining USDT, and add one to capture events when a new process was discovered.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Local testing during perf evaluation. CI is sufficient.