### PR TITLE
Block 6.3+ kernels on failing versions

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -69,6 +69,8 @@
 6.2.* 2.2.0 *
 6.2.* 2.1.0 *
 6.2.* 2.0.1 *
+# TODO(ROX-16705) - 6.3/6.4 kernel compilation errors
+~6\.[3-9]\.\d+.* ~2\.[2-5]\.\d+(?:-rc\d+)?
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod


### PR DESCRIPTION
## Description

Latest version of collector is able to build drivers for 6.3+ kernels, but legacy versions still fail. We block them for now and we can backport the fix if needed in the future.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `build-legacy-probes` should finish with no failures.
