### PR TITLE
Properly extend multiarch build timeout

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -50,6 +50,8 @@ jobs:
     name: Build the collector slim image
     needs: set-environment
     runs-on: ubuntu-latest
+    # Multiarch builds sometimes take for eeeeeeeeeever
+    timeout-minutes: 480
     strategy:
       fail-fast: false
       matrix:
@@ -106,8 +108,6 @@ jobs:
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
           !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
-        # s390x builds sometimes take for eeeeeeeever.
-        timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \


### PR DESCRIPTION
## Description

GHA has a timeout property for jobs and steps, if the timeout of a step is longer than that of a job, then it is still killed. This PR moves the timeout extension for slim images from the build step to the job as to prevent this early killing.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
