### PR TITLE
Remove argument that was causing linter errors

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -83,7 +83,6 @@ jobs:
       arch-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       skip-built-drivers: true
       build-full-image: true
-      max-layer-depth: "1"
     secrets: inherit
     needs:
     - init


### PR DESCRIPTION
## Description

`max-layer-depth` was removed by #1366, for some reason CI didn't catch this needed to be removed from `cpaas.yml` and is now causing lint errors on unrelated PRs, so we might as well fix it.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Run with `run-cpaas-steps`.
