### PR TITLE
ROX-19898: refactor collector configuration in tests

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -60,13 +60,13 @@ type PerformanceResult struct {
 
 // StartCollector will start the collector container and optionally
 // start the MockSensor, if disableGRPC is false.
-func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool) {
+func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool, options *common.CollectorStartupOptions) {
 	if !disableGRPC {
 		s.Sensor().Start()
 	}
 
 	s.Require().NoError(s.SetSelinuxPermissiveIfNeeded())
-	s.Require().NoError(s.Collector().Setup())
+	s.Require().NoError(s.Collector().Setup(options))
 	s.Require().NoError(s.Collector().Launch())
 
 	// wait for self-check process to guarantee collector is started

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -133,7 +133,7 @@ func (s *BenchmarkCollectorTestSuite) SetupSuite() {
 
 	s.StartPerfTools()
 
-	s.StartCollector(false)
+	s.StartCollector(false, nil)
 }
 
 func (s *BenchmarkCollectorTestSuite) TestBenchmarkCollector() {

--- a/integration-tests/suites/collector_startup.go
+++ b/integration-tests/suites/collector_startup.go
@@ -6,7 +6,7 @@ type CollectorStartupTestSuite struct {
 
 func (s *CollectorStartupTestSuite) SetupSuite() {
 	defer s.RecoverSetup()
-	s.StartCollector(false)
+	s.StartCollector(false, nil)
 }
 
 func (s *CollectorStartupTestSuite) TearDownSuite() {

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -31,13 +31,18 @@ type ConnectionsAndEndpointsTestSuite struct {
 func (s *ConnectionsAndEndpointsTestSuite) SetupSuite() {
 	defer s.RecoverSetup(s.Server.Name, s.Client.Name)
 	s.StartContainerStats()
-	collector := s.Collector()
 
-	collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
-	collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
-	collector.Env["ROX_ENABLE_AFTERGLOW"] = "false"
+	collectorOptions := common.CollectorStartupOptions{
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": "true",
+			"ROX_ENABLE_AFTERGLOW":            "false",
+		},
+		Config: map[string]any{
+			"turnOffScrape": false,
+		},
+	}
 
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	socatImage := config.Images().QaImageByKey("qa-socat")
 

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -1,7 +1,6 @@
 package suites
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -34,12 +33,17 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 	defer s.RecoverSetup("socat")
 	s.StartContainerStats()
 
-	collector := s.Collector()
+	collectorOptions := common.CollectorStartupOptions{
+		Config: map[string]any{
+			"turnOffScrape":  false,
+			"scrapeInterval": gScrapeInterval,
+		},
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": "true",
+		},
+	}
 
-	collector.Env["COLLECTOR_CONFIG"] = fmt.Sprintf(`{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":%d}`, gScrapeInterval)
-	collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
-
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 }
 
 func (s *DuplicateEndpointsTestSuite) TearDownSuite() {

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -6,7 +6,7 @@ type ImageLabelJSONTestSuite struct {
 
 func (s *ImageLabelJSONTestSuite) SetupSuite() {
 	defer s.RecoverSetup()
-	s.StartCollector(false)
+	s.StartCollector(false, nil)
 }
 
 func (s *ImageLabelJSONTestSuite) TestRunImageWithJSONLabel() {

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -19,12 +19,17 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 	defer s.RecoverSetup("process-ports")
 	s.StartContainerStats()
 
-	collector := s.Collector()
+	collectorOptions := common.CollectorStartupOptions{
+		Config: map[string]any{
+			"turnOffScrape":  false,
+			"scrapeInterval": 1,
+		},
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": "true",
+		},
+	}
 
-	collector.Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":1}`
-	collector.Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
-
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	processImage := getProcessListeningOnPortsImage()
 

--- a/integration-tests/suites/missing_proc_scrape.go
+++ b/integration-tests/suites/missing_proc_scrape.go
@@ -3,6 +3,7 @@ package suites
 import (
 	"os"
 
+	"github.com/stackrox/collector/integration-tests/suites/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,14 +22,19 @@ func (s *MissingProcScrapeTestSuite) SetupSuite() {
 		s.Require().NoError(err, "Failed to create fake proc directory")
 	}
 
-	s.Collector().Mounts["/host/proc:ro"] = fakeProcDir
+	collectorOptions := common.CollectorStartupOptions{
+		Mounts: map[string]string{
+			"/host/proc:ro": fakeProcDir,
+		},
+		Env: map[string]string{
+			// if /etc/hostname is empty collector will read /proc/sys/kernel/hostname
+			// which will also be empty because of the fake proc, so collector will exit.
+			// to avoid this, set NODE_HOSTNAME
+			"NODE_HOSTNAME": "collector-missing-proc-host",
+		},
+	}
 
-	// if /etc/hostname is empty collector will read /proc/sys/kernel/hostname
-	// which will also be empty because of the fake proc, so collector will exit.
-	// to avoid this, set NODE_HOSTNAME
-	s.Collector().Env["NODE_HOSTNAME"] = "collector-missing-proc-host"
-
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 }
 
 func (s *MissingProcScrapeTestSuite) TestCollectorRunning() {

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -25,7 +25,7 @@ type ProcessNetworkTestSuite struct {
 func (s *ProcessNetworkTestSuite) SetupSuite() {
 	defer s.RecoverSetup("nginx", "nginx-curl")
 	s.StartContainerStats()
-	s.StartCollector(false)
+	s.StartCollector(false, nil)
 
 	image_store := config.Images()
 

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -27,12 +27,18 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 
 	s.StartContainerStats()
 
-	s.Collector().Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":` + strconv.FormatBool(s.TurnOffScrape) + `,"scrapeInterval":2}`
-	s.Collector().Env["ROX_PROCESSES_LISTENING_ON_PORT"] = strconv.FormatBool(s.RoxProcessesListeningOnPort)
+	collectorOptions := common.CollectorStartupOptions{
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": strconv.FormatBool(s.RoxProcessesListeningOnPort),
+		},
+		Config: map[string]any{
+			"turnOffScrape": s.TurnOffScrape,
+		},
+	}
 
 	s.launchNginx()
 
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	s.cleanupContainer([]string{"nginx"})
 }

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/stackrox/collector/integration-tests/suites/common"
 	"github.com/stackrox/collector/integration-tests/suites/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,11 +38,18 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	defer s.RecoverSetup("nginx", "nginx-curl")
 	s.StartContainerStats()
 
-	s.Collector().Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":true,"scrapeInterval":` + strconv.Itoa(s.ScrapeInterval) + `}`
-	s.Collector().Env["ROX_AFTERGLOW_PERIOD"] = strconv.Itoa(s.AfterglowPeriod)
-	s.Collector().Env["ROX_ENABLE_AFTERGLOW"] = strconv.FormatBool(s.EnableAfterglow)
+	collectorOptions := common.CollectorStartupOptions{
+		Config: map[string]any{
+			"turnOffScrape":  false,
+			"scrapeInterval": s.ScrapeInterval,
+		},
+		Env: map[string]string{
+			"ROX_AFTERGLOW_PERIOD": strconv.Itoa(s.AfterglowPeriod),
+			"ROX_ENABLE_AFTERGLOW": strconv.FormatBool(s.EnableAfterglow),
+		},
+	}
 
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	image_store := config.Images()
 	scheduled_curls_image := image_store.QaImageByKey("qa-schedule-curls")

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -40,7 +40,8 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 
 	collectorOptions := common.CollectorStartupOptions{
 		Config: map[string]any{
-			"turnOffScrape":  false,
+			// turnOffScrape will be true, but the scrapeInterval
+			// also controls the reporting interval for network events
 			"scrapeInterval": s.ScrapeInterval,
 		},
 		Env: map[string]string{

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -32,10 +32,16 @@ func (s *SocatTestSuite) SetupSuite() {
 	defer s.RecoverSetup("socat")
 	s.StartContainerStats()
 
-	s.Collector().Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
-	s.Collector().Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
+	collectorOptions := common.CollectorStartupOptions{
+		Config: map[string]any{
+			"turnOffScrape": false,
+		},
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": "true",
+		},
+	}
 
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	processImage := config.Images().QaImageByKey("qa-socat")
 

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -18,10 +18,16 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 	defer s.RecoverSetup("process-ports")
 	s.StartContainerStats()
 
-	s.Collector().Env["COLLECTOR_CONFIG"] = `{"logLevel":"debug","turnOffScrape":false,"scrapeInterval":2}`
-	s.Collector().Env["ROX_PROCESSES_LISTENING_ON_PORT"] = "true"
+	collectorOptions := common.CollectorStartupOptions{
+		Config: map[string]any{
+			"turnOffScrape": false,
+		},
+		Env: map[string]string{
+			"ROX_PROCESSES_LISTENING_ON_PORT": "true",
+		},
+	}
 
-	s.StartCollector(false)
+	s.StartCollector(false, &collectorOptions)
 
 	processImage := getProcessListeningOnPortsImage()
 


### PR DESCRIPTION
## Description

To avoid having to provide (1) a hard-coded json string and (2) duplicated default options across all tests, this PR introduces `CollectorStartupOptions` structure which allows tests to set specific options/environment variables/mount points before starting collector. The collector manager itself is responsible for serializing this information as necessary and tests only need to modify the options that they need to.

Options provided by a test _always_ supersede those defined by default in the collector manager.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested and built locally against Garden Linux (of all things) CI will catch everything else. This should have no impact on the outcome of the tests.
