### PR TITLE
Prevent cache builders for specific archs from overwriting the multiarch manifest

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -108,7 +108,7 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
         run: |
           ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook -v \
+          ansible-playbook \
             --connection local \
             -i localhost, \
             --limit localhost \
@@ -255,19 +255,19 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-#       - name: Retag and push stackrox-io builder
-#         uses: ./.github/actions/retag-and-push
-#         with:
-#           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-#           dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-#           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-#           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-#
-#       - name: Retag and push rhacs-eng builder
-#         uses: ./.github/actions/retag-and-push
-#         with:
-#           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-#           dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-#           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-#           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+      - name: Retag and push stackrox-io builder
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
+          dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Retag and push rhacs-eng builder
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
+          dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -106,6 +106,8 @@ jobs:
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
           !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+        # s390x builds sometimes take for eeeeeeeever.
+        timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -108,7 +108,7 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
         run: |
           ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook \
+          ansible-playbook -v \
             --connection local \
             -i localhost, \
             --limit localhost \
@@ -255,19 +255,19 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Retag and push stackrox-io builder
-        uses: ./.github/actions/retag-and-push
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng builder
-        uses: ./.github/actions/retag-and-push
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+#       - name: Retag and push stackrox-io builder
+#         uses: ./.github/actions/retag-and-push
+#         with:
+#           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
+#           dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+#           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+#           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+#
+#       - name: Retag and push rhacs-eng builder
+#         uses: ./.github/actions/retag-and-push
+#         with:
+#           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
+#           dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+#           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+#           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -85,6 +85,9 @@ jobs:
             echo "branch-name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Use output
+        run: |
+          echo ${{ steps.collector-env.outputs.branch-name }}
       - name: Set GCP buckets
         id: gcp-buckets
         run: |

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -85,9 +85,6 @@ jobs:
             echo "branch-name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Use output
-        run: |
-          echo ${{ steps.collector-env.outputs.branch-name }}
       - name: Set GCP buckets
         id: gcp-buckets
         run: |

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -14,6 +14,28 @@
         chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
         target: image
 
+    - name: Retag collector image to arch specific
+      community.docker.docker_image:
+        name: "{{ collector_image }}"
+        repository: "{{ collector_image }}-{{ arch }}-slim"
+        source: local
+
+    - name: Untag collector image to prevent issues with multiarch
+      community.docker.docker_image:
+        name: "{{ collector_image }}"
+        state: absent
+
+    - name: Retag collector builder image to arch specific
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        repository: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        source: local
+
+    - name: Untag collector builder image to prevent issues with multiarch
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        state: absent
+
     - name: Login to quay.io
       community.docker.docker_login:
         registry_url: quay.io
@@ -22,14 +44,13 @@
 
     - name: Push slim to quay.io/stackrox-io
       community.docker.docker_image:
-        name: "{{ collector_image }}"
-        repository: "{{ collector_image }}-{{ arch }}-slim"
+        name: "{{ collector_image }}-{{ arch }}-slim"
         push: true
         source: local
 
     - name: Push base to quay.io/stackrox-io
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}-slim"
         repository: "{{ collector_image }}-{{ arch }}-base"
         push: true
         source: local
@@ -50,14 +71,14 @@
 
     - name: Push slim to quay.io/rhacs-eng
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}-slim"
         repository: "{{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-slim"
         push: true
         source: local
 
     - name: Push base to quay.io/stackrox-io
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}-slim"
         repository: "{{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-base"
         push: true
         source: local

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -14,19 +14,6 @@
         chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
         target: image
 
-    # Remove the 2 next blocks before merging
-    - name: Login to quay.io
-      community.docker.docker_login:
-        registry_url: quay.io
-        username: "{{ stackrox_io_username }}"
-        password: "{{ stackrox_io_password }}"
-
-    - name: Push current builder image
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        push: true
-        source: local
-
     - name: Retag collector image to arch specific
       community.docker.docker_image:
         name: "{{ collector_image }}"

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -14,6 +14,19 @@
         chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
         target: image
 
+    # Remove the 2 next blocks before merging
+    - name: Login to quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        username: "{{ stackrox_io_username }}"
+        password: "{{ stackrox_io_password }}"
+
+    - name: Push current builder image
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        push: true
+        source: local
+
     - name: Retag collector image to arch specific
       community.docker.docker_image:
         name: "{{ collector_image }}"
@@ -57,8 +70,7 @@
 
     - name: Push builder image to quay.io/stackrox-io
       community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        repository: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
         push: true
         source: local
       when: push_builder == "true"
@@ -85,7 +97,7 @@
 
     - name: Push builder image to quay.io/rhacs-eng
       community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
         repository: "quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
         push: true
         source: local


### PR DESCRIPTION
## Description

After #1264 got merged, a weird behavior showed up on the master branch, the `cache` tag for the builder images that is meant to be the multiarch manifest for the latest builder image was being linked to the amd64 image only. Investigation showed that tagging and pushing via ansible is updating the `RepoTags` field to contain both the base image and the arch specific image.

RepoTags before #1264:
```
podman inspect --type image --format='{{ .RepoTags }}' quay.io/stackrox-io/collector-builder:cache-amd64
[quay.io/stackrox-io/collector-builder:cache-amd64]
```

RepoTags after #1264:
```
podman inspect --type image --format='{{ .RepoTags }}' quay.io/stackrox-io/collector-builder:cache-amd64
[quay.io/stackrox-io/collector-builder:cache quay.io/stackrox-io/collector-builder:cache-amd64]
```

This causes quay to directly point the `cache` tag to the `cache-amd` tag, when the behavior we want is to leave the `cache` tag unchanged.

In order to fix this, we can untag the `cache` tag before pushing, causing the `cache-amd` tag to go back to the way it was before the change.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Manually check the generated images have the correct `RepoTags` information.
