### PR TITLE
Remove stale pull of builder image with skip-multiarch

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -150,10 +150,9 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
     steps:
       - uses: actions/checkout@v3
-      - name: Pull images to retag
+      - name: Pull image to retag
         run: |
           docker pull ${{ inputs.collector-image }}-amd64-slim
-          docker pull quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
 
       - name: Retag and push stackrox-io -slim
         uses: ./.github/actions/retag-and-push


### PR DESCRIPTION
## Description

We used to pull the builder image in the `skip-multiarch-builds`, which now breaks when the builder's build is skipped (builder tag not set).

This seems uneeded now, so let's just remove it.