### PR TITLE
Block failing Fedora integration tests

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -17,8 +17,8 @@ runtime_socket: /var/run/docker.sock
 
 excluded_pairs:
   # e.g. - ['ubuntu-1804-lts', 'core_bpf']
-  - ['fedora-coreos', 'core_bpf'] # Failing due to verifier errors
-  - ['fedora-coreos', 'ebpf'] # No drivers for kernel 6.3+, see ROX-16705
+  - ['fedora-coreos-stable', 'core_bpf'] # Failing due to verifier errors
+  - ['fedora-coreos-stable', 'ebpf'] # No drivers for kernel 6.3+, see ROX-16705
 
 virtual_machines:
   rhel:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -17,7 +17,8 @@ runtime_socket: /var/run/docker.sock
 
 excluded_pairs:
   # e.g. - ['ubuntu-1804-lts', 'core_bpf']
-  -
+  - ['fedora-coreos', 'core_bpf'] # Failing due to verifier errors
+  - ['fedora-coreos', 'ebpf'] # No drivers for kernel 6.3+, see ROX-16705
 
 virtual_machines:
   rhel:


### PR DESCRIPTION
## Description

Integration tests on the Fedora platform are failing due to known issues, we will block them for the time being and reenable them once the issues are resolved.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `all-integration-tests` label and check fedora integration tests are skipped.
