### PR TITLE
Fixes integration tests on noexec mounted directories

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,9 @@ jobs:
       fail-fast: false
       matrix:
         vm_type:
-          - cos
+          # COS testing is disabled until ROX-15295 is completed
+          # due to noexec flags on the file system mounts
+          #- cos
           - flatcar
           - fedora-coreos
           - rhel-sap

--- a/ansible/roles/run-test-target/tasks/build-tests.yml
+++ b/ansible/roles/run-test-target/tasks/build-tests.yml
@@ -12,7 +12,7 @@
 - name: Upload test binary
   copy:
     src: "{{ integration_tests_root }}/bin/collector-tests"
-    dest: "{{ remote_tests_root }}"
+    dest: "{{ remote_tests_root }}/"
     mode: '0700'
 
 - name: Upload test files

--- a/ansible/roles/run-test-target/vars/main.yml
+++ b/ansible/roles/run-test-target/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
 integration_tests_root: "{{ collector_root }}/integration-tests"
-remote_tests_root: /tmp/collector-tests/
+remote_tests_root: "{{ ansible_env.HOME }}/collector-tests/"
 remote_tests_binary: "{{ remote_tests_root }}/collector-tests"
 remote_logs_root: "{{ remote_tests_root }}/container-logs"

--- a/ansible/roles/run-test-target/vars/main.yml
+++ b/ansible/roles/run-test-target/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
 integration_tests_root: "{{ collector_root }}/integration-tests"
-remote_tests_root: "{{ ansible_env.HOME }}/collector-tests/"
+remote_tests_root: "{{ ansible_env.HOME }}/collector-tests"
 remote_tests_binary: "{{ remote_tests_root }}/collector-tests"
 remote_logs_root: "{{ remote_tests_root }}/container-logs"


### PR DESCRIPTION
## Description

With the tests now running directly on the host, some hosts mount `/tmp` `noexec` which means we get permission denied errors when trying to run the integration tests from that location. This PR changes the location to the user's home directory to avoid the `noexec` constraint. 

Longer term, tests should be containerized to avoid this issue altogether

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally against garden linux, will rely on CI to test the remainder of the platforms. 
