### PR TITLE
ROX-19605: new feature-flag to control aggregation of unmatched IPs

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -38,7 +38,7 @@ BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
 
-BoolEnvVar aggregate_unmatched_ip("ROX_COLLECTOR_AGGREGATE_UNMATCHED_IP", true);
+BoolEnvVar enable_external_ips("ROX_ENABLE_EXTERNAL_IPS", false);
 
 }  // namespace
 
@@ -60,7 +60,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   core_bpf_hardfail_ = core_bpf_hardfail.value();
   import_users_ = set_import_users.value();
   collect_connection_status_ = collect_connection_status.value();
-  aggregate_unmatched_ip_ = aggregate_unmatched_ip.value();
+  enable_external_ips_ = enable_external_ips.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);
@@ -240,7 +240,7 @@ std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
          << ", logLevel:" << c.LogLevel()
          << ", set_import_users:" << c.ImportUsers()
          << ", collect_connection_status:" << c.CollectConnectionStatus()
-         << ", aggregate_unmatched_ip:" << c.AggregateUnmatchedIp();
+         << ", enable_external_ips:" << c.EnableExternalIPs();
 }
 
 }  // namespace collector

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -38,6 +38,8 @@ BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
 
+BoolEnvVar aggregate_unmatched_ip("ROX_COLLECTOR_AGGREGATE_UNMATCHED_IP", true);
+
 }  // namespace
 
 constexpr bool CollectorConfig::kTurnOffScrape;
@@ -58,6 +60,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   core_bpf_hardfail_ = core_bpf_hardfail.value();
   import_users_ = set_import_users.value();
   collect_connection_status_ = collect_connection_status.value();
+  aggregate_unmatched_ip_ = aggregate_unmatched_ip.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.push_back(syscall);
@@ -236,7 +239,8 @@ std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
          << ", processesListeningOnPorts:" << c.IsProcessesListeningOnPortsEnabled()
          << ", logLevel:" << c.LogLevel()
          << ", set_import_users:" << c.ImportUsers()
-         << ", collect_connection_status:" << c.CollectConnectionStatus();
+         << ", collect_connection_status:" << c.CollectConnectionStatus()
+         << ", aggregate_unmatched_ip:" << c.AggregateUnmatchedIp();
 }
 
 }  // namespace collector

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -72,7 +72,7 @@ class CollectorConfig {
   bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
-  bool AggregateUnmatchedIp() const { return aggregate_unmatched_ip_; }
+  bool EnableExternalIPs() const { return enable_external_ips_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -96,7 +96,7 @@ class CollectorConfig {
   bool core_bpf_hardfail_;
   bool import_users_;
   bool collect_connection_status_;
-  bool aggregate_unmatched_ip_;
+  bool enable_external_ips_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -72,6 +72,7 @@ class CollectorConfig {
   bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
+  bool AggregateUnmatchedIp() const { return aggregate_unmatched_ip_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -95,6 +96,7 @@ class CollectorConfig {
   bool core_bpf_hardfail_;
   bool import_users_;
   bool collect_connection_status_;
+  bool aggregate_unmatched_ip_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -79,7 +79,7 @@ void CollectorService::RunForever() {
     conn_tracker = std::make_shared<ConnectionTracker>();
     UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
     conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
-    conn_tracker->AggregateUnmatchedIp(config_.AggregateUnmatchedIp());
+    conn_tracker->EnableExternalIPs(config_.EnableExternalIPs());
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
 

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -79,6 +79,7 @@ void CollectorService::RunForever() {
     conn_tracker = std::make_shared<ConnectionTracker>();
     UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
     conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
+    conn_tracker->AggregateUnmatchedIp(config_.AggregateUnmatchedIp());
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
 

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -91,15 +91,19 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return network;
   }
 
-  // Otherwise, associate it to "rest of the internet".
-  switch (address.family()) {
-    case Address::Family::IPV4:
-      return IPNet(canonical_external_ipv4_addr, 0, true);
-    case Address::Family::IPV6:
-      return IPNet(canonical_external_ipv6_addr, 0, true);
-    default:
-      return {};
+  if (aggregateUnmatchedIp_) {
+    // associate it to "rest of the internet".
+    switch (address.family()) {
+      case Address::Family::IPV4:
+        return IPNet(canonical_external_ipv4_addr, 0, true);
+      case Address::Family::IPV6:
+        return IPNet(canonical_external_ipv6_addr, 0, true);
+      default:
+        return {};
+    }
   }
+
+  return IPNet(address, 0, true);
 }
 
 Connection ConnectionTracker::NormalizeConnectionNoLock(const Connection& conn) const {

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -91,19 +91,19 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return network;
   }
 
-  if (aggregate_unmatched_ip_) {
-    // associate it to "rest of the internet".
-    switch (address.family()) {
-      case Address::Family::IPV4:
-        return IPNet(canonical_external_ipv4_addr, 0, true);
-      case Address::Family::IPV6:
-        return IPNet(canonical_external_ipv6_addr, 0, true);
-      default:
-        return {};
-    }
+  if (enable_external_ips_) {
+    return IPNet(address, 0, true);
   }
 
-  return IPNet(address, 0, true);
+  // associate it to "rest of the internet".
+  switch (address.family()) {
+    case Address::Family::IPV4:
+      return IPNet(canonical_external_ipv4_addr, 0, true);
+    case Address::Family::IPV6:
+      return IPNet(canonical_external_ipv6_addr, 0, true);
+    default:
+      return {};
+  }
 }
 
 Connection ConnectionTracker::NormalizeConnectionNoLock(const Connection& conn) const {

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -95,7 +95,7 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return IPNet(address, 0, true);
   }
 
-  // associate it to "rest of the internet".
+  // Otherwise, associate it to "rest of the internet".
   switch (address.family()) {
     case Address::Family::IPV4:
       return IPNet(canonical_external_ipv4_addr, 0, true);

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -91,7 +91,7 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return network;
   }
 
-  if (aggregateUnmatchedIp_) {
+  if (aggregate_unmatched_ip_) {
     // associate it to "rest of the internet".
     switch (address.family()) {
       case Address::Family::IPV4:

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -127,6 +127,7 @@ class ConnectionTracker {
 
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
+  void AggregateUnmatchedIp(bool aggregate) { aggregateUnmatchedIp_ = aggregate; }
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
 
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
@@ -176,6 +177,7 @@ class ConnectionTracker {
 
   UnorderedSet<Address> known_public_ips_;
   NRadixTree known_ip_networks_;
+  bool aggregateUnmatchedIp_ = true;
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
 };

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -127,7 +127,7 @@ class ConnectionTracker {
 
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
-  void AggregateUnmatchedIp(bool aggregate) { aggregateUnmatchedIp_ = aggregate; }
+  void AggregateUnmatchedIp(bool aggregate) { aggregate_unmatched_ip_ = aggregate; }
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
 
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
@@ -177,7 +177,7 @@ class ConnectionTracker {
 
   UnorderedSet<Address> known_public_ips_;
   NRadixTree known_ip_networks_;
-  bool aggregateUnmatchedIp_ = true;
+  bool aggregate_unmatched_ip_ = true;
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
 };

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -127,7 +127,7 @@ class ConnectionTracker {
 
   void UpdateKnownPublicIPs(UnorderedSet<Address>&& known_public_ips);
   void UpdateKnownIPNetworks(UnorderedMap<Address::Family, std::vector<IPNet>>&& known_ip_networks);
-  void AggregateUnmatchedIp(bool aggregate) { aggregate_unmatched_ip_ = aggregate; }
+  void EnableExternalIPs(bool enable) { enable_external_ips_ = enable; }
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
 
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
@@ -177,7 +177,7 @@ class ConnectionTracker {
 
   UnorderedSet<Address> known_public_ips_;
   NRadixTree known_ip_networks_;
-  bool aggregate_unmatched_ip_ = true;
+  bool enable_external_ips_ = false;
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
 };

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -355,7 +355,7 @@ TEST(ConnTrackerTest, TestUpdateNormalizedExternal) {
                           std::make_pair(conn5_normalized, ConnStatus(time_micros, true))));
 }
 
-TEST(ConnTrackerTest, TestNormalizedNoAggregate) {
+TEST(ConnTrackerTest, TestNormalizedEnableExternalIPs) {
   Endpoint a(Address(10, 1, 1, 8), 9999);
   Endpoint b(Address(10, 1, 1, 42), 9999);
   Endpoint c(Address(35, 127, 0, 15), 54321);
@@ -374,7 +374,7 @@ TEST(ConnTrackerTest, TestNormalizedNoAggregate) {
   int64_t time_micros = 1000;
 
   ConnectionTracker tracker;
-  tracker.AggregateUnmatchedIp(false);
+  tracker.EnableExternalIPs(true);
 
   UnorderedMap<Address::Family, std::vector<IPNet>> known_networks = {{Address::Family::IPV4, {IPNet(Address(35, 127, 1, 0), 24)}}};
   tracker.UpdateKnownIPNetworks(std::move(known_networks));

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -355,6 +355,56 @@ TEST(ConnTrackerTest, TestUpdateNormalizedExternal) {
                           std::make_pair(conn5_normalized, ConnStatus(time_micros, true))));
 }
 
+TEST(ConnTrackerTest, TestNormalizedNoAggregate) {
+  Endpoint a(Address(10, 1, 1, 8), 9999);
+  Endpoint b(Address(10, 1, 1, 42), 9999);
+  Endpoint c(Address(35, 127, 0, 15), 54321);
+  Endpoint d(Address(35, 127, 1, 200), 54321);
+
+  Connection conn1("xyz", a, b, L4Proto::TCP, true);
+  Connection conn2("xyz", a, c, L4Proto::TCP, true);
+  Connection conn3("xyz", a, d, L4Proto::TCP, true);
+  Connection conn4("xyz", a, b, L4Proto::TCP, false);
+  Connection conn5("xyz", a, c, L4Proto::TCP, false);
+  Connection conn6("xyz", a, d, L4Proto::TCP, false);
+
+  // Connection conn13_normalized("xyz", Endpoint(IPNet(), 9999), Endpoint(IPNet(Address(255, 255, 255, 255), 0, true), 0), L4Proto::TCP, true);
+  // Connection conn24_normalized("xyz", Endpoint(), Endpoint(IPNet(Address(255, 255, 255, 255), 0, true), 54321), L4Proto::TCP, false);
+
+  int64_t time_micros = 1000;
+
+  ConnectionTracker tracker;
+  tracker.AggregateUnmatchedIp(false);
+
+  UnorderedMap<Address::Family, std::vector<IPNet>> known_networks = {{Address::Family::IPV4, {IPNet(Address(35, 127, 1, 0), 24)}}};
+  tracker.UpdateKnownIPNetworks(std::move(known_networks));
+
+  tracker.Update({conn1, conn2, conn3, conn4, conn5, conn6}, {}, time_micros);
+
+  auto state = tracker.FetchConnState(true);
+
+  // from private network
+  Connection conn1_normalized("xyz", Endpoint(IPNet(), 9999), Endpoint(IPNet(Address(10, 1, 1, 42), 0, true), 0), L4Proto::TCP, true);
+  // from unmatched external IP
+  Connection conn2_normalized("xyz", Endpoint(IPNet(), 9999), Endpoint(IPNet(Address(35, 127, 0, 15), 0, true), 0), L4Proto::TCP, true);
+  // from matched external IP
+  Connection conn3_normalized("xyz", Endpoint(IPNet(), 9999), Endpoint(IPNet(Address(35, 127, 1, 0), 24, false), 0), L4Proto::TCP, true);
+  // to private network
+  Connection conn4_normalized("xyz", Endpoint(), Endpoint(IPNet(Address(10, 1, 1, 42), 0, true), 9999), L4Proto::TCP, false);
+  // to unmatched external IP
+  Connection conn5_normalized("xyz", Endpoint(), Endpoint(IPNet(Address(35, 127, 0, 15), 0, true), 54321), L4Proto::TCP, false);
+  // to matched external IP
+  Connection conn6_normalized("xyz", Endpoint(), Endpoint(IPNet(Address(35, 127, 1, 0), 24, false), 54321), L4Proto::TCP, false);
+
+  EXPECT_THAT(state, UnorderedElementsAre(
+                         std::make_pair(conn1_normalized, ConnStatus(time_micros, true)),
+                         std::make_pair(conn2_normalized, ConnStatus(time_micros, true)),
+                         std::make_pair(conn3_normalized, ConnStatus(time_micros, true)),
+                         std::make_pair(conn4_normalized, ConnStatus(time_micros, true)),
+                         std::make_pair(conn5_normalized, ConnStatus(time_micros, true)),
+                         std::make_pair(conn6_normalized, ConnStatus(time_micros, true))));
+}
+
 TEST(ConnTrackerTest, TestUpdateNormalizedExternalDelta) {
   Endpoint a(Address(10, 1, 1, 8), 9999);
   Endpoint b(Address(139, 14, 171, 3), 54321);


### PR DESCRIPTION
## Description

A new feature-flag ROX_ENABLE_EXTERNAL_IPS environment variable controls whether external network connections which do not match any defined known network are aggregated in the default bucket.

The default value is false, which corresponds to the previous behavior. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests