### PR TITLE
Use real full images on the downstream nightly

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -24,6 +24,16 @@ on:
         required: true
         description: |
           GCP bucket to pull drivers from.
+      downstream-drivers-bucket:
+        type: string
+        description: |
+          GCP bucket to pull downstream built drivers from.
+      use-downstream-drivers:
+        type: boolean
+        default: false
+        description: |
+          If true, the downstream built drivers will be added to the final
+          image and overwrite any colliding drivers.
       max-layer-depth:
         type: string
         default: "5"
@@ -66,6 +76,13 @@ jobs:
           if [[ -d "${BUILT_DRIVERS_DIR}" ]]; then
             find "${BUILT_DRIVERS_DIR}" -type f -exec mv -t "${CONTEXT_DRIVERS_DIR}" {} +
           fi
+
+      # Downstream built drivers take precedence over all others.
+      - name: Download downstream built drivers from GCP
+        if: inputs.use-downstream-drivers
+        run: |
+          gsutil -m rsync -r "gs://${{ inputs.downstream-drivers-bucket }}/${DRIVER_VERSION}/" \
+            "${CONTEXT_DRIVERS_DIR}"
 
       - name: Pull slim image and build full image
         run: |

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -19,7 +19,7 @@ on:
         required: true
         description: |
           Skip built drivers if no new drivers were built.
-      drivers-bucket:
+      upstream-drivers-bucket:
         type: string
         required: true
         description: |
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
-          gsutil -m rsync -r "gs://${{ inputs.drivers-bucket }}/${DRIVER_VERSION}/" \
+          gsutil -m rsync -r "gs://${{ inputs.upstream-drivers-bucket }}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
       - name: Add built drivers

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -39,7 +39,9 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
+      drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
+      downstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
+      use-downstream-drivers: true
       skip-built-drivers: true
       max-layer-depth: "1"
       build-full-image: true

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
+      upstream-drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       downstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
       use-downstream-drivers: true
       skip-built-drivers: true

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -43,7 +43,6 @@ jobs:
       downstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
       use-downstream-drivers: true
       skip-built-drivers: true
-      max-layer-depth: "1"
       build-full-image: true
     secrets: inherit
     needs:

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -65,6 +65,7 @@ jobs:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       offline-mode: true
+      job-tag: cpaas
     needs:
     - init
     - build-collector-full

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -23,6 +23,12 @@ on:
           Whether to run the benchmarks instead of the integration tests
         type: boolean
         default: false
+      job-tag:
+        description: |
+          Used to differentiate between different sources when creating
+          VMs in GCP.
+        type: string
+        default: ""
 
 jobs:
   run:
@@ -44,7 +50,7 @@ jobs:
       #
       # vm_type may contain hyphens, so the id is normalized below
       #
-      JOB_ID: ${{ github.run_id }}${{ inputs.vm_type }}
+      JOB_ID: ${{ github.run_id }}${{ inputs.vm_type }}${{ inputs.job-tag }}
       GCP_SSH_KEY_FILE: ~/.ssh/GCP_SSH_KEY
       BUILD_TYPE: ci
       VM_TYPE: "${{ inputs.vm_type }}"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,12 @@ on:
           Tag used for running the integration tests
         type: string
         required: true
+      job-tag:
+        description: |
+          Used to differentiate between different sources when creating
+          VMs in GCP.
+        type: string
+        default: ""
 
 jobs:
   required-integration-tests:
@@ -23,6 +29,7 @@ jobs:
     with:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ inputs.collector-tag }}
+      job-tag: ${{ inputs.job-tag}}
     secrets: inherit
 
   all-integration-tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ inputs.collector-tag }}
-      job-tag: ${{ inputs.job-tag}}
+      job-tag: ${{ inputs.job-tag }}
     secrets: inherit
 
   all-integration-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
-      drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
+      upstream-drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
       build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
     secrets: inherit


### PR DESCRIPTION
## Description

This is step one into trying to make the downstream built drivers authoritative. The nightly runs will start building true full images with all drivers, but the downstream built drivers will take precedence over all others.

There were some issues running both the cpaas and upstream integration tests for the PR in parallel due to VM names colliding, so a final section has been added to the job-id to prevent this.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Run with the `run-cpaas-steps` label.
- [x] Run with the `build-full-images` label.
- [x] Check the drivers are properly overwritten in the downstream image.
- [x] Check the driver are not overwritten in the upstream image.
