### PR TITLE
ROX-18736 Report connections only when they are established

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -129,6 +129,6 @@ if(NOT CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64le")
 	set(BUILD_LIBSCAP_MODERN_BPF ON CACHE BOOL "Enable modern bpf engine" FORCE)
 endif()
 
-set(MODERN_BPF_EXCLUDE_PROGS "^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$" CACHE STRING "Set of syscalls to exclude from modern bpf engine " FORCE)
+set(MODERN_BPF_EXCLUDE_PROGS "^(openat2|ppoll|setsockopt|clone3|io_uring_setup|nanosleep)$" CACHE STRING "Set of syscalls to exclude from modern bpf engine " FORCE)
 
 add_subdirectory(${FALCO_DIR} EXCLUDE_FROM_DEFAULT_BUILD)

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -31,6 +31,7 @@ class CollectorConfig {
       "execve",
       "fchdir",
       "fork",
+      "getsockopt",
       "procexit",
       "procinfo",
       "setresgid",

--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -28,12 +28,6 @@ EventMap<Modifier> modifiers = {
 }  // namespace
 
 std::optional<Connection> NetworkSignalHandler::GetConnection(sinsp_evt* evt) {
-  const int64_t* res = event_extractor_.get_event_rawres(evt);
-  if (!res || *res < 0) {
-    // ignore unsuccessful events for now.
-    return std::nullopt;
-  }
-
   auto* fd_info = evt->get_fd_info();
   if (!fd_info) return std::nullopt;
 
@@ -42,7 +36,13 @@ std::optional<Connection> NetworkSignalHandler::GetConnection(sinsp_evt* evt) {
   }
 
   if (fd_info->is_socket_pending()) {
-    CLOG(TRACE) << "Ignoring pending connection until we determine its status.";
+    CLOG(DEBUG) << "Ignoring pending connection until we determine its status.";
+    return std::nullopt;
+  }
+
+  const int64_t* res = event_extractor_.get_event_rawres(evt);
+  if (!res || *res < 0) {
+    // ignore unsuccessful events for now.
     return std::nullopt;
   }
 

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -5,6 +5,7 @@
 
 #include <linux/ioctl.h>
 
+#include "libsinsp/parsers.h"
 #include "libsinsp/wrapper.h"
 
 #include <google/protobuf/util/time_util.h>
@@ -78,6 +79,8 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     }
 
     inspector_->set_import_users(config.ImportUsers());
+
+    inspector_->get_parser()->set_track_connection_status(true);
 
     default_formatter_.reset(new sinsp_evt_formatter(inspector_.get(),
                                                      DEFAULT_OUTPUT_STR));

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -413,15 +413,12 @@ func TestConnectionsAndEndpointsUDPNoFork(t *testing.T) {
 	suite.Run(t, mixedHighLowPorts)
 }
 
-// TODO ROX-18736: reenable after aync-connections are fixed
-/*
 func TestAsyncConnectionBlocked(t *testing.T) {
 	blockedAsyncConnection := &suites.AsyncConnectionTestSuite{
 		BlockConnection: true,
 	}
 	suite.Run(t, blockedAsyncConnection)
 }
-*/
 
 func TestAsyncConnectionSuccess(t *testing.T) {
 	asyncConnection := &suites.AsyncConnectionTestSuite{


### PR DESCRIPTION
## Description

The Collector should report connections that can actually be used to transfer information.
In the case of a TCP connection in asynchronous mode, we have to postpone declaring the connection and
wait until we know the state of the socket.

- When connect returns `INPROGRESS`, we do not declare a connection anymore.
- If the socket is pending and a getsockopt(SO_ERROR) returns a success, we declare this connection

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [x] Added integration tests
  - [x] Added regression tests
