### PR TITLE
[ROX-18733	] Always verify core_bpf

### DIFF
--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -51,7 +51,7 @@ class CollectionHeuristic : public Heuristic {
           host.HasBPFRingBufferSupport() &&
           host.HasBPFTracingSupport()) {
         CLOG(INFO) << "CORE_BPF collection method is available. "
-                   << "HINT: Check the documentation to compare features of "
+                   << "Check the documentation to compare features of "
                    << "available collection methods.";
       }
     }

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -44,6 +44,17 @@ class CollectionHeuristic : public Heuristic {
         CLOG(FATAL) << "Missing BPF tracepoint support.";
       }
     }
+
+    // If configured to use regular eBPF, still verify if CORE_BPF is supported.
+    if (config.GetCollectionMethod() == CollectionMethod::EBPF) {
+      if (host.HasBTFSymbols() &&
+          host.HasBPFRingBufferSupport() &&
+          host.HasBPFTracingSupport()) {
+        CLOG(INFO) << "CORE_BPF collection method is available. "
+                   << "HINT: Check the documentation to compare features of "
+                   << "available collection methods.";
+      }
+    }
   }
 };
 


### PR DESCRIPTION
## Description

Even if using ebpf collection method, test for core_bpf to help with adoption. Here is how it looks like:

```
[INFO    2023/08/16 12:02:27] (HostHeuristics.cpp:53) CORE_BPF collection method is available.
HINT: Check the documentation to compare features of available collection methods.
```

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
~- [ ] Added unit tests~
~- [ ] Added integration tests~
~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Local testing.