### PR TITLE
Jv build all integration test containers

### DIFF
--- a/integration-tests/container/Makefile
+++ b/integration-tests/container/Makefile
@@ -1,0 +1,20 @@
+BASE_PATH = .
+include Makefile-constants.mk
+
+SHELL := /bin/bash
+
+.PHONY: build-all
+build-all:
+	@set -eou pipefail; \
+	mapfile -t container_dirs < <(ls -d */); \
+	for container_dir in "$${container_dirs[@]}"; do \
+		make -C "$$container_dir" build; \
+	done
+
+.PHONY: build-and-push-all
+build-and-push-all:
+	@set -eou pipefail; \
+	mapfile -t container_dirs < <(ls -d */); \
+	for container_dir in "$${container_dirs[@]}"; do \
+		make -C "$$container_dir" build-and-push; \
+	done

--- a/integration-tests/container/Makefile
+++ b/integration-tests/container/Makefile
@@ -3,18 +3,11 @@ include Makefile-constants.mk
 
 SHELL := /bin/bash
 
-.PHONY: build-all
-build-all:
-	@set -eou pipefail; \
-	mapfile -t container_dirs < <(ls -d */); \
-	for container_dir in "$${container_dirs[@]}"; do \
-		make -C "$$container_dir" build; \
-	done
+TARGETS := build build-and-push
+DIRS := $(wildcard ./*/)
 
-.PHONY: build-and-push-all
-build-and-push-all:
-	@set -eou pipefail; \
-	mapfile -t container_dirs < <(ls -d */); \
-	for container_dir in "$${container_dirs[@]}"; do \
-		make -C "$$container_dir" build-and-push; \
-	done
+$(TARGETS): $(DIRS)
+$(DIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+.PHONY: $(TARGETS) $(DIRS)

--- a/integration-tests/container/README.md
+++ b/integration-tests/container/README.md
@@ -25,13 +25,13 @@ version.
 
 To build all images run
 
-`make build-all`
+`make build`
 
 in this directory
 
 To build and push all images run
 
-`make build-and-push-all`
+`make build-and-push`
 
 in this directory
 

--- a/integration-tests/container/README.md
+++ b/integration-tests/container/README.md
@@ -23,6 +23,18 @@ The intention of this version number is to ensure consistency across master
 testing and release testing, whereby releases are pegged to a specific QA image
 version.
 
+To build all images run
+
+`make build-all`
+
+in this directory
+
+To build and push all images run
+
+`make build-and-push-all`
+
+in this directory
+
 ## stackrox/benchmark-collector:phoronix
 - This is preconfigured version of phoronix that runs the hackbench process workload -- the configuration XML files were created by running phoronix manually to create the batch configuration files and extracting the generated xml files.
 


### PR DESCRIPTION
## Description

The integration tests depend on several images. Each of these images have their own directory in integration-tests/container. Each of those directories has a Makefile that can be used to build and push the images. CI builds and pushes these images using the Makefiles. To make this more convenient when running the integration tests locally a Makefile is added to the integration-tests/container to build and push all of the images, so that the Makefile targets don't have to be run individually for each directory.

All of the Makefiles are very similar except for perf. Seems like this is a violation of DRY and they should be consolidated into the Makefile added in this PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
~~ - [ ] Added unit tests ~~
~~ - [ ] Added integration tests ~~
~~ - [ ] Added regression tests ~~

If any of these don't apply, please comment below.

This just adds a Makefile so no tests are needed for it.

## Testing Performed

`make build-all`
