### PR TITLE
Print checksum of drivers being used

### DIFF
--- a/collector/test/GetKernelObjectTest.cpp
+++ b/collector/test/GetKernelObjectTest.cpp
@@ -1,0 +1,68 @@
+/** collector
+
+A full notice with attributions is provided along with this source code.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+* In addition, as a special exception, the copyright holders give
+* permission to link the code of portions of this program with the
+* OpenSSL library under certain conditions as described in each
+* individual source file, and distribute linked combinations
+* including the two.
+* You must obey the GNU General Public License in all respects
+* for all of the code used other than OpenSSL.  If you modify
+* file(s) with this exception, you may extend this exception to your
+* version of the file(s), but you are not obligated to do so.  If you
+* do not wish to do so, delete this exception statement from your
+* version.
+*/
+
+#include <cstring>
+#include <sstream>
+#include <string>
+
+#include "GetKernelObject.cpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+/*
+ * The expected value for this test is the well known hash of an empty string:
+ * https://www.di-mgt.com.au/sha_testvectors.html
+ */
+TEST(Sha256HashStream, Empty) {
+  std::stringstream input("");
+  std::string expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  std::string output = collector::Sha256HashStream(input);
+
+  ASSERT_EQ(output, expected);
+}
+
+/*
+ * The expected value for this test was verified with the following bash commands:
+ * $ printf '0123456789ABCDEF' > newfile
+ * $ sha256sum newfile
+ */
+TEST(Sha256HashStream, SmallString) {
+  std::stringstream input("0123456789ABCDEF");
+  std::string expected = "2125b2c332b1113aae9bfc5e9f7e3b4c91d828cb942c2df1eeb02502eccae9e9";
+  std::string output = collector::Sha256HashStream(input);
+
+  ASSERT_EQ(output, expected);
+}
+
+/*
+ * The expected value for this test was verified with the following bash commands:
+ * $ yes . | head -n 10000 | tr -d "\n" > newfile
+ * $ sha256sum newfile
+ */
+TEST(Sha256HashStream, BigString) {
+  std::stringstream input{std::string(10000, '.')};
+  std::string expected = "cca2be86bf2ea72443a30bb7b7733dfd09689f975dd8bc807344f32eff401404";
+  std::string output = collector::Sha256HashStream(input);
+
+  ASSERT_EQ(output, expected);
+}

--- a/utilities/driver-checksum.sh
+++ b/utilities/driver-checksum.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+# A small script for quickly validating driver SHA256 checksums.
+# See the 'usage' function or run './driver-checksum.sh -h' for a
+# comprehensive explanation on how to use the script.
+
+set -eo pipefail
+
+function usage() {
+    printf "usage: driver-checksum.sh source checksum driver\n"
+    printf "\n"
+    printf "    source\tSpecify if the drivers exists as a file or on gcp\n"
+    printf "          \t  Values: gcp, file\n"
+    printf "    checksum\tA SHA256 checksum to be compared against the driver's\n"
+    printf "    driver\tThe path to the driver on GCP or the local fs\n"
+    printf "\n"
+    printf "    -h, --help\tThis help message\n"
+}
 
 function process_gcp_driver() {
     checksum="${1}"
@@ -37,9 +52,35 @@ function process_file_driver() {
     return $retval
 }
 
-SOURCE=${1}
-CHECKSUM=${2}
-FILE=${3}
+args=()
+
+while test $# -gt 0; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo >&2 "Invalid argument '$1'"
+            usage
+            exit 1
+            ;;
+        *)
+            args+=("$1")
+            ;;
+    esac
+    shift
+done
+
+if ((${#args[@]} != 3)); then
+    echo >&2 "Wrong number of arguments"
+    usage
+    exit 1
+fi
+
+SOURCE=${args[0]}
+CHECKSUM=${args[1]}
+FILE=${args[2]}
 
 if ((${#CHECKSUM} != 64)); then
     echo >&2 "Invalid length for checksum '${#CHECKSUM}'"

--- a/utilities/driver-checksum.sh
+++ b/utilities/driver-checksum.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function process_gcp_driver() {
+    checksum="${1}"
+    file_in_bucket="${2}"
+    retval=0
+
+    temp_dir="$(mktemp -d)"
+    driver="${temp_dir}/driver"
+
+    echo "Downloading ${file_in_bucket} to ${driver}"
+
+    gsutil cp "${file_in_bucket}" "${driver}"
+
+    if ! process_file_driver "${checksum}" "${driver}"; then
+        retval=1
+    fi
+
+    rm -rf "${temp_dir}"
+    return $retval
+}
+
+function process_file_driver() {
+    retval=0
+
+    temp_file=$(mktemp)
+    echo "${1} ${2}" > "${temp_file}"
+
+    if ! sha256sum -c "${temp_file}"; then
+        echo >&2 "Checksum validation failed"
+        retval=1
+    fi
+
+    rm -f "${temp_file}"
+    return $retval
+}
+
+SOURCE=${1}
+CHECKSUM=${2}
+FILE=${3}
+
+if ((${#CHECKSUM} != 64)); then
+    echo >&2 "Invalid length for checksum '${#CHECKSUM}'"
+    exit 1
+fi
+
+if [[ "${SOURCE}" == "gcp" ]]; then
+    process_gcp_driver "${CHECKSUM}" "${FILE}"
+elif [[ "${SOURCE}" == "file" ]]; then
+    process_file_driver "${CHECKSUM}" "${FILE}"
+else
+    echo >&2 "Invalid source for lookup provided '${SOURCE}'"
+    exit 1
+fi


### PR DESCRIPTION
## Description

Have collector print the sha256 checksum for the driver it uses. Same as #1237, this is part of the groundwork for unifying the upstream and downstream built drivers. By printing the checksum for a driver being used it'll be easier for us to check where the driver comes from in case a user reports an issue.

A small script for downloading drivers from GCP and validating checksums is also provided, in hopes that if we ever need to validate the source of a driver it will make the work somewhat easier.

## Checklist
- [x] Investigated and inspected CI test results


**Automated testing**
  - [x] Added unit tests

## Testing Performed

- [x] Manually checked `driver-checksum.sh` properly validates files and cleans up after itself. 
