### PR TITLE
Fixes lint errors in add-new-pr-to-oss-triaging workflow

### DIFF
--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -23,13 +23,13 @@ jobs:
       - id: check-external-pr
         run: |
           set -uo pipefail
-          if [[ $BASE_REPO != $HEAD_REPO ]]; then
-            echo "::set-output name=is_external_pr::true"
+          if [[ "$BASE_REPO" != "$HEAD_REPO" ]]; then
+            echo "is_external_pr=true" >> "$GITHUB_OUTPUT"
             gh pr edit \
               ${{ github.event.pull_request.number }} \
-              --add-label ${EXTERNAL_PR_LABEL}
+              --add-label "$EXTERNAL_PR_LABEL"
           else
-            echo "::set-output name=is_external_pr::false"
+            echo "is_external_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
   add-to-project:


### PR DESCRIPTION
## Description
These lint errors have existed for sometime, but have remained only because the file hasn't been modified since creation. Following some testing of actionlint when reviewing #1246 I thought I'd tackle these now.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

This is only a cosmetic change.