### PR TITLE
Improve ansible output

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -83,6 +83,8 @@ jobs:
             -e arch='${{ matrix.arch }}' \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-collector.yml
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
 
   create-multiarch-manifest:
     needs:

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
-stdout_callback=debug
+stdout_callback=selective
 stderr_callback=debug
+display_skipped_hosts=false
 host_key_checking=False
 remote_tmp = /tmp/ansible
 forks = 20

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -12,6 +12,8 @@
       community.general.make:
         chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
         target: image
+      # ensure this action is printed
+      tags: [print_action]
 
     - name: Retag collector image to arch specific
       community.docker.docker_image:
@@ -71,6 +73,7 @@
         - "  {{ collector_image }}-{{ arch }}-base"
         - "  {{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-slim"
         - "  {{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-base"
+      tags: [print_action]
 
     - name: Logout of quay.io
       community.docker.docker_login:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -22,6 +22,10 @@
             msg: "{{ build_result.stdout }}"
           tags: [print_action]
 
+        # propagate the failure (otherwise the tasks below will run)
+        - ansible.builtin.fail:
+            msg: Build failed
+
     - name: Retag collector image to arch specific
       community.docker.docker_image:
         name: "{{ collector_image }}"

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -8,12 +8,19 @@
     COLLECTOR_TAG: "{{ ansible_env.COLLECTOR_TAG }}"
 
   tasks:
-    - name: Build the collector image
-      community.general.make:
-        chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
-        target: image
-      # ensure this action is printed
-      tags: [print_action]
+    - block:
+        - name: Build the collector image
+          community.general.make:
+            chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
+            target: image
+          register: build_result
+          # ensure this action is printed
+          tags: [print_action]
+      rescue:
+        - name: Output built log
+          debug:
+            msg: "{{ build_result.stdout }}"
+          tags: [print_action]
 
     - name: Retag collector image to arch specific
       community.docker.docker_image:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -16,15 +16,11 @@
           register: build_result
           # ensure this action is printed
           tags: [print_action]
-      rescue:
+      always:
         - name: Output built log
           debug:
             msg: "{{ build_result.stdout }}"
           tags: [print_action]
-
-        # propagate the failure (otherwise the tasks below will run)
-        - ansible.builtin.fail:
-            msg: Build failed
 
     - name: Retag collector image to arch specific
       community.docker.docker_image:

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -33,6 +33,17 @@
     # ensure that this is printed
     tags: [print_action]
 
+  rescue:
+  - name: Set tests as failed
+    set_fact:
+      success: false
+
+  - name: Output integration test log
+    debug:
+      msg: "{{ test_result.stdout }}"
+    tags: [print_action]
+
+  always:
   - name: Write integration test log
     copy:
       content: "{{ test_result.stdout }}"
@@ -44,17 +55,6 @@
     environment:
       LOG_FILE: "{{ logs_root }}/integration-test.log"
     delegate_to: localhost
-
-  rescue:
-  - name: Set tests as failed
-    set_fact:
-      success: false
-
-  always:
-  - name: Output integration test log
-    debug:
-      msg: "{{ test_result.stdout }}"
-    tags: [print_action]
 
   # If this host is just for a certain collection method, skip running
   # the test if we're not using that collection method.

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -30,6 +30,8 @@
       RUNTIME_SOCKET: "{{ runtime_socket }}"
     register: test_result
     delegate_to: localhost
+    # ensure that this is printed
+    tags: [print_action]
 
   - name: Write integration test log
     copy:
@@ -47,6 +49,12 @@
   - name: Set tests as failed
     set_fact:
       success: false
+
+  always:
+  - name: Output integration test log
+    debug:
+      msg: "{{ test_result.stdout }}"
+    tags: [print_action]
 
   # If this host is just for a certain collection method, skip running
   # the test if we're not using that collection method.


### PR DESCRIPTION
## Description

To reduce the amount of useless information in the ansible output (setup tasks, skipped tasks etc) this PR enables the `selective` stdout callback which will only print tasks that are explicitly opt-in via the `print_action` task, with the exception of failures which are always printed

As a first pass, this PR also opts-in with integration testing tasks and build tasks, but none of the VM creation or provisioning task. This is by no means set in stone and if more tasks make sense for logging then we can opt-in.

The advantage should be that the CI logs are more readable and we can identify flakes/failures more easily. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
Tested locally. Example output, including some successes and failures:

```
ansible-playbook \
		-i dev \
		-e job_id="ghutton" \
		-e @secrets.yml \
		--tags run-tests \
		integration-tests.yml
............
# run-test-target : Run integration tests *********************************************************************************
  * collector-dev-any-rhel-8-ghutton- FAILED!!! -- non-zero return code -----------------------
.
# run-test-target : Output integration test log ***************************************************************************
  * collector-dev-any-rhel-8-ghutton- changed=False ---------------------------------------------
    docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
    go version
    go version go1.20.2 darwin/amd64
    set -o pipefail; go test -tags bench -timeout 60m -count=1 -v -run TestProcessNetwork 2>&1 | tee -a integration-test.log
    === RUN   TestProcessNetwork
        require.go:794:
            	Error Trace:	process_network.go:74
            	            				suite.go:64
            	            				integration_test.go:14
            	Error:      	Received unexpected error:
            	            	invalid character '@' looking for beginning of value
            	Test:       	TestProcessNetwork
    --- FAIL: TestProcessNetwork (44.48s)
    FAIL
    exit status 1
    FAIL	github.com/stackrox/collector/integration-tests	45.108s
# run-test-target : Check results *****************************************************************************************
  * collector-dev-any-rhel-8-ghutton- FAILED!!! -- Tests failed -------------------------------
  * collector-dev-any-rhel-9-ghutton- changed=True --  ----------------------------------------
..
# run-test-target : Output integration test log ***************************************************************************
  * collector-dev-any-rhel-9-ghutton- changed=False ---------------------------------------------
    docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
    go version
    go version go1.20.2 darwin/amd64
    set -o pipefail; go test -tags bench -timeout 60m -count=1 -v -run TestProcessNetwork 2>&1 | tee -a integration-test.log
    === RUN   TestProcessNetwork
    === RUN   TestProcessNetwork/TestNetworkFlows
    ServerDetails from Bolt: 2902e6934451 {LocalAddress::80 RemoteAddress:172.17.0.4 Role:ROLE_SERVER SocketFamily:SOCKET_FAMILY_UNKNOWN CloseTimestamp:(timestamp: nil Timestamp)}
    ServerDetails from test: 2902e6934451 172.17.0.3, Port: 80
    ClientDetails from Bolt: 2902e6934451 {LocalAddress: RemoteAddress:172.17.0.3:80 Role:ROLE_CLIENT SocketFamily:SOCKET_FAMILY_UNKNOWN CloseTimestamp:(timestamp: nil Timestamp)}
    ClientDetails from test: 5e0273a68238 172.17.0.4
    === RUN   TestProcessNetwork/TestProcessLineageInfo
    === RUN   TestProcessNetwork/TestProcessViz
    CPU: Container grpc-server, Mean 0.016250000000000004, StdDev 0.036571847095819475
    CPU: Container collector, Mean 3.945714285714285, StdDev 6.519131515338966
    Writing perf.json
    --- PASS: TestProcessNetwork (109.26s)
        --- PASS: TestProcessNetwork/TestNetworkFlows (0.00s)
        --- PASS: TestProcessNetwork/TestProcessLineageInfo (0.00s)
        --- PASS: TestProcessNetwork/TestProcessViz (0.00s)
    PASS
    ok  	github.com/stackrox/collector/integration-tests	109.821s

# STATS *******************************************************************************************************************
collector-dev-any-rhel-8-ghutton    : ok=8	changed=2	failed=1	unreachable=0	rescued=1	ignored=0
collector-dev-any-rhel-9-ghutton    : ok=10	changed=5	failed=0	unreachable=0	rescued=0	ignored=0
make: *** [integration-tests] Error 2 
```
