### PR TITLE
Include stderr in build output ansible

### DIFF
--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -8,24 +8,13 @@
     COLLECTOR_TAG: "{{ ansible_env.COLLECTOR_TAG }}"
 
   tasks:
-    - block:
-        - name: Build the collector image
-          community.general.make:
-            chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
-            target: image
-          register: build_result
-          # ensure this action is printed
-          tags: [print_action]
-      always:
-        - name: Output built log
-          debug:
-            msg: "{{ build_result.stdout }}"
-          tags: [print_action]
-
-        - name: Build Errors
-          debug:
-            msg: "{{ build_result.stderr }}"
-          tags: [print_action]
+    - name: Build the collector image
+      community.general.make:
+        chdir: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
+        target: image
+      register: build_result
+      # ensure this action is printed
+      tags: [print_action]
 
     - name: Retag collector image to arch specific
       community.docker.docker_image:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -22,6 +22,11 @@
             msg: "{{ build_result.stdout }}"
           tags: [print_action]
 
+        - name: Build Errors
+          debug:
+            msg: "{{ build_result.stderr }}"
+          tags: [print_action]
+
     - name: Retag collector image to arch specific
       community.docker.docker_image:
         name: "{{ collector_image }}"


### PR DESCRIPTION
## Description

Rely on ansible to report stderr rather than dumping the build log in several parts. Avoids confusion and ensures a clean output on success.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

**Automated testing**
~- [ ] Added unit tests~
~- [ ] Added integration tests~
~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Tested with and without a compilation errors, and logs shared with @Molter73 for comment
