### PR TITLE
Move multiarch manifest creation to a separate action

### DIFF
--- a/.github/actions/create-multiarch-manifest/action.yml
+++ b/.github/actions/create-multiarch-manifest/action.yml
@@ -26,5 +26,5 @@ runs:
           images+=("${{ inputs.base-image }}-${arch}${{ inputs.suffix }}")
         done
 
-        docker manifest create ${{ inputs.base-image }} "${images[@]}"
+        docker manifest create ${{ inputs.base-image }}${{ inputs.suffix }} "${images[@]}"
         docker manifest push ${{ inputs.base-image }}${{ inputs.suffix }}

--- a/.github/actions/create-multiarch-manifest/action.yml
+++ b/.github/actions/create-multiarch-manifest/action.yml
@@ -1,0 +1,30 @@
+name: Create and push a multiarch manifest
+description: |
+  This action will create a multiarch manifest and push it to a remote registry.
+
+inputs:
+  base-image:
+    description:
+      The base tag to be used for the manifest
+    required: true
+  suffix:
+    description:
+      Optional suffix for the tags used and the manifest
+    default: ''
+  archs:
+    description:
+      Architectures to be included in the final manifest, separated by a space
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -x
+
+        read -ra archs <<< "${{ inputs.archs }}"
+        for arch in "${archs[@]}"; do
+          images+=("${{ inputs.base-image }}-${arch}${{ inputs.suffix }}")
+        done
+
+        docker manifest create ${{ inputs.base-image }} "${images[@]}"
+        docker manifest push ${{ inputs.base-image }}${{ inputs.suffix }}

--- a/.github/actions/create-multiarch-manifest/action.yml
+++ b/.github/actions/create-multiarch-manifest/action.yml
@@ -19,8 +19,6 @@ runs:
   steps:
     - shell: bash
       run: |
-        set -x
-
         read -ra archs <<< "${{ inputs.archs }}"
         for arch in "${archs[@]}"; do
           images+=("${{ inputs.base-image }}-${arch}${{ inputs.suffix }}")

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         # Waiting on ROX-XXXX
         # arch: [amd64, ppc64le, s390x]
-        arch: [amd64, ppc64le]
+        arch: [amd64]
 
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -53,9 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Waiting on ROX-XXXX
-        # arch: [amd64, ppc64le, s390x]
-        arch: [amd64]
+        arch: [amd64, ppc64le, s390x]
 
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
@@ -131,9 +129,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
-      # Waiting on ROX-XXXX
-      # ARCHS: amd64 ppc64le s390x
-      ARCHS: amd64 ppc64le
+      ARCHS: amd64 ppc64le s390x
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -147,30 +147,31 @@ jobs:
 
       - name: Create and push multiarch manifest for stackrox-io -slim
         run: |
+          set -x
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-slim "
+            images+=("quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-slim")
           done
 
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim "${images}"
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim "${images[@]}"
           docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 
       - name: Create and push multiarch manifest for stackrox-io -base
         run: |
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-base "
+            images+=("quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-base")
           done
 
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base "${images}"
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base "${images[@]}"
           docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base
 
       - name: Create and push multiarch manifest for builder to stackrox-io
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch} "
+            images+=("quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch}")
           done
 
-          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images}"
+          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images[@]}"
           docker manifest push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
       - name: Login to quay.io/rhacs-eng
@@ -184,29 +185,29 @@ jobs:
       - name: Create and push multiarch manifest for rhacs-eng -slim
         run: |
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-slim "
+            images+=("quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-slim")
           done
 
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim "${images}"
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim "${images[@]}"
           docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim
 
       - name: Create and push multiarch manifest for rhacs-eng -base
         run: |
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-base "
+            images+=("quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-base")
           done
 
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base "${images}"
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base "${images[@]}"
           docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base
 
       - name: Create and push multiarch manifest for builder to rhacs-eng
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
           for arch in "${ARCHS[@]}"; do
-            images+="quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch} "
+            images+=("quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch}")
           done
 
-          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images}"
+          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images[@]}"
           docker manifest push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
   retag-x86-image:

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -53,7 +53,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, s390x]
+        # Waiting on ROX-XXXX
+        # arch: [amd64, ppc64le, s390x]
+        arch: [amd64, ppc64le]
 
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
@@ -124,11 +126,14 @@ jobs:
     - build-collector-image
     name: Create Multiarch manifest
     runs-on: ubuntu-latest
-    env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
     if: |
       github.event_name == 'push' ||
       !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+    env:
+      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
+      # Waiting on ROX-XXXX
+      # ARCHS: ("amd64" "ppc64le" "s390x")
+      ARCHS: ("amd64" "ppc64le")
 
     steps:
 
@@ -142,31 +147,30 @@ jobs:
 
       - name: Create and push multiarch manifest for stackrox-io -slim
         run: |
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-slim \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-slim \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-s390x-slim
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-slim "
+          done
 
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim "${images}"
           docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 
       - name: Create and push multiarch manifest for stackrox-io -base
         run: |
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64-base \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-ppc64le-base \
-                                 quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-s390x-base
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-base "
+          done
 
-
+          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base "${images}"
           docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base
 
       - name: Create and push multiarch manifest for builder to stackrox-io
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
-          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" \
-                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
-                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le" \
-                                 "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-s390x"
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch} "
+          done
 
+          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images}"
           docker manifest push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
       - name: Login to quay.io/rhacs-eng
@@ -179,30 +183,30 @@ jobs:
 
       - name: Create and push multiarch manifest for rhacs-eng -slim
         run: |
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-slim \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-slim \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-s390x-slim
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-slim "
+          done
 
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim "${images}"
           docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim
 
       - name: Create and push multiarch manifest for rhacs-eng -base
         run: |
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-amd64-base \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-ppc64le-base \
-                                quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-s390x-base
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-base "
+          done
 
+          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base "${images}"
           docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base
 
       - name: Create and push multiarch manifest for builder to rhacs-eng
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         run: |
-          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" \
-                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64" \
-                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-ppc64le" \
-                                 "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-s390x"
+          for arch in "${ARCHS[@]}"; do
+            images+="quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch} "
+          done
 
+          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images}"
           docker manifest push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
 
   retag-x86-image:

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -132,10 +132,11 @@ jobs:
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
       # Waiting on ROX-XXXX
-      # ARCHS: ("amd64" "ppc64le" "s390x")
-      ARCHS: ("amd64" "ppc64le")
+      # ARCHS: amd64 ppc64le s390x
+      ARCHS: amd64 ppc64le
 
     steps:
+      - uses: actions/checkout@v3
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2
@@ -144,35 +145,26 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
-
       - name: Create and push multiarch manifest for stackrox-io -slim
-        run: |
-          set -x
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-slim")
-          done
-
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim "${images[@]}"
-          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+          suffix: -slim
 
       - name: Create and push multiarch manifest for stackrox-io -base
-        run: |
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${arch}-base")
-          done
-
-          docker manifest create quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base "${images[@]}"
-          docker manifest push quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-base
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+          suffix: -base
 
       - name: Create and push multiarch manifest for builder to stackrox-io
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        run: |
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch}")
-          done
-
-          docker manifest create "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images[@]}"
-          docker manifest push "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}"
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          archs: ${{ env.ARCHS }}
 
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v2
@@ -181,34 +173,26 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-
       - name: Create and push multiarch manifest for rhacs-eng -slim
-        run: |
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-slim")
-          done
-
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim "${images[@]}"
-          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-slim
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+          suffix: -slim
 
       - name: Create and push multiarch manifest for rhacs-eng -base
-        run: |
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${arch}-base")
-          done
-
-          docker manifest create quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base "${images[@]}"
-          docker manifest push quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-base
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+          suffix: -base
 
       - name: Create and push multiarch manifest for builder to rhacs-eng
         if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        run: |
-          for arch in "${ARCHS[@]}"; do
-            images+=("quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}-${arch}")
-          done
-
-          docker manifest create "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}" "${images[@]}"
-          docker manifest push "quay.io/rhacs-eng/collector-builder:${COLLECTOR_BUILDER_TAG}"
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          archs: ${{ env.ARCHS }}
 
   retag-x86-image:
     needs:
@@ -275,4 +259,3 @@ jobs:
           dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-


### PR DESCRIPTION
## Description

This PR started as a way to disable the s390x builds after an error broke CI on our master branch but, after fixing that issue, it turned into a way to easily disable and enable individual architectures to the collector-slim workflow. Changing the archs we build for has always been easy, simply add or remove them from the build matrix, the manifest creation on the other hand has a bunch of arch dependent images hardcoded and requires multiple changes to it. To make editing the archs supported in the manifest creation as simple as the image build step, a new action is created and archs supported can be supplied via a space separated environment variable.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
