### PR TITLE
Jv fix missing probe troubelshooting

### DIFF
--- a/utilities/troubleshooting/missing-probe.sh
+++ b/utilities/troubleshooting/missing-probe.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 
 kernel=$1
 module_version=$2
-probe_type=${3:-both}
+probe_type=${3:-bpf}
 bucket=${4:-612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656}
 branch=${5:-master}
 
@@ -136,7 +136,7 @@ check_if_bundle_exists() {
 
     print_header "Checking if bundle exists"
 
-    bundle_file="gs://stackrox-kernel-bundles/bundle-$kernel.tgz"
+    bundle_file="gs://collector-kernel-bundles-public/bundle-$kernel.tgz"
 
     if ! gsutil ls "$bundle_file"; then
         echo "The bundle for $kernel does NOT exist"


### PR DESCRIPTION
## Description

The script modified here does a few checks when a probe is missing. It was checking for bundles in a bucket that is no longer used. The bucket is updated here. This script also checks for both ebpf and kernel module probes by default. I am keeping the checks for kernel modules for now, but the default is switched to ebpf.

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
 ~~ - [ ] Added unit tests~~
 ~~ - [ ] Added integration tests~~
 ~~ - [ ] Added regression tests~~

If any of these don't apply, please comment below.

This isn't a change to the product itself.

## Testing Performed

Test for missing probe

```
./missing-probe.sh 5.14.0-284.30.1.el9_2.x86_64 2.6.0

################

Checking if kernel version is supported by branch master

Kernel 5.14.0-284.30.1.el9_2.x86_64 NOT found in kernel-modules/KERNEL_VERSIONS in the master branch

################


################

Checking if bundle exists

CommandException: One or more URLs matched no objects.
The bundle for 5.14.0-284.30.1.el9_2.x86_64 does NOT exist

################


################

Checking if the bpf probe exists for the module version

CommandException: One or more URLs matched no objects.
The bpf probe for 5.14.0-284.30.1.el9_2.x86_64 does NOT exist for module version 2.6.0

################


################

Checking if the bpf probe is marked unavailable for the module version

CommandException: One or more URLs matched no objects.
The bpf probe for 5.14.0-284.30.1.el9_2.x86_64 is not marked as unavailable for module_version 2.6.0. That does not mean that it is available

################


################

Checking if the bpf probe exists for any module version

CommandException: One or more URLs matched no objects.
A bpf probe for 5.14.0-284.30.1.el9_2.x86_64 does NOT exist in any module version

################
```


Test for existent probe

```

./missing-probe.sh 5.14.0-284.28.1.el9_2.x86_64 2.6.0

################

Checking if kernel version is supported by branch master

master:kernel-modules/KERNEL_VERSIONS:5.14.0-284.28.1.el9_2.x86_64
Kernel 5.14.0-284.28.1.el9_2.x86_64 FOUND in kernel-modules/KERNEL_VERSIONS in the master branch

################


################

Checking if bundle exists

gs://collector-kernel-bundles-public/bundle-5.14.0-284.28.1.el9_2.x86_64.tgz
The bundle for 5.14.0-284.28.1.el9_2.x86_64 DOES exist

################


################

Checking if the bpf probe exists for the module version

gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.6.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
The bpf probe for 5.14.0-284.28.1.el9_2.x86_64 DOES exist for module version 2.6.0

################


################

Checking if the bpf probe is marked unavailable for the module version

CommandException: One or more URLs matched no objects.
The bpf probe for 5.14.0-284.28.1.el9_2.x86_64 is not marked as unavailable for module_version 2.6.0. That does not mean that it is available

################


################

Checking if the bpf probe exists for any module version

gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.2.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.3.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.4.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.5.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
gs://collector-modules/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656/2.6.0/collector-ebpf-5.14.0-284.28.1.el9_2.x86_64.o.gz
A bpf probe for 5.14.0-284.28.1.el9_2.x86_64 DOES exist in at least one module version

################
```
