### PR TITLE
Pull all test images to avoid timing issues during tests

### DIFF
--- a/ansible/roles/run-test-target/tasks/main.yml
+++ b/ansible/roles/run-test-target/tasks/main.yml
@@ -17,6 +17,15 @@
   vars:
     arch: "{{ arch_info }}"
 
+- name: Pull test images
+  include_tasks: pull-images.yml
+  # only pull all images when we're running all tests.
+  # The performance penalty is several minutes
+  # which is quite significant for a specific test suite
+  # (i.e. when testing during development) but is only
+  # minor when running on CI
+  when: collector_test == 'ci-integration-tests'
+
 #
 # Separation of collection method is only possible with a separate
 # task file, because we need to loop over a set of tasks to ensure

--- a/ansible/roles/run-test-target/tasks/pull-images.yml
+++ b/ansible/roles/run-test-target/tasks/pull-images.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Load image info
+  set_fact:
+    images: "{{ lookup('file', collector_root + '/integration-tests/images.yml') | from_yaml }}"
+    qa_tag: "{{ lookup('file', collector_root + '/integration-tests/container/QA_TAG') }}"
+  delegate_to: localhost
+
+- name: Pull QA images
+  command: "docker pull {{ item.value }}-{{ qa_tag }}"
+  loop: "{{ images.qa | dict2items }}"
+  # parallel for speeeeed
+  async: 300
+  poll: 0
+  register: qa_result
+
+- name: Pull non-QA images
+  command: "docker pull {{ item.value }}"
+  loop: "{{ images.non_qa | dict2items }}"
+  # parallel for speeeeed
+  async: 300
+  poll: 0
+  register: non_qa_result
+
+- name: Await QA
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  loop: "{{ qa_result.results }}"
+  register: await_qa
+  until: await_qa.finished
+  retries: 30
+
+- name: Await non-QA
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  loop: "{{ non_qa_result.results }}"
+  register: await_non_qa
+  until: await_non_qa.finished
+  retries: 30

--- a/ansible/roles/run-test-target/tasks/pull-images.yml
+++ b/ansible/roles/run-test-target/tasks/pull-images.yml
@@ -7,7 +7,7 @@
   delegate_to: localhost
 
 - name: Pull QA images
-  command: "docker pull {{ item.value }}-{{ qa_tag }}"
+  command: "{{ runtime_command }} pull {{ item.value }}-{{ qa_tag }}"
   loop: "{{ images.qa | dict2items }}"
   # parallel for speeeeed
   async: 300
@@ -15,7 +15,7 @@
   register: qa_result
 
 - name: Pull non-QA images
-  command: "docker pull {{ item.value }}"
+  command: "{{ runtime_command }} pull {{ item.value }}"
   loop: "{{ images.non_qa | dict2items }}"
   # parallel for speeeeed
   async: 300

--- a/ansible/roles/run-test-target/tasks/pull-images.yml
+++ b/ansible/roles/run-test-target/tasks/pull-images.yml
@@ -7,7 +7,7 @@
   delegate_to: localhost
 
 - name: Pull QA images
-  command: "{{ runtime_command }} pull {{ item.value }}-{{ qa_tag }}"
+  command: "{{ 'sudo' if runtime_as_root else '' }} {{ runtime_command }} pull {{ item.value }}-{{ qa_tag }}"
   loop: "{{ images.qa | dict2items }}"
   # parallel for speeeeed
   async: 300
@@ -15,7 +15,7 @@
   register: qa_result
 
 - name: Pull non-QA images
-  command: "{{ runtime_command }} pull {{ item.value }}"
+  command: "{{ 'sudo' if runtime_as_root else '' }} {{ runtime_command }} pull {{ item.value }}"
   loop: "{{ images.non_qa | dict2items }}"
   # parallel for speeeeed
   async: 300


### PR DESCRIPTION
## Description

This PR will pre-pull test images on CI to make test execution times more consistent. There is currently a situation where test setup might start various containers and then wait to pull an image. When the timing of events is important/crucial, this waiting can cause flakes.

This behaviour is disabled when running individual test suites because the upfront performance penalty is significant at that level. I have yet to figure out a neat way of only pulling the images that the requested test uses, but that can be looked at in a follow up if it is deemed useful. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally, with timings:

```
# with pre-pulling images:

➜  collector git:(giles/ROX-14542-pre-pull-all-images) ✗ time make -C ansible/ integration-tests COLLECTION_METHODS=core-bpf COLLECTOR_IMAGE=quay.io/stackrox-io/collector:3.16.0 COLLECTOR_TEST=TestProcessNetwork
ansible-playbook \
		-i dev \
		-e job_id="ghutton" \
		-e @secrets.yml \
		--tags run-tests \
		integration-tests.yml
...................
# run-test-target : Run integration tests *********************************************************************************
  * collector-dev-garden-linux-any-777da73a-ghutton- changed=True --  -------------------------
......

# STATS *******************************************************************************************************************
collector-dev-garden-linux-any-777da73a-ghutton    : ok=26	changed=13	failed=0	unreachable=0	rescued=0	ignored=0

________________________________________________________
Executed in  376.03 secs    fish           external
   usr time   52.34 secs    0.13 millis   52.34 secs
   sys time   13.40 secs    1.55 millis   13.40 secs

# without pre-pulling images:

➜  collector git:(giles/ROX-14542-pre-pull-all-images) ✗ time make -C ansible/ integration-tests COLLECTION_METHODS=core-bpf COLLECTOR_IMAGE=quay.io/stackrox-io/collector:3.16.0 COLLECTOR_TEST=TestProcessNetwork
ansible-playbook \
		-i dev \
		-e job_id="ghutton" \
		-e @secrets.yml \
		--tags run-tests \
		integration-tests.yml
.............
# run-test-target : Run integration tests *********************************************************************************
  * collector-dev-garden-linux-any-777da73a-ghutton- changed=True --  -------------------------
......

# STATS *******************************************************************************************************************
collector-dev-garden-linux-any-777da73a-ghutton    : ok=20	changed=9	failed=0	unreachable=0	rescued=0	ignored=0

________________________________________________________
Executed in  228.68 secs    fish           external
   usr time   44.81 secs    0.14 millis   44.81 secs
   sys time   10.31 secs    1.60 millis   10.31 secs
```
