### PR TITLE
Remove kernel modules from the dev build

### DIFF
--- a/kernel-modules/dev/build-drivers.sh
+++ b/kernel-modules/dev/build-drivers.sh
@@ -3,14 +3,6 @@ set -euo pipefail
 
 OUTPUT_DIR="/collector/kernel-modules/container/kernel-modules"
 
-package_kmod() {
-    kernel=$1
-    probe_object=$2
-
-    gzip -c "${probe_object}" \
-        > "${OUTPUT_DIR}/collector-${kernel}.ko.gz"
-}
-
 package_probe() {
     kernel=$1
     probe_object=$2
@@ -38,11 +30,9 @@ cmake -S ${DRIVER_DIR} \
     -DBUILD_LIBSCAP_MODERN_BPF=ON \
     -DMODERN_BPF_EXCLUDE_PROGS='^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$' \
     -B ${DRIVER_DIR}/build
-make -C ${DRIVER_DIR}/build/driver
 make -C ${PROBE_DIR} FALCO_DIR="${DRIVER_DIR}/driver/bpf"
 
 mkdir -p "${OUTPUT_DIR}"
-package_kmod "$KERNEL_VERSION" "$DRIVER_DIR/build/driver/collector.ko"
 package_probe "$KERNEL_VERSION" "$PROBE_DIR/probe.o"
 
 # No reason to leave this hanging about


### PR DESCRIPTION
## Description

Since kernel modules have been deprecated, I think we can remove them from the dev image builds. Further more, the build is broken on newer kernels (tested on 6.4) so the script fails in these cases and makes it harder to test changes.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [x] Manually built an image with embedded eBPF probe for dev purposes.
