### PR TITLE
Allow collector to fallback to regular eBPF by default

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -55,7 +55,7 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 // If true, add originator process information in NetworkEndpoint
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
-BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", true);
+BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", false);
 
 BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 

--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -37,13 +37,15 @@ func NewCollectorManager(e Executor, name string) *CollectorManager {
 	image_store := config.Images()
 
 	collectionMethod := config.CollectionMethod()
+	collectorConfig := fmt.Sprintf(`{"logLevel":"%s","turnOffScrape":true,"scrapeInterval":2}`, collectorOptions.LogLevel)
 
 	env := map[string]string{
-		"GRPC_SERVER":             "localhost:9999",
-		"COLLECTOR_CONFIG":        fmt.Sprintf(`{"logLevel":"%s","turnOffScrape":true,"scrapeInterval":2}`, collectorOptions.LogLevel),
-		"COLLECTION_METHOD":       collectionMethod,
-		"COLLECTOR_PRE_ARGUMENTS": collectorOptions.PreArguments,
-		"ENABLE_CORE_DUMP":        "false",
+		"GRPC_SERVER":                     "localhost:9999",
+		"COLLECTOR_CONFIG":                collectorConfig,
+		"COLLECTION_METHOD":               collectionMethod,
+		"COLLECTOR_PRE_ARGUMENTS":         collectorOptions.PreArguments,
+		"ENABLE_CORE_DUMP":                "false",
+		"ROX_COLLECTOR_CORE_BPF_HARDFAIL": "true",
 	}
 	if !collectorOptions.Offline {
 		env["MODULE_DOWNLOAD_BASE_URL"] = "https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656"


### PR DESCRIPTION
## Description

Change the default collector configuration so that it falls back to eBPF when the CO-RE BPF driver fails to be inserted.

Fixes #1224

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough since the change is pretty straightforward.
