### PR TITLE
ROX-19721: block modules for RHEL >= 8.9

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -4,6 +4,8 @@
 # Wildcards (*) can be used for glob-style pattern matching; if a pattern is
 # prefixed with ~, it is interpreted as a (Python) regex.
 # If <module-version> or <object type> is omitted, "*" is assumed
+# ROX-19721: RHEL8.9 breaks modules
+~4.18.0-(?:50[89]|5[1-9][0-9]|[6-9][0-9]{2})\.el8\.x86_64 * mod
 ~3\.10\.0-1062(?:\.\d+)*\.el7.x86_64 * bpf
 *.el6.*
 # TODO(ROX-6615) - Kernel crawler deletes debian kernels


### PR DESCRIPTION
## Description

RHEL8.9 received backports which breaks the probe's kernel-version-adaptation-macros for most versions.
This PR blocks modules from RHEL8.9 and onwards.