### PR TITLE
Use the downstream built image for testing

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -19,21 +19,22 @@ on:
         required: true
         description: |
           Skip built drivers if no new drivers were built.
-      upstream-drivers-bucket:
+      drivers-bucket:
         type: string
         required: true
         description: |
           GCP bucket to pull drivers from.
-      downstream-drivers-bucket:
+      optional-drivers-bucket:
         type: string
         description: |
-          GCP bucket to pull downstream built drivers from.
-      use-downstream-drivers:
+          Optional GCP bucket. When used, the drivers in this bucket will
+          take precendence over the one in drivers-bucket.
+      use-optional-bucket:
         type: boolean
         default: false
         description: |
-          If true, the downstream built drivers will be added to the final
-          image and overwrite any colliding drivers.
+          If true, the optional drivers will be added to the final image
+          and overwrite any colliding drivers.
       max-layer-depth:
         type: string
         default: "5"
@@ -66,7 +67,7 @@ jobs:
         run: |
           mkdir -p "${CONTEXT_DRIVERS_DIR}"
 
-          gsutil -m rsync -r "gs://${{ inputs.upstream-drivers-bucket }}/${DRIVER_VERSION}/" \
+          gsutil -m rsync -r "gs://${{ inputs.drivers-bucket }}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
       - name: Add built drivers
@@ -79,9 +80,9 @@ jobs:
 
       # Downstream built drivers take precedence over all others.
       - name: Download downstream built drivers from GCP
-        if: inputs.use-downstream-drivers
+        if: inputs.use-optional-bucket
         run: |
-          gsutil -m rsync -r "gs://${{ inputs.downstream-drivers-bucket }}/${DRIVER_VERSION}/" \
+          gsutil -m rsync -r "gs://${{ inputs.optional-drivers-bucket }}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
       - name: Pull slim image and build full image

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -59,6 +59,7 @@ jobs:
       use-downstream-drivers: false
       skip-built-drivers: true
       build-full-image: true
+      max-layer-depth: "1"
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -55,9 +55,8 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      upstream-drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
-      downstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
-      use-downstream-drivers: true
+      upstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
+      use-downstream-drivers: false
       skip-built-drivers: true
       build-full-image: true
     secrets: inherit

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -55,8 +55,7 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      upstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
-      use-downstream-drivers: false
+      drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
       skip-built-drivers: true
       build-full-image: true
       max-layer-depth: "1"

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -28,12 +28,26 @@ jobs:
         drivers-build-failures
 
   build-collector-slim:
-    uses: ./.github/workflows/collector-slim.yml
+    runs-on: ubuntu-latest
     needs: init
-    with:
-      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
-      collector-image: ${{ needs.init.outputs.collector-image }}-cpaas
-    secrets: inherit
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: brew.registry.redhat.io
+          username: ${{ secrets.REDHAT_USERNAME }}
+          password: ${{ secrets.REDHAT_PASSWORD }}
+
+      - name: Pull downstream slim collector
+        run: |
+          docker pull brew.registry.redhat.io/rh-osbs/rhacs-collector-slim-rhel8:0.1.0
+
+      - name: Retag and push stackrox-io -slim
+        uses: ./.github/actions/retag-and-push
+        with:
+          src-image: brew.registry.redhat.io/rh-osbs/rhacs-collector-slim-rhel8:0.1.0
+          dst-image: ${{ needs.init.outputs.collector-image }}-cpaas-slim
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
   build-collector-full:
     uses: ./.github/workflows/collector-full.yml

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: init
     steps:
+      - uses: actions/checkout@v3
+
       - uses: docker/login-action@v2
         with:
           registry: brew.registry.redhat.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,9 @@ jobs:
     uses: ./.github/workflows/collector-full.yml
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
-      upstream-drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
-      downstream-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
-      use-downstream-drivers: true
+      drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
+      optional-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}/x86_64
+      use-optional-bucket: true
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
       build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
     secrets: inherit


### PR DESCRIPTION
## Description

Instead of using an image built upstream with the downstream drivers, the CPaaS workflow will start running tests using a slim image built downstream with the latest commit for collector. In order to continue testing the downstream built drivers, a full image is built by embedding the downstream built drivers in the slim image and running the tests in offline mode.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `run-cpaas-steps`
