### PR TITLE
Remove all mentions of Sysdig and Falco in our codebase

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -62,29 +62,7 @@ add_definitions("-DINTERESTING_SUBSYS=\"perf_event\", \"cpu\", \"cpuset\", \"mem
 
 add_definitions(-DASSERT_TO_LOG)
 
-file(GLOB COLLECTOR_LIB_SRC_FILES ${PROJECT_SOURCE_DIR}/lib/*.cpp)
-add_library(collector_lib ${DRIVER_HEADERS} ${COLLECTOR_LIB_SRC_FILES})
-add_dependencies(collector_lib sinsp)
-target_link_libraries(collector_lib sinsp)
-target_link_libraries(collector_lib stdc++fs) # This is needed for GCC-8 to link against the filesystem library
-target_link_libraries(collector_lib cap-ng)
-target_link_libraries(collector_lib uuid)
-target_link_libraries(collector_lib libgrpc++.a libgrpc.a libgpr.a libupb.a libabsl_bad_optional_access.a libabsl_base.a libabsl_log_severity.a libabsl_spinlock_wait.a libabsl_str_format_internal.a libabsl_strings.a libabsl_strings_internal.a libabsl_throw_delegate.a libabsl_int128.a libabsl_raw_logging_internal.a libaddress_sorting.a)
-target_link_libraries(collector_lib civetweb-cpp civetweb)
-
-target_link_libraries(collector_lib rox-proto)
-
-if(DEFINED ENV{WITH_RHEL_RPMS})
-	target_link_libraries(collector_lib protobuf cares)
-else()
-	target_link_libraries(collector_lib libprotobuf.a libcares.a)
-endif()
-
-if(NOT DISABLE_PROFILING)
-	target_link_libraries(collector_lib profiler tcmalloc)
-endif()
-
-target_link_libraries(collector_lib z ssl crypto CURL::libcurl bpf)
+add_subdirectory(lib)
 
 add_executable(collector collector.cpp)
 target_link_libraries(collector collector_lib)

--- a/collector/lib/CMakeLists.txt
+++ b/collector/lib/CMakeLists.txt
@@ -1,43 +1,8 @@
-set(COLLECTOR_LIB_SRC_FILES
-    NetworkConnection.cpp
-    CollectorConfig.cpp
-    CollectorArgs.cpp
-    SignalServiceClient.cpp
-    RateLimit.cpp
-    Process.cpp
-    ProtoUtil.cpp
-    Logging.cpp
-    HostInfo.cpp
-    ProfilerHandler.cpp
-    GetStatus.cpp
-    FileDownloader.cpp
-    AbortHandler.cpp
-    ProcfsScraper.cpp
-    EventNames.cpp
-    CollectorService.cpp
-    NetworkSignalHandler.cpp
-    CollectionMethod.cpp
-    GRPCUtil.cpp
-    NetworkStatusNotifier.cpp
-    NRadix.cpp
-    GRPC.cpp
-    GetKernelObject.cpp
-    HostHeuristics.cpp
-    DriverCandidates.cpp
-    CollectorStatsExporter.cpp
-    SelfCheckHandler.cpp
-    CollectorStats.cpp
-    ConnTracker.cpp
-    StoppableThread.cpp
-    Utility.cpp
-    ProcessSignalHandler.cpp
-    ProcessSignalFormatter.cpp
-    NetworkConnectionInfoServiceComm.cpp
-    SelfChecks.cpp
-    LogLevel.cpp
-    system-inspector/Service.cpp
-    system-inspector/EventExtractor.cpp
+file(GLOB COLLECTOR_LIB_SRC_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/system-inspector/*.cpp
 )
+
 add_library(collector_lib ${DRIVER_HEADERS} ${COLLECTOR_LIB_SRC_FILES})
 add_dependencies(collector_lib sinsp)
 target_link_libraries(collector_lib sinsp)

--- a/collector/lib/CMakeLists.txt
+++ b/collector/lib/CMakeLists.txt
@@ -1,0 +1,62 @@
+set(COLLECTOR_LIB_SRC_FILES
+    NetworkConnection.cpp
+    CollectorConfig.cpp
+    CollectorArgs.cpp
+    SignalServiceClient.cpp
+    RateLimit.cpp
+    Process.cpp
+    ProtoUtil.cpp
+    Logging.cpp
+    HostInfo.cpp
+    ProfilerHandler.cpp
+    GetStatus.cpp
+    FileDownloader.cpp
+    AbortHandler.cpp
+    ProcfsScraper.cpp
+    EventNames.cpp
+    CollectorService.cpp
+    NetworkSignalHandler.cpp
+    CollectionMethod.cpp
+    GRPCUtil.cpp
+    NetworkStatusNotifier.cpp
+    NRadix.cpp
+    GRPC.cpp
+    GetKernelObject.cpp
+    HostHeuristics.cpp
+    DriverCandidates.cpp
+    CollectorStatsExporter.cpp
+    SelfCheckHandler.cpp
+    CollectorStats.cpp
+    ConnTracker.cpp
+    StoppableThread.cpp
+    Utility.cpp
+    ProcessSignalHandler.cpp
+    ProcessSignalFormatter.cpp
+    NetworkConnectionInfoServiceComm.cpp
+    SelfChecks.cpp
+    LogLevel.cpp
+    system-inspector/Service.cpp
+    system-inspector/EventExtractor.cpp
+)
+add_library(collector_lib ${DRIVER_HEADERS} ${COLLECTOR_LIB_SRC_FILES})
+add_dependencies(collector_lib sinsp)
+target_link_libraries(collector_lib sinsp)
+target_link_libraries(collector_lib stdc++fs) # This is needed for GCC-8 to link against the filesystem library
+target_link_libraries(collector_lib cap-ng)
+target_link_libraries(collector_lib uuid)
+target_link_libraries(collector_lib libgrpc++.a libgrpc.a libgpr.a libupb.a libabsl_bad_optional_access.a libabsl_base.a libabsl_log_severity.a libabsl_spinlock_wait.a libabsl_str_format_internal.a libabsl_strings.a libabsl_strings_internal.a libabsl_throw_delegate.a libabsl_int128.a libabsl_raw_logging_internal.a libaddress_sorting.a)
+target_link_libraries(collector_lib civetweb-cpp civetweb)
+
+target_link_libraries(collector_lib rox-proto)
+
+if(DEFINED ENV{WITH_RHEL_RPMS})
+    target_link_libraries(collector_lib protobuf cares)
+else()
+    target_link_libraries(collector_lib libprotobuf.a libcares.a)
+endif()
+
+if(NOT DISABLE_PROFILING)
+    target_link_libraries(collector_lib profiler tcmalloc)
+endif()
+
+target_link_libraries(collector_lib z ssl crypto CURL::libcurl bpf)

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -7,11 +7,11 @@
 #include "CollectorStats.h"
 #include "Control.h"
 #include "DriverCandidates.h"
-#include "SysdigService.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
-class SysdigService;
+class Service;
 
 class CollectorService {
  public:
@@ -29,7 +29,7 @@ class CollectorService {
   std::atomic<ControlValue>* control_;
   const std::atomic<int>& signum_;
 
-  SysdigService sysdig_;
+  system_inspector::Service system_inspector_;
 };
 
 bool SetupKernelDriver(CollectorService& collector, const std::string& GRPCServer, const CollectorConfig& config);

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -1,17 +1,12 @@
 #ifndef _COLLECTOR_SERVICE_H_
 #define _COLLECTOR_SERVICE_H_
 
-#include <vector>
-
 #include "CollectorConfig.h"
-#include "CollectorStats.h"
 #include "Control.h"
 #include "DriverCandidates.h"
 #include "system-inspector/Service.h"
 
 namespace collector {
-
-class Service;
 
 class CollectorService {
  public:

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -7,10 +7,10 @@
 #include "Containers.h"
 #include "EventNames.h"
 #include "Logging.h"
-#include "SysdigService.h"
 #include "Utility.h"
 #include "prometheus/gauge.h"
 #include "prometheus/summary.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
@@ -58,10 +58,10 @@ class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
   }
 };
 
-CollectorStatsExporter::CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, SysdigService* sysdig)
+CollectorStatsExporter::CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, system_inspector::Service* si)
     : registry_(std::move(registry)),
       config_(config),
-      sysdig_(sysdig),
+      system_inspector_(si),
       connections_total_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<unsigned int>>(
           registry_,
           "rox_connections_total",
@@ -206,8 +206,8 @@ void CollectorStatsExporter::run() {
   }
 
   while (thread_.Pause(std::chrono::seconds(5))) {
-    SysdigStats stats;
-    if (!sysdig_->GetStats(&stats)) {
+    system_inspector::Stats stats;
+    if (!system_inspector_->GetStats(&stats)) {
       continue;
     }
 

--- a/collector/lib/CollectorStatsExporter.h
+++ b/collector/lib/CollectorStatsExporter.h
@@ -6,14 +6,14 @@
 #include "CollectorConfig.h"
 #include "CollectorStats.h"
 #include "StoppableThread.h"
-#include "SysdigService.h"
 #include "prometheus/registry.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
 class CollectorStatsExporter {
  public:
-  CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, SysdigService* sysdig);
+  CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, system_inspector::Service* si);
 
   bool start();
   void run();
@@ -25,7 +25,7 @@ class CollectorStatsExporter {
  private:
   std::shared_ptr<prometheus::Registry> registry_;
   const CollectorConfig* config_;
-  SysdigService* sysdig_;
+  system_inspector::Service* system_inspector_;
   std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter_;
   std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter_;
   StoppableThread thread_;

--- a/collector/lib/Control.h
+++ b/collector/lib/Control.h
@@ -4,9 +4,8 @@
 namespace collector {
 
 enum ControlValue {
-  RUN = 0,           // Keep running
-  INTERRUPT_SYSDIG,  // Stop running sysdig, but resume collector operation (e.g., for chisel update)
-  STOP_COLLECTOR,    // Stop the collector (e.g., SIGINT or SIGTERM received).
+  RUN = 0,         // Keep running
+  STOP_COLLECTOR,  // Stop the collector (e.g., SIGINT or SIGTERM received).
 };
 
 }

--- a/collector/lib/DriverCandidates.cpp
+++ b/collector/lib/DriverCandidates.cpp
@@ -5,15 +5,15 @@
 #include <string_view>
 
 #include "HostInfo.h"
-#include "SysdigService.h"
 #include "Utility.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
 namespace {
 
 std::string driverFullName(const std::string& shortName) {
-  return std::string{SysdigService::kProbeName} + "-" + shortName + ".o";
+  return std::string{system_inspector::Service::kProbeName} + "-" + shortName + ".o";
 }
 
 // Retrieves the ubuntu backport version from the host kernel's release

--- a/collector/lib/GetKernelObject.cpp
+++ b/collector/lib/GetKernelObject.cpp
@@ -14,8 +14,8 @@ extern "C" {
 #include "FileDownloader.h"
 #include "FileSystem.h"
 #include "Logging.h"
-#include "SysdigService.h"
 #include "Utility.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
@@ -177,7 +177,7 @@ bool GetKernelObject(const std::string& hostname, const Json::Value& tls_config,
 
   std::string expected_path = candidate.GetPath() + "/" + candidate.GetName();
   std::string expected_path_compressed = expected_path + ".gz";
-  std::string module_path = candidate.GetCollectionMethod() == CollectionMethod::EBPF ? SysdigService::kProbePath : SysdigService::kModulePath;
+  std::string module_path = candidate.GetCollectionMethod() == CollectionMethod::EBPF ? system_inspector::Service::kProbePath : system_inspector::Service::kModulePath;
   struct stat sb;
 
   // first check for an existing compressed kernel object in the

--- a/collector/lib/GetStatus.cpp
+++ b/collector/lib/GetStatus.cpp
@@ -11,8 +11,8 @@ bool GetStatus::handleGet(CivetServer* server, struct mg_connection* conn) {
 
   Json::Value status(Json::objectValue);
 
-  SysdigStats stats;
-  bool ready = sysdig_->GetStats(&stats);
+  system_inspector::Stats stats;
+  bool ready = system_inspector_->GetStats(&stats);
 
   if (ready) {
     status["status"] = "ok";

--- a/collector/lib/GetStatus.h
+++ b/collector/lib/GetStatus.h
@@ -4,19 +4,19 @@
 #include <string>
 
 #include "CivetServer.h"
-#include "Sysdig.h"
+#include "system-inspector/SystemInspector.h"
 
 namespace collector {
 
 class GetStatus : public CivetHandler {
  public:
-  GetStatus(std::string node_name, const Sysdig* sysdig)
-      : node_name_(std::move(node_name)), sysdig_(sysdig) {}
+  GetStatus(std::string node_name, const system_inspector::SystemInspector* si)
+      : node_name_(std::move(node_name)), system_inspector_(si) {}
   bool handleGet(CivetServer* server, struct mg_connection* conn);
 
  private:
   std::string node_name_;
-  const Sysdig* sysdig_;
+  const system_inspector::SystemInspector* system_inspector_;
 };
 
 } /* namespace collector */

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -14,8 +14,8 @@ extern "C" {
 #include "EventNames.h"
 #include "FileSystem.h"
 #include "Logging.h"
-#include "SysdigService.h"
 #include "Utility.h"
+#include "system-inspector/Service.h"
 
 extern const struct syscall_evt_pair g_syscall_table[];  // defined in libscap
 static const unsigned long DRIVER_BUFFER_DIM = 16UL * 1024UL * 1024UL;
@@ -63,9 +63,9 @@ class KernelDriverEBPF : public IKernelDriver {
   KernelDriverEBPF() = default;
 
   bool Setup(const CollectorConfig& config, sinsp& inspector) override {
-    FDHandle fd = FDHandle(open(SysdigService::kProbePath, O_RDONLY));
+    FDHandle fd = FDHandle(open(system_inspector::Service::kProbePath, O_RDONLY));
     if (!fd.valid()) {
-      CLOG(ERROR) << "Cannot open eBPF probe at " << SysdigService::kProbePath;
+      CLOG(ERROR) << "Cannot open eBPF probe at " << system_inspector::Service::kProbePath;
       return false;
     }
 
@@ -73,7 +73,7 @@ class KernelDriverEBPF : public IKernelDriver {
     std::unordered_set<ppm_sc_code> ppm_sc = GetSyscallList(config);
 
     try {
-      inspector.open_bpf(SysdigService::kProbePath,
+      inspector.open_bpf(system_inspector::Service::kProbePath,
                          config.GetSinspBufferSize(),
                          ppm_sc);
     } catch (const sinsp_exception& ex) {

--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -51,7 +51,7 @@ std::optional<Connection> NetworkSignalHandler::GetConnection(sinsp_evt* evt) {
   // With collect_connection_status_ set, we can prevent reporting of asynchronous
   // connections which fail.
   if (collect_connection_status_) {
-    // note: connection status tracking enablement is managed in SysdigService
+    // note: connection status tracking enablement is managed in system_inspector::Service
     if (fd_info->is_socket_failed()) {
       // connect() failed or getsockopt(SO_ERROR) returned a failure
       return std::nullopt;

--- a/collector/lib/NetworkSignalHandler.h
+++ b/collector/lib/NetworkSignalHandler.h
@@ -5,14 +5,14 @@
 
 #include "ConnTracker.h"
 #include "SignalHandler.h"
-#include "SysdigEventExtractor.h"
-#include "SysdigService.h"
+#include "system-inspector/EventExtractor.h"
+#include "system-inspector/SystemInspector.h"
 
 namespace collector {
 
 class NetworkSignalHandler final : public SignalHandler {
  public:
-  explicit NetworkSignalHandler(sinsp* inspector, std::shared_ptr<ConnectionTracker> conn_tracker, SysdigStats* stats)
+  explicit NetworkSignalHandler(sinsp* inspector, std::shared_ptr<ConnectionTracker> conn_tracker, system_inspector::Stats* stats)
       : conn_tracker_(std::move(conn_tracker)), stats_(stats), collect_connection_status_(true) {
     event_extractor_.Init(inspector);
   }
@@ -27,9 +27,9 @@ class NetworkSignalHandler final : public SignalHandler {
  private:
   std::optional<Connection> GetConnection(sinsp_evt* evt);
 
-  SysdigEventExtractor event_extractor_;
+  EventExtractor event_extractor_;
   std::shared_ptr<ConnectionTracker> conn_tracker_;
-  SysdigStats* stats_;
+  system_inspector::Stats* stats_;
 
   bool collect_connection_status_;
 };

--- a/collector/lib/NetworkSignalHandler.h
+++ b/collector/lib/NetworkSignalHandler.h
@@ -27,7 +27,7 @@ class NetworkSignalHandler final : public SignalHandler {
  private:
   std::optional<Connection> GetConnection(sinsp_evt* evt);
 
-  EventExtractor event_extractor_;
+  system_inspector::EventExtractor event_extractor_;
   std::shared_ptr<ConnectionTracker> conn_tracker_;
   system_inspector::Stats* stats_;
 

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -40,7 +40,7 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
   void CountLineage(const std::vector<LineageInfo>& lineage);
 
   const EventNames& event_names_;
-  EventExtractor event_extractor_;
+  system_inspector::EventExtractor event_extractor_;
 };
 
 }  // namespace collector

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -8,7 +8,7 @@
 #include "CollectorStats.h"
 #include "EventNames.h"
 #include "ProtoSignalFormatter.h"
-#include "SysdigEventExtractor.h"
+#include "system-inspector/EventExtractor.h"
 
 namespace collector {
 
@@ -40,7 +40,7 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
   void CountLineage(const std::vector<LineageInfo>& lineage);
 
   const EventNames& event_names_;
-  SysdigEventExtractor event_extractor_;
+  EventExtractor event_extractor_;
 };
 
 }  // namespace collector

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -10,13 +10,13 @@
 #include "ProcessSignalFormatter.h"
 #include "RateLimit.h"
 #include "SignalHandler.h"
-#include "SysdigService.h"
+#include "system-inspector/Service.h"
 
 namespace collector {
 
 class ProcessSignalHandler : public SignalHandler {
  public:
-  ProcessSignalHandler(sinsp* inspector, ISignalServiceClient* client, SysdigStats* stats)
+  ProcessSignalHandler(sinsp* inspector, ISignalServiceClient* client, system_inspector::Stats* stats)
       : client_(client), formatter_(inspector), stats_(stats) {}
 
   bool Start() override;
@@ -29,7 +29,7 @@ class ProcessSignalHandler : public SignalHandler {
  private:
   ISignalServiceClient* client_;
   ProcessSignalFormatter formatter_;
-  SysdigStats* stats_;
+  system_inspector::Stats* stats_;
   RateLimitCache rate_limiter_;
 };
 

--- a/collector/lib/SelfCheckHandler.h
+++ b/collector/lib/SelfCheckHandler.h
@@ -22,7 +22,7 @@ class SelfCheckHandler : public SignalHandler {
 
  protected:
   sinsp* inspector_;
-  EventExtractor event_extractor_;
+  system_inspector::EventExtractor event_extractor_;
 
   std::chrono::time_point<std::chrono::steady_clock> start_;
   std::chrono::seconds timeout_;

--- a/collector/lib/SelfCheckHandler.h
+++ b/collector/lib/SelfCheckHandler.h
@@ -6,7 +6,7 @@
 
 #include "SelfChecks.h"
 #include "SignalHandler.h"
-#include "SysdigEventExtractor.h"
+#include "system-inspector/EventExtractor.h"
 
 namespace collector {
 
@@ -22,7 +22,7 @@ class SelfCheckHandler : public SignalHandler {
 
  protected:
   sinsp* inspector_;
-  SysdigEventExtractor event_extractor_;
+  EventExtractor event_extractor_;
 
   std::chrono::time_point<std::chrono::steady_clock> start_;
   std::chrono::seconds timeout_;

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -32,7 +32,7 @@ std::unique_ptr<T> MakeUnique(Args&&... args) {
 // Return string decoded from base 64
 std::string Base64Decode(std::string const& encoded_string);
 
-// Get path using host prefix from SYSDIG_HOST_ROOT env var
+// Get path using host prefix from COLLECTOR_HOST_ROOT env var
 std::string GetHostPath(const std::string& file);
 
 // Get SNI hostname from SNI_HOSTNAME env var

--- a/collector/lib/system-inspector/EventExtractor.cpp
+++ b/collector/lib/system-inspector/EventExtractor.cpp
@@ -1,11 +1,11 @@
 
-#include "SysdigEventExtractor.h"
+#include "EventExtractor.h"
 
 #include "Logging.h"
 
 namespace collector {
 
-void SysdigEventExtractor::Init(sinsp* inspector) {
+void EventExtractor::Init(sinsp* inspector) {
   for (auto* wrapper : wrappers_) {
     sinsp_filter_check* check = g_filterlist.new_filter_check_from_fldname(wrapper->event_name, inspector, true);
     check->parse_field_name(wrapper->event_name, true, false);
@@ -13,7 +13,7 @@ void SysdigEventExtractor::Init(sinsp* inspector) {
   }
 }
 
-void SysdigEventExtractor::ClearWrappers() {
+void EventExtractor::ClearWrappers() {
   for (FilterCheckWrapper* wrapper : wrappers_) {
     if (wrapper) {
       wrapper->filter_check.reset();

--- a/collector/lib/system-inspector/EventExtractor.cpp
+++ b/collector/lib/system-inspector/EventExtractor.cpp
@@ -1,9 +1,6 @@
-
 #include "EventExtractor.h"
 
-#include "Logging.h"
-
-namespace collector {
+namespace collector::system_inspector {
 
 void EventExtractor::Init(sinsp* inspector) {
   for (auto* wrapper : wrappers_) {
@@ -22,4 +19,4 @@ void EventExtractor::ClearWrappers() {
   wrappers_.clear();
 }
 
-}  // namespace collector
+}  // namespace collector::system_inspector

--- a/collector/lib/system-inspector/EventExtractor.h
+++ b/collector/lib/system-inspector/EventExtractor.h
@@ -9,7 +9,7 @@
 
 #include "Logging.h"
 
-namespace collector {
+namespace collector::system_inspector {
 
 // This class allows extracting a predefined set of system_inspector event fields in an efficient manner.
 class EventExtractor {
@@ -116,6 +116,6 @@ class EventExtractor {
 #undef DECLARE_FILTER_CHECK
 };
 
-}  // namespace collector
+}  // namespace collector::system_inspector
 
 #endif  // _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_

--- a/collector/lib/system-inspector/EventExtractor.h
+++ b/collector/lib/system-inspector/EventExtractor.h
@@ -1,5 +1,5 @@
-#ifndef _SYSDIG_EVENT_EXTRACTOR_H_
-#define _SYSDIG_EVENT_EXTRACTOR_H_
+#ifndef _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_
+#define _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_
 
 #include <string>
 #include <vector>
@@ -11,15 +11,15 @@
 
 namespace collector {
 
-// This class allows extracting a predefined set of Sysdig event fields in an efficient manner.
-class SysdigEventExtractor {
+// This class allows extracting a predefined set of system_inspector event fields in an efficient manner.
+class EventExtractor {
  public:
   void Init(sinsp* inspector);
   void ClearWrappers();
 
  private:
   struct FilterCheckWrapper {
-    FilterCheckWrapper(SysdigEventExtractor* extractor, const char* event_name) : event_name(event_name) {
+    FilterCheckWrapper(EventExtractor* extractor, const char* event_name) : event_name(event_name) {
       extractor->wrappers_.push_back(this);
     }
 
@@ -81,9 +81,9 @@ class SysdigEventExtractor {
   // Fields can be made available for querying by using a number of macros:
   // - TINFO_FIELD_RAW(id, fieldname, type): exposes the m_<fieldname> field of threadinfo via get_<id>()
   // - TINFO_FIELD(name): exposes the m_<name> field of threadinfo via get_<name>()
-  // - FIELD_CSTR(id, fieldname): exposes the sysdig field <fieldname> via get_<id>(), returning a null-terminated
+  // - FIELD_CSTR(id, fieldname): exposes the system inspector field <fieldname> via get_<id>(), returning a null-terminated
   //   const char*.
-  // - FIELD_RAW(id, fieldname, type): exposes the sysdig field <fieldname> via get_<id>(), returning a const <type>*.
+  // - FIELD_RAW(id, fieldname, type): exposes the system inspector field <fieldname> via get_<id>(), returning a const <type>*.
   // - EVT_ARG(argname): shorthand for FIELD_CSTR(evt_arg_<argname>, "evt.arg.<argname>")
   // - EVT_ARG_RAW(argname, type): shorthand for FIELD_RAW(evt_arg_<argname>, "evt.rawarg.<argname>", <type>)
   //
@@ -118,4 +118,4 @@ class SysdigEventExtractor {
 
 }  // namespace collector
 
-#endif  // _SYSDIG_EVENT_EXTRACTOR_H_
+#endif  // _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_

--- a/collector/lib/system-inspector/Service.h
+++ b/collector/lib/system-inspector/Service.h
@@ -1,5 +1,5 @@
-#ifndef _SYSDIG_SERVICE_H_
-#define _SYSDIG_SERVICE_H_
+#ifndef _SYSTEM_INSPECTOR_SERVICE_H_
+#define _SYSTEM_INSPECTOR_SERVICE_H_
 
 #include <atomic>
 #include <bitset>
@@ -15,12 +15,12 @@
 #include "DriverCandidates.h"
 #include "SignalHandler.h"
 #include "SignalServiceClient.h"
-#include "Sysdig.h"
+#include "SystemInspector.h"
 #include "threadinfo.h"
 
-namespace collector {
+namespace collector::system_inspector {
 
-class SysdigService : public Sysdig {
+class Service : public SystemInspector {
  public:
   static constexpr char kModulePath[] = "/module/collector.ko";
   static constexpr char kModuleName[] = "collector";
@@ -29,14 +29,14 @@ class SysdigService : public Sysdig {
   static constexpr int kMessageBufferSize = 8192;
   static constexpr int kKeyBufferSize = 48;
 
-  SysdigService() = default;
+  Service() = default;
 
   void Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) override;
   void Start() override;
   void Run(const std::atomic<ControlValue>& control) override;
   void CleanUp() override;
 
-  bool GetStats(SysdigStats* stats) const override;
+  bool GetStats(Stats* stats) const override;
 
   bool InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) override;
 
@@ -45,7 +45,7 @@ class SysdigService : public Sysdig {
   void GetProcessInformation(uint64_t pid, ProcessInfoCallbackRef callback);
 
  private:
-  FRIEND_TEST(SysdigServiceTest, FilterEvent);
+  FRIEND_TEST(SystemInspectorServiceTest, FilterEvent);
 
   struct SignalHandlerEntry {
     std::unique_ptr<SignalHandler> handler;
@@ -72,7 +72,7 @@ class SysdigService : public Sysdig {
   std::unique_ptr<sinsp_evt_formatter> default_formatter_;
   std::unique_ptr<ISignalServiceClient> signal_client_;
   std::vector<SignalHandlerEntry> signal_handlers_;
-  SysdigStats userspace_stats_;
+  Stats userspace_stats_;
   std::bitset<PPM_EVENT_MAX> global_event_filter_;
 
   mutable std::mutex running_mutex_;
@@ -84,6 +84,6 @@ class SysdigService : public Sysdig {
   std::list<std::pair<uint64_t, ProcessInfoCallbackRef>> pending_process_requests_;
 };
 
-}  // namespace collector
+}  // namespace collector::system_inspector
 
-#endif  // _SYSDIG_SERVICE_H_
+#endif  // _SYSTEM_INSPECTOR_SERVICE_H_

--- a/collector/lib/system-inspector/SystemInspector.h
+++ b/collector/lib/system-inspector/SystemInspector.h
@@ -1,5 +1,5 @@
-#ifndef _SYSDIG_
-#define _SYSDIG_
+#ifndef _SYSTEM_INSPECTOR_
+#define _SYSTEM_INSPECTOR_
 
 #include <atomic>
 #include <cstdint>
@@ -11,9 +11,9 @@
 #include "DriverCandidates.h"
 #include "ppm_events_public.h"
 
-namespace collector {
+namespace collector::system_inspector {
 
-struct SysdigStats {
+struct Stats {
   using uint64_t = std::uint64_t;
 
   // stats gathered in kernel space
@@ -39,9 +39,9 @@ struct SysdigStats {
   volatile uint64_t event_process_micros[PPM_EVENT_MAX] = {0};  // total microseconds spent processing event type (correlates w/ nFilteredevents)
 };
 
-class Sysdig {
+class SystemInspector {
  public:
-  virtual ~Sysdig() = default;
+  virtual ~SystemInspector() = default;
 
   virtual void Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) = 0;
   virtual bool InitKernel(const CollectorConfig& config, const DriverCandidate& candidate) = 0;
@@ -49,9 +49,9 @@ class Sysdig {
   virtual void Run(const std::atomic<ControlValue>& control) = 0;
   virtual void CleanUp() = 0;
 
-  virtual bool GetStats(SysdigStats* stats) const = 0;
+  virtual bool GetStats(Stats* stats) const = 0;
 };
 
-} /* namespace collector */
+}  // namespace collector::system_inspector
 
-#endif /* _SYSDIG_ */
+#endif /* _SYSTEM_INSPECTOR_ */

--- a/collector/test/SystemInspectorServiceTest.cpp
+++ b/collector/test/SystemInspectorServiceTest.cpp
@@ -1,10 +1,9 @@
-#include "SysdigService.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "system-inspector/Service.h"
 
-namespace collector {
+namespace collector::system_inspector {
 
-TEST(SysdigServiceTest, FilterEvent) {
+TEST(SystemInspectorServiceTest, FilterEvent) {
   std::unique_ptr<sinsp> inspector(new sinsp());
 
   sinsp_threadinfo regular_process(inspector.get());
@@ -35,8 +34,8 @@ TEST(SysdigServiceTest, FilterEvent) {
   };
 
   for (const auto& t : tests) {
-    ASSERT_EQ(SysdigService::FilterEvent(t.tinfo), t.expected);
+    ASSERT_EQ(system_inspector::Service::FilterEvent(t.tinfo), t.expected);
   }
 }
 
-}  // namespace collector
+}  // namespace collector::system_inspector

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -18,6 +18,10 @@ working option, the `KERNEL_CANDIDATES` environment variable can be used to
 bypass this mechanism altogether.
 
 ## Falco libraries integration
+The aforementioned data gathering from the kernel is powered by the
+[Falco libraries](https://github.com/falcosecurity/libs/), an abstraction named
+`system_inspector` is put around them in order to have a better separation
+between the two, while also making it easier to integrate into our code base.
 
 ## Resource consumption breakdown
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -246,7 +246,7 @@ Units: microseconds
 | net_fetch_state                                  | Time spent to build a delta message content (connections + endpoints) to send to Sensor                                              |
 | net_create_message                               | Time spent to serialize the delta message and store the resulting state for next computation.                                        |
 | net_write_message                                | Time spent sending the raw message content.                                                                                          |
-| process_info_wait                                | Time spent blocked waiting for process info to be resolved by Falco.                                                                 |
+| process_info_wait                                | Time spent blocked waiting for process info to be resolved by system_inspector.                                                      |
 
 
 ### Network status notifier counters
@@ -278,10 +278,10 @@ Units: occurence
 \[1\] the process lineage information contains the ancestors list of a process. This attribute is formatted as a list of
 the process exec file paths.
 
-### Falco counters
+### system_inspector counters
 
 ```
-Component: SysdigStats
+Component: system_inspector::Stats
 Prometheus name: rox_collector_events
 Units: occurence
 ```
@@ -315,10 +315,10 @@ Note that the `[syscall]` suffix in a metric name means that it is instanciated 
 
 Note that if ProcfsScraper is unable to open /proc it is not able to open any of the subdirectories, but only procfs_could_not_open_proc_dir will be incremented in that case.
 
-### Falco timers per syscall
+### system_inspector timers per syscall
 
 ```
-Component: SysdigStats
+Component: system_inspector::Stats
 Prometheus name: rox_collector_events_typed
 Units: microseconds
 ```


### PR DESCRIPTION
## Description

This is a long due change, all mentions of Sysdig and Falco have been replaced by a more generic system_inspector name. No functional change has been made, the PR is purely organizational.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing Performed

CI should be enough, since things are just being shuffled around.
