### PR TITLE
Use the effective URL for logging when downloading a driver

### DIFF
--- a/collector/lib/FileDownloader.cpp
+++ b/collector/lib/FileDownloader.cpp
@@ -317,7 +317,6 @@ bool FileDownloader::Download() {
 
     if (result != CURLE_OK) {
       CLOG(WARNING) << "Unable to set connection host, the download is likely to fail - " << curl_easy_strerror(result);
-      return false;
     }
   }
 

--- a/collector/lib/FileDownloader.cpp
+++ b/collector/lib/FileDownloader.cpp
@@ -145,8 +145,6 @@ FileDownloader::~FileDownloader() {
   }
 
   curl_global_cleanup();
-
-  connect_to_.reset();
 }
 
 bool FileDownloader::SetURL(const char* const url) {

--- a/collector/lib/FileDownloader.h
+++ b/collector/lib/FileDownloader.h
@@ -6,6 +6,7 @@
 #include <ostream>
 
 #include <curl/curl.h>
+#include <curl/urlapi.h>
 
 namespace collector {
 
@@ -15,6 +16,11 @@ struct DownloadData {
   std::ostream* os;
 };
 
+/**
+ * Wrapper aroung libcurl for downloading files.
+ * See https://curl.se/libcurl/c/libcurl-easy.html for details about specific
+ * methods
+ */
 class FileDownloader {
  public:
   enum resolve_t {
@@ -41,15 +47,23 @@ class FileDownloader {
   bool ConnectTo(const char* const entry);
   void SetVerboseMode(bool verbose);
 
+  std::string GetURL() { return GetURLPart(CURLUPART_URL); }
+  std::string GetHost() { return GetURLPart(CURLUPART_HOST); }
+  std::string GetPort() { return GetURLPart(CURLUPART_PORT); }
+  std::string GetScheme() { return GetURLPart(CURLUPART_SCHEME); }
+  std::string GetPath() { return GetURLPart(CURLUPART_PATH); }
+  std::string GetEffectiveURL();
+
   void ResetCURL();
   bool IsReady();
   bool Download();
 
  private:
   CURL* curl_;
+  CURLU* url_;
   curl_slist* connect_to_;
   std::string output_path_;
-  std::string url_path_;
+  std::string file_path_;
   std::array<char, CURL_ERROR_SIZE> error_;
   struct {
     unsigned int times;
@@ -58,6 +72,7 @@ class FileDownloader {
   } retry_;
 
   void SetDefaultOptions();
+  std::string GetURLPart(CURLUPart part);
 };
 
 }  // namespace collector

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -71,9 +71,10 @@ bool DownloadKernelObjectFromHostname(FileDownloader& downloader, const Json::Va
 
   std::string server_hostname;
   if (hostname.compare(0, port_offset, SNI_hostname) != 0) {
+    downloader.SetConnectTo(SNI_hostname, hostname);
+
     const std::string server_port(hostname.substr(port_offset + 1));
     server_hostname = SNI_hostname + ":" + server_port;
-    downloader.ConnectTo(SNI_hostname + ":" + server_port + ":" + hostname);
   } else {
     server_hostname = hostname;
   }

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -32,10 +32,15 @@ bool DownloadKernelObjectFromURL(FileDownloader& downloader, const std::string& 
   url += "?cid=collector";
 #endif
 
-  CLOG(INFO) << "Attempting to download kernel object from " << url;
+  if (!downloader.SetURL(url)) {
+    return false;
+  }
 
-  if (!downloader.SetURL(url)) return false;
-  if (!downloader.Download()) return false;
+  CLOG(INFO) << "Attempting to download kernel object from " << downloader.GetEffectiveURL();
+
+  if (!downloader.Download()) {
+    return false;
+  }
 
   CLOG(DEBUG) << "Downloaded kernel object from " << url;
 

--- a/collector/test/FileDownloaderTest.cpp
+++ b/collector/test/FileDownloaderTest.cpp
@@ -113,23 +113,25 @@ TEST(FileDownloaderTest, EffectiveURLBasic) {
 
 TEST(FileDownloaderTest, EffectiveURLConnectTo) {
   std::string url = "https://sensor.stackrox.svc:443/some-file.o.gz";
-  std::string target = "sensor.stackrox.svc:443:sensor.rhacs-operator.svc:443";
+  std::string host = "sensor.stackrox.svc";
+  std::string connect_to = "sensor.rhacs-operator.svc:443";
   std::string expected_url = "https://sensor.rhacs-operator.svc:443/some-file.o.gz";
   FileDownloader fd;
 
   fd.SetURL(url);
-  fd.ConnectTo(target);
+  fd.SetConnectTo(host, connect_to);
 
   ASSERT_EQ(expected_url, fd.GetEffectiveURL());
 }
 TEST(FileDownloaderTest, EffectiveURLConnectToNoMatch) {
   std::string url = "https://sensor.stackrox.svc:8443/some-file.o.gz";
-  std::string target = "sensor.stackrox.svc:443:sensor.rhacs-operator.svc:443";
+  std::string host = "sensor.stackrox.svc";
+  std::string connect_to = "sensor.rhacs-operator.svc:443";
   std::string_view expected_url = url;
   FileDownloader fd;
 
   fd.SetURL(url);
-  fd.ConnectTo(target);
+  fd.SetConnectTo(host, connect_to);
 
   ASSERT_EQ(expected_url, fd.GetEffectiveURL());
 }


### PR DESCRIPTION
## Description

Loosely related to ROX-19614, when sensor and collector are deployed to a namespace other than stackrox, the URL logged by collector points to it trying to download the driver from sensor.stackrox.svc when it should be using sensor.<namespace>.svc.

This change adds a GetEffectiveURL method to the FileDownloader class, so we can now print the correct URL the driver will be downloaded from.

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
  - [x] Added unit tests

## Testing Performed

Deployed the image to a non standard namespace and checked the collector logs:
```
[INFO    2023/09/12 10:38:20] Sensor configured at address: sensor.rhacs-operator.svc:443
[INFO    2023/09/12 10:38:20] Attempting to connect to Sensor
[INFO    2023/09/12 10:38:20] Successfully connected to Sensor.
[INFO    2023/09/12 10:38:20] Module version: 2.6.0
[INFO    2023/09/12 10:38:20] Config: collection_method:ebpf, scrape_interval:30, turn_off_scrape:0, hostname:kind-control-plane, processesListeningOnPorts:1, logLevel:INFO, set_import_users:0, collect_connection_status:1
[INFO    2023/09/12 10:38:20] Candidate drivers:
[INFO    2023/09/12 10:38:20] collector-ebpf-6.4.13-200.fc38.x86_64.o
[INFO    2023/09/12 10:38:20] Attempting to download collector-ebpf-6.4.13-200.fc38.x86_64.o
[INFO    2023/09/12 10:38:20] Attempting to download kernel object from https://sensor.rhacs-operator.svc:443/kernel-objects/2.6.0/collector-ebpf-6.4.13-200.fc38.x86_64.o.gz
```
