### PR TITLE
ROX-18838: Remove docker socket mountpoint from collector container.

### DIFF
--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -33,6 +33,7 @@ type CollectorManager struct {
 
 func NewCollectorManager(e Executor, name string) *CollectorManager {
 	collectorOptions := config.CollectorInfo()
+	runtimeOptions := config.RuntimeInfo()
 	image_store := config.Images()
 
 	collectionMethod := config.CollectionMethod()
@@ -50,9 +51,9 @@ func NewCollectorManager(e Executor, name string) *CollectorManager {
 		env["MODULE_DOWNLOAD_BASE_URL"] = "https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656"
 	}
 	mounts := map[string]string{
-		// The presence of this file disables an optimisation, which turns off podman runtime parsing.
+		// The presence of this socket disables an optimisation, which would turn off podman runtime parsing.
 		// https://github.com/falcosecurity/libs/pull/296
-		"/run/podman/podman.sock:ro": "/tmp/dummy_podman_socket_mount",
+		"/run/podman/podman.sock:ro": runtimeOptions.Socket,
 		"/host/proc:ro":              "/proc",
 		"/host/etc:ro":               "/etc/",
 		"/host/usr/lib:ro":           "/usr/lib/",


### PR DESCRIPTION
## Description

The current definition of the Collector daemonset contains a volume to access to the Docker socket. This is not used anymore and could cause security concern.

This PR removes the mountpoint parameters in the CI tests to check that Collector is not affected by this change.

## Checklist
- [ ] Investigated and inspected CI test results
