### PR TITLE
Fixes test cleanup, to ensure cleanup regardless of exit reason

### DIFF
--- a/integration-tests/suites/async_connections.go
+++ b/integration-tests/suites/async_connections.go
@@ -31,7 +31,7 @@ type AsyncConnectionTestSuite struct {
  *     a dummy address.
  */
 func (s *AsyncConnectionTestSuite) SetupSuite() {
-	defer s.RecoverSetup("server", "client")
+	s.RegisterCleanup("server", "client")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -126,7 +126,7 @@ func (b *BenchmarkTestSuiteBase) StopPerfTools() {
 }
 
 func (s *BenchmarkCollectorTestSuite) SetupSuite() {
-	defer s.RecoverSetup("perf", "bcc", "bpftrace", "init")
+	s.RegisterCleanup("perf", "bcc", "bpftrace", "init")
 	s.StartContainerStats()
 
 	s.StartPerfTools()

--- a/integration-tests/suites/collector_startup.go
+++ b/integration-tests/suites/collector_startup.go
@@ -5,7 +5,7 @@ type CollectorStartupTestSuite struct {
 }
 
 func (s *CollectorStartupTestSuite) SetupSuite() {
-	defer s.RecoverSetup()
+	s.RegisterCleanup()
 	s.StartCollector(false, nil)
 }
 

--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -116,7 +116,7 @@ func (c *CollectorManager) TearDown() error {
 		return coreDumpErr
 	}
 
-	isRunning, err := c.executor.IsContainerRunning("collector")
+	isRunning, err := c.IsRunning()
 	if err != nil {
 		fmt.Println("Error: Checking if container running")
 		return err
@@ -140,6 +140,10 @@ func (c *CollectorManager) TearDown() error {
 	}
 
 	return nil
+}
+
+func (c *CollectorManager) IsRunning() (bool, error) {
+	return c.executor.IsContainerRunning("collector")
 }
 
 // These two methods might be useful in the future. I used them for debugging

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -29,7 +29,7 @@ type ConnectionsAndEndpointsTestSuite struct {
 }
 
 func (s *ConnectionsAndEndpointsTestSuite) SetupSuite() {
-	defer s.RecoverSetup(s.Server.Name, s.Client.Name)
+	s.RegisterCleanup(s.Server.Name, s.Client.Name)
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -30,7 +30,7 @@ func (s *DuplicateEndpointsTestSuite) killSocatProcess(port int) {
 }
 
 func (s *DuplicateEndpointsTestSuite) SetupSuite() {
-	defer s.RecoverSetup("socat")
+	s.RegisterCleanup("socat")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -9,7 +9,7 @@ type ImageLabelJSONTestSuite struct {
 }
 
 func (s *ImageLabelJSONTestSuite) SetupSuite() {
-	defer s.RecoverSetup()
+	s.RegisterCleanup()
 	s.StartCollector(false, nil)
 }
 

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -16,7 +16,7 @@ type ProcessListeningOnPortTestSuite struct {
 }
 
 func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
-	defer s.RecoverSetup("process-ports")
+	s.RegisterCleanup("process-ports")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/missing_proc_scrape.go
+++ b/integration-tests/suites/missing_proc_scrape.go
@@ -14,7 +14,7 @@ type MissingProcScrapeTestSuite struct {
 const fakeProcDir = "/tmp/fake-proc"
 
 func (s *MissingProcScrapeTestSuite) SetupSuite() {
-	defer s.RecoverSetup()
+	s.RegisterCleanup()
 
 	_, err := os.Stat(fakeProcDir)
 	if os.IsNotExist(err) {

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -23,7 +23,7 @@ type ProcessNetworkTestSuite struct {
 // Launches nginx container
 // Execs into nginx and does a sleep
 func (s *ProcessNetworkTestSuite) SetupSuite() {
-	defer s.RecoverSetup("nginx", "nginx-curl")
+	s.RegisterCleanup("nginx", "nginx-curl")
 	s.StartContainerStats()
 	s.StartCollector(false, nil)
 

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -23,7 +23,7 @@ type ProcfsScraperTestSuite struct {
 // other tests. The purpose is that we want ProcfsScraper to see the nginx endpoint and we do not want
 // NetworkSignalHandler to see the nginx endpoint.
 func (s *ProcfsScraperTestSuite) SetupSuite() {
-	defer s.RecoverSetup("nginx")
+	s.RegisterCleanup("nginx")
 
 	s.StartContainerStats()
 

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -35,7 +35,7 @@ type RepeatedNetworkFlowTestSuite struct {
 // Launches gRPC server in insecure mode
 // Launches nginx container
 func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
-	defer s.RecoverSetup("nginx", "nginx-curl")
+	s.RegisterCleanup("nginx", "nginx-curl")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -29,7 +29,7 @@ type SocatTestSuite struct {
 }
 
 func (s *SocatTestSuite) SetupSuite() {
-	defer s.RecoverSetup("socat")
+	s.RegisterCleanup("socat")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -15,7 +15,7 @@ type SymbolicLinkProcessTestSuite struct {
 }
 
 func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
-	defer s.RecoverSetup("process-ports")
+	s.RegisterCleanup("process-ports")
 	s.StartContainerStats()
 
 	collectorOptions := common.CollectorStartupOptions{


### PR DESCRIPTION
## Description

The initial attempt at cleaning up after panics only covered a single possible exit condition for the tests (panicking). If a test/setup/teardown instead calls `assert.FailNow` it will ultimately call `runtime.Goexit` which according to the docs - "recover() calls will return nil"

The new mechanism will register a function with `testing.T.Cleanup` which will run when the tests and subtests end for any reason (panic, fails, and success.)

The success possibility is taken into account - we cannot fail or panic if resources that are being cleaned up no longer exist.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally by forcing a FailNow and a panic and observing that the cleanup function is called correctly. Also verified that the clean up works correctly when the tests pass.
