### PR TITLE
Skip builder image build when it is unmodified

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -8,6 +8,10 @@ on:
         required: true
         description: |
           The tag used to build the collector image
+    outputs:
+      collector-builder-tag:
+        description: The builder tag used by the build
+        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -1,0 +1,137 @@
+name: Collector builder image build
+
+on:
+  workflow_call:
+    inputs:
+      collector-tag:
+        type: string
+        required: true
+        description: |
+          The tag used to build the collector image
+
+env:
+  COLLECTOR_TAG: ${{ inputs.collector-tag }}
+  DEFAULT_BUILDER_TAG: cache
+
+jobs:
+  builder-needs-rebuilding:
+    name: Determine if builder image needs to be built
+    runs-on: ubuntu-latest
+    outputs:
+      build-image: steps.changed.outputs.builder-changed
+
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changed
+        with:
+          filters: |
+            builder-changed:
+              - builder/**
+              - third_party/**
+
+  build-builder-image:
+    name: Build the collector slim image
+    runs-on: ubuntu-latest
+    # Multiarch builds sometimes take for eeeeeeeeeever
+    timeout-minutes: 480
+    needs:
+    - builder-needs-rebuilding
+    if: |
+      needs.builder-needs-rebuilding.outputs.build-image == 'true' ||
+      (github.event_name == 'push' && github.ref_type == 'tag') ||
+      contains(github.event.pull_request.labels.*.name, 'build-builder-image')
+    outputs:
+      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, ppc64le, s390x]
+
+    env:
+      PLATFORM: linux/${{ matrix.arch }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Define builder tag
+        id: builder-tag
+        run: |
+          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
+          fi
+
+          echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
+          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create secrets.yml
+        run: |
+          {
+            echo "---"
+            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
+            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
+            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
+            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
+          } > ${{ github.workspace }}/ansible/secrets.yml
+
+      - name: Build images
+        timeout-minutes: 480
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e arch='${{ matrix.arch }}' \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-builder.yml
+
+  create-multiarch-manifest:
+    needs:
+    - build-builder-image
+    name: Create Multiarch manifest
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      needs.build-builder-image.outputs.collector-builder-tag != 'cache'
+    env:
+      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      ARCHS: amd64 ppc64le s390x
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to quay.io/stackrox-io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Create and push multiarch manifest for builder to stackrox-io
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          archs: ${{ env.ARCHS }}
+
+      - name: Login to quay.io/rhacs-eng
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Create and push multiarch manifest for builder to rhacs-eng
+        uses: ./.github/actions/create-multiarch-manifest
+        with:
+          base-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
+          archs: ${{ env.ARCHS }}
+

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -34,7 +34,7 @@ jobs:
               - third_party/**
 
   build-builder-image:
-    name: Build the collector slim image
+    name: Build the builder image
     runs-on: ubuntu-latest
     # Multiarch builds sometimes take for eeeeeeeeeever
     timeout-minutes: 480

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -22,7 +22,7 @@ jobs:
     name: Determine if builder image needs to be built
     runs-on: ubuntu-latest
     outputs:
-      build-image: steps.changed.outputs.builder-changed
+      build-image: ${{ steps.changed.outputs.builder-changed }}
 
     steps:
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -20,45 +20,15 @@ env:
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
 
 jobs:
-  set-environment:
-    name: Set environment variables
-    runs-on: ubuntu-latest
-    outputs:
-      build-builder-image: ${{ steps.set-env.outputs.build-builder-image }}
-      collector-builder-tag: ${{ steps.set-env.outputs.collector-builder-tag }}
-
-    steps:
-      - name: Define builder tag
-        id: set-env
-        run: |
-
-          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
-            echo "collector-builder-tag=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
-          else
-            #We have 2 options:
-            #- We build the builder from scratch and give it a custom tag
-            #- We use the existing cache
-            COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
-              COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
-            fi
-
-            echo "collector-builder-tag=$COLLECTOR_BUILDER_TAG" >> "$GITHUB_OUTPUT"
-          fi
-
   build-collector-image:
     name: Build the collector slim image
-    needs: set-environment
     runs-on: ubuntu-latest
-    # Multiarch builds sometimes take for eeeeeeeeeever
-    timeout-minutes: 480
     strategy:
       fail-fast: false
       matrix:
         arch: [amd64, ppc64le, s390x]
 
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
       PLATFORM: linux/${{ matrix.arch }}
 
     steps:
@@ -75,17 +45,9 @@ jobs:
       - name: Checks PR, main and release branches
         run: |
           if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
-            echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
+            echo "COLLECTOR_BUIDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"
           else
-            # We have 2 options:
-            # - We build the builder from scratch and give it a custom tag
-            # - We use the existing cache
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
-              echo 'BUILD_BUILDER_IMAGE=true' >> "$GITHUB_ENV"
-            else
-              echo 'BUILD_BUILDER_IMAGE=false' >> "$GITHUB_ENV"
-            fi
-
+            echo "COLLECTOR_BUIDER_TAG=${COLLECTOR_TAG}" >> "$GITHUB_ENV"
             echo "COLLECTOR_APPEND_CID=true" >> "$GITHUB_ENV"
 
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
@@ -117,13 +79,11 @@ jobs:
             --limit localhost \
             -e collector_image='${{ inputs.collector-image }}' \
             -e arch='${{ matrix.arch }}' \
-            -e push_builder="${{ github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG }}" \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-collector.yml
 
   create-multiarch-manifest:
     needs:
-    - set-environment
     - build-collector-image
     name: Create Multiarch manifest
     runs-on: ubuntu-latest
@@ -131,7 +91,6 @@ jobs:
       github.event_name == 'push' ||
       !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x
 
     steps:
@@ -158,13 +117,6 @@ jobs:
           archs: ${{ env.ARCHS }}
           suffix: -base
 
-      - name: Create and push multiarch manifest for builder to stackrox-io
-        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          archs: ${{ env.ARCHS }}
-
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v2
         with:
@@ -186,24 +138,14 @@ jobs:
           archs: ${{ env.ARCHS }}
           suffix: -base
 
-      - name: Create and push multiarch manifest for builder to rhacs-eng
-        if: github.event_name == 'push' || needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          archs: ${{ env.ARCHS }}
-
   retag-x86-image:
     needs:
-    - set-environment
     - build-collector-image
     name: Retag x86 slim image
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
-    env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.set-environment.outputs.collector-builder-tag }}
     steps:
       - uses: actions/checkout@v3
       - name: Pull images to retag
@@ -240,27 +182,5 @@ jobs:
         with:
           src-image: ${{ inputs.collector-image }}-amd64-slim
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-base
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Retag and push stackrox-io builder
-        uses: ./.github/actions/retag-and-push
-        if: |
-          github.event_name == 'push' ||
-          needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng builder
-        uses: ./.github/actions/retag-and-push
-        if: |
-          github.event_name == 'push' ||
-          needs.set-environment.outputs.collector-builder-tag != env.DEFAULT_BUILDER_TAG
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -13,10 +13,15 @@ on:
         required: true
         description: |
           Basic stackrox-io image built
+      collector-builder-tag:
+        type: string
+        required: true
+        description: |
+          The builder tag to use in the build
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
-  DEFAULT_BUILDER_TAG: cache
+  COLLECTOR_BUILDER_TAG: ${{ inputs.collector-builder-tag }}
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
 
 jobs:
@@ -44,10 +49,7 @@ jobs:
 
       - name: Checks PR, main and release branches
         run: |
-          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
-            echo "COLLECTOR_BUIDER_TAG=${DEFAULT_BUILDER_TAG}" >> "$GITHUB_ENV"
-          else
-            echo "COLLECTOR_BUIDER_TAG=${COLLECTOR_TAG}" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
             echo "COLLECTOR_APPEND_CID=true" >> "$GITHUB_ENV"
 
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}
+      collector-builder-tag: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
     secrets: inherit
 
   build-collector-full:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,18 @@ jobs:
     with:
       logs-artifact: driver-build-failures
 
+  build-builder-image:
+    uses: ./.github/workflows/collector-builder.yml
+    needs: init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+    secrets: inherit
+
   build-collector-slim:
     uses: ./.github/workflows/collector-slim.yml
-    needs: init
+    needs:
+    - init
+    - build-builder-image
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -21,17 +21,39 @@ $ pip3 install -r requirements.txt
 ```
 
 ## Image builds
-### Builder and slim collector images
+### Builder image
 
-The `ci-build-collector.yml` playbook is meant to be used by CI, it handles the
-build process for the builder and slim collector images, as well as retagging
-and pushing of these images to quay.io.
+The `ci-build-builder.yml` playbook is meant to be used by CI, it handles the
+build process for the builder image, as well as retagging and pushing to
+quay.io.
 
 #### Environment variables used by the playbook
 
 | Name | Description |
 | ---  | ---         |
-| BUILD_BUILDER_IMAGE | Controls whether the builder image should be built or pulled from a remote registry. |
+| COLLECTOR_BUILDER_TAG | The tag used for the builder image. |
+| PLATFORM | The platform the images are being built for, currently the supported values are:<br>- linux/amd64<br>- linux/ppc64le<br>- linux/s390x |
+
+#### Ansible variables to be supplied to the playbook
+
+| Name | Description |
+| ---  | ---         |
+| arch | The architecture the images are being built for, currently the supported values are:<br>- amd64<br>- ppc64le<br>- s390x |
+| stackrox_io_username | Username used for pushing images to quay.io/stackrox-io |
+| stackrox_io_password | Password used for pushing images to quay.io/stackrox-io |
+| rhacs_eng_username | Username used for pushing images to quay.io/rhacs-eng |
+| rhacs_eng_password | Password used for pushing images to quay.io/rhacs-eng |
+
+### Slim collector image
+
+The `ci-build-collector.yml` playbook is meant to be used by CI, it handles the
+build process for the slim collector image, as well as retagging and pushing
+of these images to quay.io.
+
+#### Environment variables used by the playbook
+
+| Name | Description |
+| ---  | ---         |
 | COLLECTOR_BUILDER_TAG | The tag used for the builder image. |
 | PLATFORM | The platform the images are being built for, currently the supported values are:<br>- linux/amd64<br>- linux/ppc64le<br>- linux/s390x |
 | COLLECTOR_TAG | The tag to be used with the collector image |
@@ -47,7 +69,6 @@ and pushing of these images to quay.io.
 | stackrox_io_password | Password used for pushing images to quay.io/stackrox-io |
 | rhacs_eng_username | Username used for pushing images to quay.io/rhacs-eng |
 | rhacs_eng_password | Password used for pushing images to quay.io/rhacs-eng |
-| push_builder | If 'true', the builder will be pushed to the registries alongside the collector images |
 
 ## Integration tests
 ### Overview

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -1,0 +1,63 @@
+---
+- name: Build and push collector image
+  hosts: all
+
+  environment:
+    BUILD_BUILDER_IMAGE: "true"
+    COLLECTOR_BUILDER_TAG: "{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+    PLATFORM: "{{ ansible_env.PLATFORM }}"
+
+  tasks:
+    - name: Build the collector builder image
+      community.general.make:
+        chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
+        target: builder
+
+    - name: Retag collector builder image to arch specific
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        repository: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        source: local
+
+    - name: Untag collector builder image to prevent issues with multiarch
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        state: absent
+
+    - name: Login to quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        username: "{{ stackrox_io_username }}"
+        password: "{{ stackrox_io_password }}"
+
+    - name: Push builder image to quay.io/stackrox-io
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        push: true
+        source: local
+
+    - name: Login to quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        username: "{{ rhacs_eng_username }}"
+        password: "{{ rhacs_eng_password }}"
+
+    - name: Push builder image to quay.io/rhacs-eng
+      community.docker.docker_image:
+        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        repository: "quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        push: true
+        source: local
+
+    - name: Print builder images pushed
+      debug:
+        msg:
+          - "Pushed the following builder images:"
+          - "  quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+          - "  quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+
+    - name: Logout of quay.io
+      community.docker.docker_login:
+        registry_url: quay.io
+        state: absent
+      when: true

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -3,7 +3,6 @@
   hosts: all
 
   environment:
-    BUILD_BUILDER_IMAGE: "{{ ansible_env.BUILD_BUILDER_IMAGE }}"
     COLLECTOR_BUILDER_TAG: "{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
     PLATFORM: "{{ ansible_env.PLATFORM }}"
     COLLECTOR_TAG: "{{ ansible_env.COLLECTOR_TAG }}"
@@ -25,17 +24,6 @@
         name: "{{ collector_image }}"
         state: absent
 
-    - name: Retag collector builder image to arch specific
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        repository: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        source: local
-
-    - name: Untag collector builder image to prevent issues with multiarch
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        state: absent
-
     - name: Login to quay.io
       community.docker.docker_login:
         registry_url: quay.io
@@ -54,13 +42,6 @@
         repository: "{{ collector_image }}-{{ arch }}-base"
         push: true
         source: local
-
-    - name: Push builder image to quay.io/stackrox-io
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        push: true
-        source: local
-      when: push_builder == "true"
 
     - name: Login to quay.io
       community.docker.docker_login:
@@ -82,14 +63,6 @@
         push: true
         source: local
 
-    - name: Push builder image to quay.io/rhacs-eng
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        repository: "quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        push: true
-        source: local
-      when: push_builder == "true"
-
     - name: Print images pushed
       debug:
         msg:
@@ -98,14 +71,6 @@
         - "  {{ collector_image }}-{{ arch }}-base"
         - "  {{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-slim"
         - "  {{ ansible_env.RHACS_ENG_IMAGE }}-{{ arch }}-base"
-
-    - name: Print builder images pushed
-      debug:
-        msg:
-        - "Pushed the following builder images:"
-        - "  quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        - "  quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-      when: push_builder == "true"
 
     - name: Logout of quay.io
       community.docker.docker_login:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -5,6 +5,7 @@ ENV NPROCS=$NPROCS
 
 ARG BUILD_DIR=/install-tmp
 
+# Useless change for CI, rollback afterwards
 USER root
 
 # clang 15 is used here due to an error on clang 16 when running on QEMU

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -5,7 +5,6 @@ ENV NPROCS=$NPROCS
 
 ARG BUILD_DIR=/install-tmp
 
-# Useless change for CI, rollback afterwards
 USER root
 
 # clang 15 is used here due to an error on clang 16 when running on QEMU


### PR DESCRIPTION
## Description

Skip the builder image build when no changes would make modifications to the actual image (i.e.: no change to third_party libraries and the builder directory itself).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing Performed
- [x] Run with `build-builder-image` should force build the builder.
- [x] Run with a change to either the `third_party` or `builder` directories should build the builder. ([CI run](https://github.com/stackrox/collector/actions/runs/5834100265?pr=1284))
- [x] Running with no changes to the `third_party` or `builder` directories should skip building the builder. ([CI run](https://github.com/stackrox/collector/actions/runs/5853649433/job/15870801596?pr=1284))