### PR TITLE
Push the builder image only when absolutely necessary

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -244,6 +244,9 @@ jobs:
 
       - name: Retag and push stackrox-io builder
         uses: ./.github/actions/retag-and-push
+        if: |
+          github.event_name == 'push' ||
+          needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         with:
           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
           dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
@@ -252,6 +255,9 @@ jobs:
 
       - name: Retag and push rhacs-eng builder
         uses: ./.github/actions/retag-and-push
+        if: |
+          github.event_name == 'push' ||
+          needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
         with:
           src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
           dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}


### PR DESCRIPTION
## Description

#1264 introduced a bug where PRs are pushing the `cache` tag for builders, this change should restore the previous behavior.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
