### PR TITLE
Check bucket has drivers before using it

### DIFF
--- a/.github/actions/support-package-driver-matrix/action.yml
+++ b/.github/actions/support-package-driver-matrix/action.yml
@@ -30,7 +30,7 @@ runs:
           gsutil ls "${{ inputs.upstream-drivers-bucket }}/${mod_ver}/*" \
               | ${{ github.action_path }}/driver-matrix.py --update /tmp/driver-matrix.json
 
-          if use_downstream "$mod_ver"; then
+          if use_downstream "$mod_ver" && bucket_has_drivers "${{ inputs.downstream-drivers-bucket }}/${mod_ver}/*"; then
             # Update the matrix with downstream drivers
             gsutil ls "${{ inputs.downstream-drivers-bucket }}/${mod_ver}/*" \
                 | ${{ github.action_path }}/driver-matrix.py --update /tmp/driver-matrix.json --downstream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
     # Skip support-package step when the workflow is cancelled only
     if: |
-      (success() || failure()) &&
+      always() &&
       (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
     needs:
     - init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,6 @@ jobs:
       support-packages-bucket: ${{ needs.init.outputs.support-packages-bucket }}
       support-packages-index-bucket: ${{ needs.init.outputs.support-packages-index-bucket }}
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
-    # Skip support-package step when the workflow is cancelled only
     if: |
       always() &&
       (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -50,7 +50,7 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     # Remains to be clarified; we might provide more fine granular download options in the future.
     gsutil -m cp "${COLLECTOR_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
     if use_downstream "$mod_ver" && bucket_has_drivers "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz"; then
-        gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir" || true
+        gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
     fi
 
     package_out_dir="${OUT_DIR}/${mod_ver}"

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -49,8 +49,8 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     # support the slim collector use-case.
     # Remains to be clarified; we might provide more fine granular download options in the future.
     gsutil -m cp "${COLLECTOR_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
-    if use_downstream "$mod_ver"; then
-        gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
+    if use_downstream "$mod_ver" && bucket_has_drivers "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz"; then
+        gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir" || true
     fi
 
     package_out_dir="${OUT_DIR}/${mod_ver}"

--- a/kernel-modules/support-packages/utils.sh
+++ b/kernel-modules/support-packages/utils.sh
@@ -17,3 +17,9 @@ use_downstream() {
 
     return 0
 }
+
+bucket_has_drivers() {
+    count=$(gsutil ls "$1" | wc -l)
+
+    ((count != 0))
+}


### PR DESCRIPTION
## Description

With the recent changes introduced by #1248, a few potential failures can occur when the downstream drivers have not yet been mirrored upstream. Checking before using them should fix the issue.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `test-support-packages` and check the `2.6.0-rc1` package is built correctly.