### PR TITLE
Makes main workflow run on PR label changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ on:
     tags:
       - 3.*.*
   pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - reopened
 
 permissions:
   pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,8 @@ jobs:
       support-packages-bucket: ${{ needs.init.outputs.support-packages-bucket }}
       support-packages-index-bucket: ${{ needs.init.outputs.support-packages-index-bucket }}
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
-    if: always() && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
+    # note: not using `always()` here because it prevents task cancellation.
+    if: (success() || failure()) && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
     needs:
     - init
     - build-drivers


### PR DESCRIPTION
## Description

In order to ease the PR experience a little, this change will make the workflow re-run when labels are changed (added or removed.)

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
~- [ ] Added unit tests~
~- [ ] Added integration tests~
~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

- [x] Add a label after PR creation
- [x] Remove a label after PR creation
- [x] Close PR
- [x] Reopen PR
- [x] Add/Remove a label in the middle of an existing workflow
