### PR TITLE
Makes expect logging clearer when more events are reveived than expected

### DIFF
--- a/integration-tests/suites/mock_sensor/expect_conn.go
+++ b/integration-tests/suites/mock_sensor/expect_conn.go
@@ -67,7 +67,7 @@ loop:
 	for {
 		select {
 		case <-timer:
-			assert.FailNowf(t, "timed out", "Only found %d/%d connections", len(s.Connections(containerID)), n)
+			assert.FailNowf(t, "timed out", "found %d connections (expected %d)", len(s.Connections(containerID)), n)
 		case conn := <-s.LiveConnections():
 			if conn.GetContainerId() != containerID {
 				continue loop
@@ -102,7 +102,7 @@ loop:
 		case <-timer:
 			// we know they don't match at this point, but by using
 			// ElementsMatch we get much better logging about the differences
-			return assert.ElementsMatch(t, expected, s.Endpoints(containerID), "timed out waiting for networks")
+			return assert.ElementsMatch(t, expected, s.Endpoints(containerID), "timed out waiting for endpoints")
 		case network := <-s.LiveEndpoints():
 			if network.GetContainerId() != containerID {
 				continue loop
@@ -128,7 +128,7 @@ loop:
 // have been received
 func (s *MockSensor) ExpectEndpointsN(t *testing.T, containerID string, timeout time.Duration, n int) []types.EndpointInfo {
 	return s.waitEndpointsN(func() {
-		assert.FailNowf(t, "timed out", "Only found %d/%d connections", len(s.Endpoints(containerID)), n)
+		assert.FailNowf(t, "timed out", "found %d endpoints (expected %d)", len(s.Endpoints(containerID)), n)
 	}, containerID, timeout, n)
 }
 

--- a/integration-tests/suites/mock_sensor/expect_proc.go
+++ b/integration-tests/suites/mock_sensor/expect_proc.go
@@ -13,7 +13,7 @@ import (
 
 func (s *MockSensor) ExpectProcessesN(t *testing.T, containerID string, timeout time.Duration, n int) []types.ProcessInfo {
 	return s.waitProcessesN(func() {
-		assert.FailNowf(t, "timed out", "only retrieved %d processes, expected %d", len(s.Processes(containerID)), n)
+		assert.FailNowf(t, "timed out", "found %d processes (expected %d)", len(s.Processes(containerID)), n)
 	}, containerID, timeout, n)
 }
 


### PR DESCRIPTION
## Description

Improves the logging output for clarity in scenarios where number of events received exceeds the expected number.

Before:

`only retrieved 4 processes, expected 3` 

After

`found 4 processes (expected 3)`
