### PR TITLE
Checkout code when determining if builder should be built

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -25,6 +25,8 @@ jobs:
       build-image: ${{ steps.changed.outputs.builder-changed }}
 
     steps:
+      - uses: actions/checkout@v3
+
       - uses: dorny/paths-filter@v2
         id: changed
         with:


### PR DESCRIPTION

## Description

The docs for the dorny/paths-filter action are somewhat confusing, apparently not checking out the repo works fine on PRs, but fail miserably on any other sort of trigger:
https://github.com/dorny/paths-filter/issues/60

Looking closer at the docs, seems a simple checkout should work for the cases we care about.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Test on a mock branch with the push event trigger ([CI run](https://github.com/stackrox/collector/actions/runs/5875564405/job/15932108491))
