### PR TITLE
Extend the build image step to match the job timeout

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -108,6 +108,7 @@ jobs:
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
           !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+        timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \


### PR DESCRIPTION
## Description

Turns out that, after trying to extend just the step in #1270 and then trying to just extend the timeout in #1276 (which I should've guessed was not gonna be enough), the correct way is to extend both timeouts, otherwise GHA just stops after 6 hours.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI should be enough (but reality is, this change is tested on master when the build takes longer than 6 hours).
