### PR TITLE
Add .clangd file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: cmake-build/


### PR DESCRIPTION
## Description

This file is used by clangd to find the location where the compile_commands.json file is normally located. We don't create this file by default, though generating it is trivial, so when running a dev container for continuous compilation of the collector binary it is useful to have.

This was originally meant to be added in #948, which has been stuck for quite some time and I don't currently have time to pick back up, but I'd still want to have this file added so I can stop carrying the change in my local environment.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

This is a development change only and shouldn't affect anything other than those environments using `clangd` as a language server.
