### PR TITLE
Use non-docker actionlint commit hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v3
       - uses: mfinelli/setup-shfmt@v2
+
+      - name: Install actionlint
+        run: |
+          GOBIN="${HOME}/bin/" go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
       - uses: pre-commit/action@v3.0.0
         with:
           # ensure we're only linting the diff between the PR and the base ref
           extra_args: --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref HEAD
-  

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install actionlint
         run: |
+          # Install actionlint to ~/bin/, otherwise pre-commit won't be able to find the executable.
           GOBIN="${HOME}/bin/" go install github.com/rhysd/actionlint/cmd/actionlint@latest
 
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - repo: https://github.com/rhysd/actionlint.git
     rev: "v1.6.22"
     hooks:
-      - id: actionlint-docker
+      - id: actionlint
 
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: "v1.0.0-rc.1"


### PR DESCRIPTION
## Description

The actionlint-docker commit hook has some issues when running using podman from macos, it tries to mount the repository in a way that is not supported and fails. Because fixing this upstream would be annoying and installing actionlint locally shouldn't be a big deal, we should start using the native binary option. This is also preferable to committing with --no-verify and relaying on people running the check manually.

For instructions on how to install actionlint see: https://github.com/rhysd/actionlint/blob/main/docs/install.md

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

This is a change that only affects developer workflow.