### PR TITLE
Build multiarch full collector images

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -116,57 +116,42 @@ jobs:
           gsutil -m rsync -r "${GCP_BUCKET}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
-      - name: Pull slim image and build full image
+      - name: Create secrets.yml
         run: |
-          docker build \
-            --platform linux/${{ matrix.arch }} \
-            --target=probe-layer-${{ matrix.max-layer-depth }} \
-            --tag "${COLLECTOR_IMAGE}-${{ matrix.arch }}" \
-            --build-arg collector_repo=quay.io/stackrox-io/collector \
-            --build-arg collector_version=${{ inputs.collector-tag }} \
-            --build-arg module_version="${DRIVER_VERSION}" \
-            --build-arg max_layer_size=300 \
-            --build-arg max_layer_depth=${{ matrix.max-layer-depth }} \
-            "${{ github.workspace }}/kernel-modules/container"
+          {
+            echo "---"
+            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
+            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
+            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
+            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
+          } > ${{ github.workspace }}/ansible/secrets.yml
 
-      - name: Login to quay.io/stackrox-io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Push stackrox-io full image
+      # Ansible here is overkill, but GHA doesn't let me call a workflow from
+      # a step, so... Overkill it is!
+      - name: Build and push full images
+        if: |
+          matrix.arch == 'amd64' ||
+          !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
         run: |
-          docker push "${COLLECTOR_IMAGE}-${{ matrix.arch }}"
-
-      - name: Retag and push stackrox-io -latest
-        uses: ./.github/actions/retag-and-push
-        with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
-          dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}-latest
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng
-        uses: ./.github/actions/retag-and-push
-        with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
-          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng -latest
-        uses: ./.github/actions/retag-and-push
-        with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
-          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}-latest
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          ansible-galaxy install -r ansible/requirements.yml
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e collector_image="${COLLECTOR_IMAGE}" \
+            -e arch="${{ matrix.arch }}" \
+            -e max_layer_depth="${{ matrix.max-layer-depth }}" \
+            -e collector_tag="${{ inputs.collector-tag }}" \
+            -e driver_version="${DRIVER_VERSION}" \
+            -e context_path="${{ github.workspace }}/kernel-modules/container" \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-collector-full.yml
 
   multiarch-manifests:
     runs-on: ubuntu-latest
-    if: inputs.build-full-image
+    if: |
+      inputs.build-full-image &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
     needs:
     - build-collector-full
     env:
@@ -216,6 +201,52 @@ jobs:
           suffix: -latest
 
   retag-collector-full:
+    runs-on: ubuntu-latest
+    if: |
+      inputs.build-full-image &&
+      contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+    needs:
+    - build-collector-full
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Pull full image
+        run: |
+          docker pull quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
+
+      - name: Retag and push stackrox-io
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
+          dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Retag and push stackrox-io -latest
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
+          dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-latest
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Retag and push rhacs-eng
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
+          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Retag and push rhacs-eng -latest
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-amd64
+          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-latest
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+  retag-collector-slim:
     runs-on: ubuntu-latest
     if: ${{ !inputs.build-full-image }}
     env:

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -86,11 +86,12 @@ jobs:
           echo "DRIVER_VERSION=$(cat ${{ github.workspace }}/kernel-modules/MODULE_VERSION)" >> "$GITHUB_ENV"
           echo "CONTEXT_DRIVERS_DIR=${{ github.workspace }}/kernel-modules/container/kernel-modules" >> "$GITHUB_ENV"
 
+      - name: Create context directory
+        run: mkdir -p "${CONTEXT_DRIVERS_DIR}"
+
       - name: Download drivers from GCP
         if: matrix.arch == 'amd64'
         run: |
-          mkdir -p "${CONTEXT_DRIVERS_DIR}"
-
           gsutil -m rsync -r "gs://${{ inputs.drivers-bucket }}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -39,21 +39,44 @@ on:
         type: string
         default: "5"
         description: |
-          Max layer the drivers will be split into
+          Max layer the drivers will be split into for x86 images
 
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
     if: inputs.build-full-image
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+        - amd64
+        - ppc64le
+        - s390x
+        max-layer-depth:
+        - ${{ inputs.max-layer-depth }}
+        - 1
+        exclude:
+        - arch: amd64
+          max-layer-depth: 1
+        - arch: ppc64le
+          max-layer-depth: ${{ inputs.max-layer-depth }}
+        - arch: s390x
+          max-layer-depth: ${{ inputs.max-layer-depth }}
     env:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Restore built drivers
         uses: actions/download-artifact@v3
-        if: ${{ !inputs.skip-built-drivers }}
+        if: matrix.arch == 'amd64' && !inputs.skip-built-drivers
         with:
           name: built-drivers
           path: /tmp/built-drivers/
@@ -64,6 +87,7 @@ jobs:
           echo "CONTEXT_DRIVERS_DIR=${{ github.workspace }}/kernel-modules/container/kernel-modules" >> "$GITHUB_ENV"
 
       - name: Download drivers from GCP
+        if: matrix.arch == 'amd64'
         run: |
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
@@ -71,6 +95,7 @@ jobs:
             "${CONTEXT_DRIVERS_DIR}"
 
       - name: Add built drivers
+        if: matrix.arch == 'amd64'
         run: |
           BUILT_DRIVERS_DIR="/tmp/built-drivers/${DRIVER_VERSION}/"
 
@@ -82,19 +107,25 @@ jobs:
       - name: Download downstream built drivers from GCP
         if: inputs.use-optional-bucket
         run: |
-          gsutil -m rsync -r "gs://${{ inputs.optional-drivers-bucket }}/${DRIVER_VERSION}/" \
+          GCP_BUCKET="gs://${{ inputs.optional-drivers-bucket }}/${{ matrix.arch }}"
+          if [[ ${{ matrix.arch }} == "amd64" ]]; then
+            GCP_BUCKET="gs://${{ inputs.optional-drivers-bucket }}/x86_64"
+          fi
+
+          gsutil -m rsync -r "${GCP_BUCKET}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
       - name: Pull slim image and build full image
         run: |
           docker build \
-            --target=probe-layer-${{ inputs.max-layer-depth }} \
-            --tag "${COLLECTOR_IMAGE}" \
+            --platform linux/${{ matrix.arch }} \
+            --target=probe-layer-${{ matrix.max-layer-depth }} \
+            --tag "${COLLECTOR_IMAGE}-${{ matrix.arch }}" \
             --build-arg collector_repo=quay.io/stackrox-io/collector \
             --build-arg collector_version=${{ inputs.collector-tag }} \
             --build-arg module_version="${DRIVER_VERSION}" \
             --build-arg max_layer_size=300 \
-            --build-arg max_layer_depth=${{ inputs.max-layer-depth }} \
+            --build-arg max_layer_depth=${{ matrix.max-layer-depth }} \
             "${{ github.workspace }}/kernel-modules/container"
 
       - name: Login to quay.io/stackrox-io
@@ -106,31 +137,82 @@ jobs:
 
       - name: Push stackrox-io full image
         run: |
-          docker push "${COLLECTOR_IMAGE}"
+          docker push "${COLLECTOR_IMAGE}-${{ matrix.arch }}"
 
       - name: Retag and push stackrox-io -latest
         uses: ./.github/actions/retag-and-push
         with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}
-          dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-latest
+          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
+          dst-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}-latest
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
       - name: Retag and push rhacs-eng
         uses: ./.github/actions/retag-and-push
         with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}
-          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
+          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
       - name: Retag and push rhacs-eng -latest
         uses: ./.github/actions/retag-and-push
         with:
-          src-image: ${{ env.COLLECTOR_IMAGE }}
-          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-latest
+          src-image: ${{ env.COLLECTOR_IMAGE }}-${{ matrix.arch }}
+          dst-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}-${{ matrix.arch }}-latest
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+  multiarch-manifests:
+    runs-on: ubuntu-latest
+    if: inputs.build-full-image
+    needs:
+    - build-collector-full
+    env:
+      ARCHS: amd64 ppc64le s390x
+      COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to quay.io/stackrox-io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Create and push multiarch manifest for stackrox-io
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: ${{ env.COLLECTOR_IMAGE }}
+          archs: ${{ env.ARCHS }}
+
+      - name: Create and push multiarch manifest for stackrox-io -latest
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: ${{ env.COLLECTOR_IMAGE }}
+          archs: ${{ env.ARCHS }}
+          suffix: -latest
+
+      - name: Login to quay.io/rhacs-eng
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Create and push multiarch manifest for rhacs-eng
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+
+      - name: Create and push multiarch manifest for rhacs-eng -latest
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
+          archs: ${{ env.ARCHS }}
+          suffix: -latest
 
   retag-collector-full:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
-      optional-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
+      optional-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       use-optional-bucket: true
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
       build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -75,6 +75,26 @@ of these images to quay.io.
 | rhacs_eng_username | Username used for pushing images to quay.io/rhacs-eng |
 | rhacs_eng_password | Password used for pushing images to quay.io/rhacs-eng |
 
+### Full collector images
+The `ci-build-collector-full.yml` playbook is meant to be used by CI, it builds
+the full collector image for a given architecture. The drivers to be embedded
+in the final image need to be downloaded before calling the playbook.
+
+#### Ansible variables to be supplied to the playbook
+
+| Name | Description |
+| ---  | ---         |
+| collector_image | The collector image name to be built, including its tag but excluding the arch |
+| arch | The architecture the images are being built for, currently the supported values are:<br>- amd64<br>- ppc64le<br>- s390x |
+| max_layer-depth | The maximum number of layers expected to be used for the drivers |
+| collector_tag | The tag being used for the image |
+| driver_version | The driver version that will be used by the built image |
+| context_path | The path to the context for the image build |
+| stackrox_io_username | Username used for pushing images to quay.io/stackrox-io |
+| stackrox_io_password | Password used for pushing images to quay.io/stackrox-io |
+| rhacs_eng_username | Username used for pushing images to quay.io/rhacs-eng |
+| rhacs_eng_password | Password used for pushing images to quay.io/rhacs-eng |
+
 ## Integration tests
 ### Overview
 

--- a/ansible/ci-build-collector-full.yml
+++ b/ansible/ci-build-collector-full.yml
@@ -1,0 +1,65 @@
+---
+- name: Build and push collector image
+  hosts: all
+
+  tasks:
+    - name: Login to quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        username: "{{ stackrox_io_username }}"
+        password: "{{ stackrox_io_password }}"
+
+    - name: Pull slim image
+      community.docker.docker_image:
+        name: "{{ collector_image }}-{{ arch }}-slim"
+        source: pull
+        platform: "linux/{{ arch }}"
+
+    - name: Build the collector full image
+      community.docker.docker_image:
+        name: "{{ collector_image }}-{{ arch }}"
+        build:
+          platform: "linux/{{ arch }}"
+          target: "probe-layer-{{ max_layer_depth }}"
+          args:
+            collector_repo: quay.io/stackrox-io/collector
+            collector_version: "{{ collector_tag }}"
+            module_version: "{{ driver_version }}"
+            max_layer_size: 300
+            max_layer_depth: "{{ max_layer_depth }}"
+          path: "{{ context_path }}"
+        push: true
+        source: build
+
+    - name: Retag and push stackrox-io -latest
+      community.docker.docker_image:
+        name: "{{ collector_image }}"
+        repository: "quay.io/stackrox-io/collector:{{ collector_tag }}-{{ arch }}-latest"
+        push: true
+        source: local
+
+    - name: Login to quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        username: "{{ rhacs_eng_username }}"
+        password: "{{ rhacs_eng_password }}"
+
+    - name: Retag and push rhacs-eng
+      community.docker.docker_image:
+        name: "{{ collector_image }}"
+        repository: "quay.io/rhacs-eng/collector:{{ collector_tag }}-{{ arch }}"
+        push: true
+        source: local
+
+    - name: Retag and push rhacs-eng -latest
+      community.docker.docker_image:
+        name: "{{ collector_image }}"
+        repository: "quay.io/rhacs-eng/collector:{{ collector_tag }}-{{ arch }}-latest"
+        push: true
+        source: local
+
+    - name: Logout of quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        state: absent
+      when: true

--- a/ansible/ci-build-collector-full.yml
+++ b/ansible/ci-build-collector-full.yml
@@ -34,7 +34,7 @@
 
     - name: Retag and push stackrox-io -latest
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}"
         repository: "quay.io/stackrox-io/collector:{{ collector_tag }}-{{ arch }}-latest"
         push: true
         source: local
@@ -47,14 +47,14 @@
 
     - name: Retag and push rhacs-eng
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}"
         repository: "quay.io/rhacs-eng/collector:{{ collector_tag }}-{{ arch }}"
         push: true
         source: local
 
     - name: Retag and push rhacs-eng -latest
       community.docker.docker_image:
-        name: "{{ collector_image }}"
+        name: "{{ collector_image }}-{{ arch }}"
         repository: "quay.io/rhacs-eng/collector:{{ collector_tag }}-{{ arch }}-latest"
         push: true
         source: local

--- a/ansible/ci-build-collector-full.yml
+++ b/ansible/ci-build-collector-full.yml
@@ -13,7 +13,8 @@
       community.docker.docker_image:
         name: "{{ collector_image }}-{{ arch }}-slim"
         source: pull
-        platform: "linux/{{ arch }}"
+        pull:
+          platform: "linux/{{ arch }}"
 
     - name: Build the collector full image
       community.docker.docker_image:


### PR DESCRIPTION
## Description

Use the downstream built drivers for P and Z alongside the downstream built images to build full collectors images.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Skipping multiarch builds in PRs should build a single x86 full image.