### PR TITLE
Clean up of perf results accesses and storage

### DIFF
--- a/integration-tests/scripts/baseline/main.py
+++ b/integration-tests/scripts/baseline/main.py
@@ -150,8 +150,8 @@ def verify_data(data):
         # NOTE: We rely only on baseline/collector hackbench at the moment. As
         # soon as data for more tests will be collected, this section has to be
         # extended accordingly.
-        no_overhead_count = counter.get("baseline_benchmark", 0)
-        overhead_count = counter.get("collector_benchmark", 0)
+        no_overhead_count = counter.get("baseline_benchmark", 0) + counter.get("TestBenchmarkBaseline", 0)
+        overhead_count = counter.get("collector_benchmark", 0) + counter.get("TestBenchmarkBaseline", 0)
 
         if (no_overhead_count != overhead_count):
             raise Exception(f"Number of with/without overhead do not match:"
@@ -231,16 +231,23 @@ def group_data(content, *columns):
 
 
 def split_benchmark(measurements):
-    no_overhead = [
-        m["baseline_benchmark"]
-        for m in measurements
-        if "baseline_benchmark" in m
-    ]
-    overhead = [
-        m["collector_benchmark"]
-        for m in measurements
-        if "collector_benchmark" in m
-    ]
+    no_overhead = []
+    overhead = []
+
+    # This has to cover versions of the tests that tag perf data
+    # with "*_benchmark" or automatically with the test name.
+    for m in measurements:
+        if "baseline_benchmark" in m:
+            no_overhead.append(m["baseline_benchmark"])
+
+        if "TestBenchmarkBaseline" in m:
+            no_overhead.append(m["TestBenchmarkBaseline"])
+
+        if "collector_benchmark" in m:
+            overhead.append(m["collector_benchmark"])
+
+        if "TestBenchmarkCollector" in m:
+            overhead.append(m["TestBenchmarkCollector"])
 
     return (no_overhead, overhead)
 

--- a/integration-tests/suites/async_connections.go
+++ b/integration-tests/suites/async_connections.go
@@ -71,8 +71,8 @@ func (s *AsyncConnectionTestSuite) SetupSuite() {
 
 func (s *AsyncConnectionTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"server", "client"})
-	s.WritePerfResults("AsyncConnection")
+	s.cleanupContainers("server", "client")
+	s.WritePerfResults()
 }
 
 func (s *AsyncConnectionTestSuite) TestNetworkFlows() {

--- a/integration-tests/suites/async_connections.go
+++ b/integration-tests/suites/async_connections.go
@@ -72,9 +72,7 @@ func (s *AsyncConnectionTestSuite) SetupSuite() {
 func (s *AsyncConnectionTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"server", "client"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("AsyncConnection", stats, s.metrics)
+	s.WritePerfResults("AsyncConnection")
 }
 
 func (s *AsyncConnectionTestSuite) TestNetworkFlows() {

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -160,10 +160,7 @@ func (s *IntegrationTestSuiteBase) GetContainerStats() []ContainerStat {
 		for _, line := range logLines {
 			var stat ContainerStat
 
-			err := json.Unmarshal([]byte(line), &stat)
-			if err != nil {
-				fmt.Errorf("failed to unmarshall stats line: %v", err)
-			}
+			_ = json.Unmarshal([]byte(line), &stat)
 
 			s.stats = append(s.stats, stat)
 		}

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -146,9 +146,7 @@ func (s *BenchmarkCollectorTestSuite) TearDownSuite() {
 	s.StopCollector()
 
 	s.cleanupContainer([]string{"collector", "grpc-server", "benchmark"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("collector_benchmark", stats, s.metrics)
+	s.WritePerfResults("collector_benchmark")
 }
 
 func (s *BenchmarkBaselineTestSuite) SetupSuite() {
@@ -163,7 +161,5 @@ func (s *BenchmarkBaselineTestSuite) TestBenchmarkBaseline() {
 func (s *BenchmarkBaselineTestSuite) TearDownSuite() {
 	s.StopPerfTools()
 	s.cleanupContainer([]string{"benchmark"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("baseline_benchmark", stats, s.metrics)
+	s.WritePerfResults("baseline_benchmark")
 }

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -70,7 +70,6 @@ func (b *BenchmarkTestSuiteBase) StartPerfContainer(name string, image string, a
 func (b *BenchmarkTestSuiteBase) RunInitContainer() {
 	init_image := config.Images().QaImageByKey("performance-init")
 	cmd := []string{
-		"host-init",
 		"-v", "/lib/modules:/lib/modules",
 		"-v", "/etc/os-release:/etc/os-release",
 		"-v", "/etc/lsb-release:/etc/lsb-release",
@@ -79,7 +78,7 @@ func (b *BenchmarkTestSuiteBase) RunInitContainer() {
 		init_image,
 	}
 
-	containerID, err := b.launchContainer(cmd...)
+	containerID, err := b.launchContainer("host-init", cmd...)
 	require.NoError(b.T(), err)
 
 	if finished, _ := b.waitForContainerToExit("host-init", containerID, 5*time.Second); !finished {
@@ -89,12 +88,11 @@ func (b *BenchmarkTestSuiteBase) RunInitContainer() {
 		}
 		assert.FailNow(b.T(), "Failed to initialize host for performance testing")
 	}
-	b.cleanupContainer([]string{containerID})
+	b.cleanupContainers(containerID)
 }
 
 func (b *BenchmarkTestSuiteBase) startContainer(name string, image string, args ...string) {
 	cmd := []string{
-		name,
 		"--privileged",
 		"-v", "/sys:/sys",
 		"-v", "/usr/src:/usr/src",
@@ -107,7 +105,7 @@ func (b *BenchmarkTestSuiteBase) startContainer(name string, image string, args 
 
 	cmd = append(cmd, args...)
 
-	containerID, err := b.launchContainer(cmd...)
+	containerID, err := b.launchContainer(name, cmd...)
 	require.NoError(b.T(), err)
 
 	b.perfContainers = append(b.perfContainers, containerID)
@@ -145,8 +143,8 @@ func (s *BenchmarkCollectorTestSuite) TearDownSuite() {
 
 	s.StopCollector()
 
-	s.cleanupContainer([]string{"collector", "grpc-server", "benchmark"})
-	s.WritePerfResults("collector_benchmark")
+	s.cleanupContainers("benchmark")
+	s.WritePerfResults()
 }
 
 func (s *BenchmarkBaselineTestSuite) SetupSuite() {
@@ -160,6 +158,6 @@ func (s *BenchmarkBaselineTestSuite) TestBenchmarkBaseline() {
 
 func (s *BenchmarkBaselineTestSuite) TearDownSuite() {
 	s.StopPerfTools()
-	s.cleanupContainer([]string{"benchmark"})
-	s.WritePerfResults("baseline_benchmark")
+	s.cleanupContainers("benchmark")
+	s.WritePerfResults()
 }

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -74,9 +74,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TearDownSuite() {
 	s.cleanupContainer([]string{"collector"})
 	s.cleanupContainer([]string{s.Server.Name})
 	s.cleanupContainer([]string{s.Client.Name})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("ConnectionsAndEndpoints", stats, s.metrics)
+	s.WritePerfResults("ConnectionsAndEndpoints")
 }
 
 func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -71,10 +71,8 @@ func (s *ConnectionsAndEndpointsTestSuite) SetupSuite() {
 
 func (s *ConnectionsAndEndpointsTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"collector"})
-	s.cleanupContainer([]string{s.Server.Name})
-	s.cleanupContainer([]string{s.Client.Name})
-	s.WritePerfResults("ConnectionsAndEndpoints")
+	s.cleanupContainers(s.Server.Name, s.Client.Name)
+	s.WritePerfResults()
 }
 
 func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -44,8 +44,8 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 
 func (s *DuplicateEndpointsTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"socat"})
-	s.WritePerfResults("DuplicateEndpoints")
+	s.cleanupContainers("socat")
+	s.WritePerfResults()
 }
 
 // https://issues.redhat.com/browse/ROX-13628

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -45,9 +45,7 @@ func (s *DuplicateEndpointsTestSuite) SetupSuite() {
 func (s *DuplicateEndpointsTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"socat"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("DuplicateEndpoints", stats, s.metrics)
+	s.WritePerfResults("DuplicateEndpoints")
 }
 
 // https://issues.redhat.com/browse/ROX-13628

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -1,5 +1,9 @@
 package suites
 
+import (
+	"github.com/stackrox/collector/integration-tests/suites/config"
+)
+
 type ImageLabelJSONTestSuite struct {
 	IntegrationTestSuiteBase
 }
@@ -10,10 +14,20 @@ func (s *ImageLabelJSONTestSuite) SetupSuite() {
 }
 
 func (s *ImageLabelJSONTestSuite) TestRunImageWithJSONLabel() {
-	s.RunImageWithJSONLabels()
+	name := "jsonlabel"
+	image := config.Images().QaImageByKey("performance-json-label")
+
+	err := s.Executor().PullImage(image)
+	s.Require().NoError(err)
+
+	containerID, err := s.launchContainer(name, image)
+	s.Require().NoError(err)
+
+	_, err = s.waitForContainerToExit(name, containerID, defaultWaitTickSeconds)
+	s.Require().NoError(err)
 }
 
 func (s *ImageLabelJSONTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"grpc-server", "jsonlabel"})
+	s.cleanupContainers("json-label")
 }

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -57,8 +57,8 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 
 func (s *ProcessListeningOnPortTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"process-ports"})
-	s.WritePerfResults("ProcessListeningOnPort")
+	s.cleanupContainers("process-ports")
+	s.WritePerfResults()
 }
 
 func (s *ProcessListeningOnPortTestSuite) TestProcessListeningOnPort() {

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -58,9 +58,7 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 func (s *ProcessListeningOnPortTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"process-ports"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("ProcessListeningOnPort", stats, s.metrics)
+	s.WritePerfResults("ProcessListeningOnPort")
 }
 
 func (s *ProcessListeningOnPortTestSuite) TestProcessListeningOnPort() {

--- a/integration-tests/suites/missing_proc_scrape.go
+++ b/integration-tests/suites/missing_proc_scrape.go
@@ -39,5 +39,4 @@ func (s *MissingProcScrapeTestSuite) TestCollectorRunning() {
 
 func (s *MissingProcScrapeTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"collector"})
 }

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -71,9 +71,7 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 func (s *ProcessNetworkTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"nginx", "nginx-curl"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("process_network", stats, s.metrics)
+	s.WritePerfResults("process_network")
 }
 
 func (s *ProcessNetworkTestSuite) TestProcessViz() {

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -70,8 +70,8 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 
 func (s *ProcessNetworkTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"nginx", "nginx-curl"})
-	s.WritePerfResults("process_network")
+	s.cleanupContainers("nginx", "nginx-curl")
+	s.WritePerfResults()
 }
 
 func (s *ProcessNetworkTestSuite) TestProcessViz() {

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -52,9 +52,7 @@ func (s *ProcfsScraperTestSuite) launchNginx() {
 func (s *ProcfsScraperTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"nginx"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("ProcfsScraper", stats, s.metrics)
+	s.WritePerfResults("ProcfsScraper")
 }
 
 func (s *ProcfsScraperTestSuite) TestProcfsScraper() {

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -34,7 +34,7 @@ func (s *ProcfsScraperTestSuite) SetupSuite() {
 
 	s.StartCollector(false)
 
-	s.cleanupContainer([]string{"nginx"})
+	s.cleanupContainers("nginx")
 }
 
 func (s *ProcfsScraperTestSuite) launchNginx() {
@@ -51,8 +51,8 @@ func (s *ProcfsScraperTestSuite) launchNginx() {
 
 func (s *ProcfsScraperTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"nginx"})
-	s.WritePerfResults("ProcfsScraper")
+	s.cleanupContainers("nginx")
+	s.WritePerfResults()
 }
 
 func (s *ProcfsScraperTestSuite) TestProcfsScraper() {

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -93,9 +93,7 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 func (s *RepeatedNetworkFlowTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"nginx", "nginx-curl"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("repeated_network_flow", stats, s.metrics)
+	s.WritePerfResults("repeated_network_flow")
 }
 
 func (s *RepeatedNetworkFlowTestSuite) TestRepeatedNetworkFlow() {

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -92,8 +92,8 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 
 func (s *RepeatedNetworkFlowTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"nginx", "nginx-curl"})
-	s.WritePerfResults("repeated_network_flow")
+	s.cleanupContainers("nginx", "nginx-curl")
+	s.WritePerfResults()
 }
 
 func (s *RepeatedNetworkFlowTestSuite) TestRepeatedNetworkFlow() {

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -55,9 +55,7 @@ func (s *SocatTestSuite) SetupSuite() {
 func (s *SocatTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"socat"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("Socat", stats, s.metrics)
+	s.WritePerfResults("Socat")
 }
 
 func (s *SocatTestSuite) TestSocat() {

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -54,8 +54,8 @@ func (s *SocatTestSuite) SetupSuite() {
 
 func (s *SocatTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"socat"})
-	s.WritePerfResults("Socat")
+	s.cleanupContainers("socat")
+	s.WritePerfResults()
 }
 
 func (s *SocatTestSuite) TestSocat() {

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -43,8 +43,8 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 
 func (s *SymbolicLinkProcessTestSuite) TearDownSuite() {
 	s.StopCollector()
-	s.cleanupContainer([]string{"process-ports"})
-	s.WritePerfResults("SymbolicLinkProcess")
+	s.cleanupContainers("process-ports")
+	s.WritePerfResults()
 }
 
 func (s *SymbolicLinkProcessTestSuite) TestSymbolicLinkProcess() {

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -44,9 +44,7 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 func (s *SymbolicLinkProcessTestSuite) TearDownSuite() {
 	s.StopCollector()
 	s.cleanupContainer([]string{"process-ports"})
-	stats := s.GetContainerStats()
-	s.PrintContainerStats(stats)
-	s.WritePerfResults("SymbolicLinkProcess", stats, s.metrics)
+	s.WritePerfResults("SymbolicLinkProcess")
 }
 
 func (s *SymbolicLinkProcessTestSuite) TestSymbolicLinkProcess() {


### PR DESCRIPTION
## Description

Removes some boilerplate from the tests around the printing and storage of various perf results after the tests have executed. Now, perf results are all handled within the integration tests base struct, and the test simply has to call `WritePerfResults` in `TearDownSuite`

This also fixes an issue where container stats weren't initialized properly, resulting in invalid perf reporting. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally against RHEL 8 and RHEL 9
