### PR TITLE
Use the default cmake version

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -15,7 +15,7 @@ RUN dnf -y update \
         bison \
         ca-certificates \
         clang \
-        cmake-3.18.2-9.el8 \
+        cmake \
         cracklib-dicts \
         diffutils \
         elfutils-libelf-devel \

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(collector-bin)
 
 find_package(Threads)
+find_package(CURL REQUIRED)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++17 -pthread -Wno-deprecated-declarations -fno-omit-frame-pointer -rdynamic")
@@ -62,7 +63,7 @@ else()
 	target_link_libraries(collector_lib libprotobuf.a libcares.a)
 endif()
 
-target_link_libraries(collector_lib z ssl crypto curl bpf)
+target_link_libraries(collector_lib z ssl crypto CURL::libcurl bpf)
 
 add_executable(collector collector.cpp)
 target_link_libraries(collector collector_lib)


### PR DESCRIPTION
## Description

Mixing the 'curl' custom_target with the 'curl' library dependency was making cmake rather angry (segfault)

We fix the curl dependency issue, and then can make use of the default cmake version.

## Checklist
- [x] Investigated and inspected CI test results
