### PR TITLE
Split cpaas workflow from main

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 6 * * *'
   pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - reopened
 
 jobs:
   should-run:
@@ -15,6 +21,7 @@ jobs:
         run: |
           SHOULD_RUN="${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps') }}"
           echo "should-run=${SHOULD_RUN}" >> "$GITHUB_OUTPUT"
+
   init:
     needs:
     - should-run

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -3,10 +3,22 @@ name: CPaaS related workflows
 on:
   schedule:
     - cron: '0 6 * * *'
-  workflow_call:
+  pull_request:
 
 jobs:
+  should-run:
+    outputs:
+      should-run: ${{ steps.should-run.outputs.should-run }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: should-run
+        run: |
+          SHOULD_RUN="${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps') }}"
+          echo "should-run=${SHOULD_RUN}" >> "$GITHUB_OUTPUT"
   init:
+    needs:
+    - should-run
+    if: needs.should-run.outputs.should-run == 'true'
     uses: ./.github/workflows/init.yml
 
   sync-drivers-and-support-packages:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,8 +116,3 @@ jobs:
     - build-drivers
     - upload-drivers
     secrets: inherit
-
-  run-cpaas-steps:
-    uses: ./.github/workflows/cpaas.yml
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps')
-    secrets: inherit


### PR DESCRIPTION
## Description

The only purpose for this change is to bring additional clarity to our CI pipeline, since the main workflow was becoming too crowded.

Summary for a PR before this change:
![image](https://github.com/stackrox/collector/assets/20206636/b02bbfa5-c06b-4476-8811-34604102638f)

After this change the summary gets split in two:
![image](https://github.com/stackrox/collector/assets/20206636/69e25b0c-2c26-465e-83d1-f42815349d26)

![image](https://github.com/stackrox/collector/assets/20206636/2440409d-8cf0-44be-b72f-0caffbf10de3)

This makes them a bit easier to understand and follow what is going on.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Running with the `run-cpaas-steps` label runs the CPaaS related workflows in the PR.
- [ ] Running without the `run-cpaas-steps` label skips all CPaaS related workflows in the PR.
 