### PR TITLE
Use ccache for builder builds

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -74,7 +74,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: deps-ccache
-          key: deps-ccache-${{ matrix.arch }}-${{ hashFiles('builder/**', 'third_party/++') }}
+          key: deps-ccache-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+          restore-keys: |
+            deps-ccache-${{ matrix.arch }}-b57e7706065cb32ef659bc60cf06bd9f563f3579e1af2a8b895ffeee07432a24
+            deps-ccache-${{ matrix.arch }}-
 
       - name: inject deps-ccache into docker
         uses: reproducible-containers/buildkit-cache-dance@v2.1.2

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -70,6 +70,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set up dependency ccache
+        uses: actions/cache@v3
+        with:
+          path: deps-ccache
+          key: deps-ccache-${{ matrix.arch }}-${{ hashFiles('builder/**', 'third_party/++') }}
+
+      - name: inject deps-ccache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: deps-ccache
+          cache-target: /root/.ccache
+
       - name: Define builder tag
         id: builder-tag
         run: |

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -115,7 +115,7 @@ jobs:
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook \
+          ansible-playbook -vvv \
             --connection local \
             -i localhost, \
             --limit localhost \

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -76,14 +76,13 @@ jobs:
           path: deps-ccache
           key: deps-ccache-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
           restore-keys: |
-            deps-ccache-${{ matrix.arch }}-b57e7706065cb32ef659bc60cf06bd9f563f3579e1af2a8b895ffeee07432a24
             deps-ccache-${{ matrix.arch }}-
 
       - name: inject deps-ccache into docker
         uses: reproducible-containers/buildkit-cache-dance@v2.1.2
         with:
           cache-source: deps-ccache
-          cache-target: /root/.ccache
+          cache-target: /root/.cache
 
       - name: Define builder tag
         id: builder-tag

--- a/.gitmodules
+++ b/.gitmodules
@@ -57,3 +57,6 @@
 	path = builder/third_party/libbpf
 	url = https://github.com/libbpf/libbpf
 	branch = v1.1.0
+[submodule "third_party/ccache"]
+	path = builder/third_party/ccache
+	url = https://github.com/ccache/ccache.git

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -63,7 +63,7 @@ ENV CMAKE_C_COMPILER_LAUNCHER=ccache
 ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
 ENV CCACHE_NOINODECACHE=true
 
-COPY builder builder
+COPY install builder/install
 COPY third_party third_party
 
 RUN --mount=type=cache,target=/root/.ccache/ "builder/install/install-dependencies.sh" && \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,17 +8,13 @@ USER root
 # emulating s390x on a x86 host (which is our case on GHA), see:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2209635
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2211472
-RUN dnf -y install epel-release && \
-    dnf -y install ccache && \
-    dnf -y remove epel-release && \
-    dnf -y update \
+RUN dnf -y update \
     && dnf -y install --nobest \
         autoconf \
         automake \
         binutils-devel \
         bison \
         ca-certificates \
-        ccache \
         clang-15.0.7 \
         cmake \
         cracklib-dicts \
@@ -57,6 +53,13 @@ WORKDIR ${BUILD_DIR}
 
 COPY install builder/install
 COPY third_party third_party
+
+# Install ccache before the rest of dependencies
+RUN mkdir -p third_party/ccache/build && \
+    cd third_party/ccache/build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=OFF -DENABLE_DOCUMENTATION=OFF -DREDIS_STORAGE_BACKEND=OFF .. && \
+    make && \
+    make install
 
 RUN --mount=type=cache,target=/root/.ccache/ "builder/install/install-dependencies.sh" && \
     rm -rf ${BUILD_DIR} && \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -56,8 +56,11 @@ COPY third_party/ccache third_party/ccache
 RUN mkdir -p third_party/ccache/build && \
     cd third_party/ccache/build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=OFF -DENABLE_DOCUMENTATION=OFF -DREDIS_STORAGE_BACKEND=OFF .. && \
-    make && \
+    make -j${NPROCS} && \
     make install
+
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 COPY builder builder
 COPY third_party third_party

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,7 +8,9 @@ USER root
 # emulating s390x on a x86 host (which is our case on GHA), see:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2209635
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2211472
-RUN dnf install -y epel-release && \
+RUN dnf install -y dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y epel-release && \
     dnf -y update \
     && dnf -y install --nobest \
         autoconf \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -61,6 +61,7 @@ RUN mkdir -p third_party/ccache/build && \
 
 ENV CMAKE_C_COMPILER_LAUNCHER=ccache
 ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+ENV CCACHE_NOINODECACHE=true
 
 COPY builder builder
 COPY third_party third_party

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -51,15 +51,16 @@ RUN dnf -y update \
 # Build dependencies from source
 WORKDIR ${BUILD_DIR}
 
-COPY install builder/install
-COPY third_party third_party
-
 # Install ccache before the rest of dependencies
+COPY third_party/ccache third_party/ccache
 RUN mkdir -p third_party/ccache/build && \
     cd third_party/ccache/build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=OFF -DENABLE_DOCUMENTATION=OFF -DREDIS_STORAGE_BACKEND=OFF .. && \
     make && \
     make install
+
+COPY builder builder
+COPY third_party third_party
 
 RUN --mount=type=cache,target=/root/.ccache/ "builder/install/install-dependencies.sh" && \
     rm -rf ${BUILD_DIR} && \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,13 +8,15 @@ USER root
 # emulating s390x on a x86 host (which is our case on GHA), see:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2209635
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2211472
-RUN dnf -y update \
+RUN dnf install -y epel-release && \
+    dnf -y update \
     && dnf -y install --nobest \
         autoconf \
         automake \
         binutils-devel \
         bison \
         ca-certificates \
+        ccache \
         clang-15.0.7 \
         cmake \
         cracklib-dicts \
@@ -54,7 +56,7 @@ WORKDIR ${BUILD_DIR}
 COPY install builder/install
 COPY third_party third_party
 
-RUN "builder/install/install-dependencies.sh" && \
+RUN --mount=type=cache,target=/root/.ccache/ "builder/install/install-dependencies.sh" && \
     rm -rf ${BUILD_DIR} && \
     echo -e '/usr/local/lib\n/usr/local/lib64' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,9 +8,9 @@ USER root
 # emulating s390x on a x86 host (which is our case on GHA), see:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2209635
 # - https://bugzilla.redhat.com/show_bug.cgi?id=2211472
-RUN dnf install -y dnf-plugins-core && \
-    dnf config-manager --set-enabled crb && \
-    dnf install -y epel-release && \
+RUN dnf -y install epel-release && \
+    dnf -y install ccache && \
+    dnf -y remove epel-release && \
     dnf -y update \
     && dnf -y install --nobest \
         autoconf \

--- a/builder/install/install-dependencies.sh
+++ b/builder/install/install-dependencies.sh
@@ -3,8 +3,6 @@
 set -e
 
 export LICENSE_DIR="/THIRD_PARTY_NOTICES"
-export CMAKE_C_COMPILER_LAUNCHER=ccache
-export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 mkdir -p "${LICENSE_DIR}"
 

--- a/builder/install/install-dependencies.sh
+++ b/builder/install/install-dependencies.sh
@@ -3,6 +3,8 @@
 set -e
 
 export LICENSE_DIR="/THIRD_PARTY_NOTICES"
+export CMAKE_C_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 mkdir -p "${LICENSE_DIR}"
 


### PR DESCRIPTION
## Description

This is currently under test, from local testing the initial build becomes incredibly slow, which might mean this is not viable for cross compiled images (ppc64le, s390x). However, subsequent builds are MUCH faster, so if we can power through the first run, we might be able to speed up the builder build process. If this is successful we might want to look into doing something similar for the collector binary build.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
