### PR TITLE
Build drivers and support packages on master and PRs only

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -27,6 +27,9 @@ env:
 jobs:
   split-tasks:
     runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && github.ref_name == 'master') ||
+      github.event_name == 'pull_request'
     outputs:
       parallel-jobs: ${{ steps.set-parallel.outputs.parallel-jobs }}
       parallel-array: ${{ steps.set-parallel.outputs.parallel-array }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,8 @@ jobs:
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
     if: |
       always() &&
-      (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
+      ((github.event_name == 'push' && github.ref_name == 'master') ||
+      contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
     needs:
     - init
     - build-drivers


### PR DESCRIPTION
## Description

Exclude drivers and support package builds from release branches and tags, these artifacts are built by every commit on the master branch. The only complication that might arise from this is doing a patch release for our drivers, since the tags and release branches will not have drivers available until master does a CI run. There are a few workarounds for this, like adding a filter checking to see if the `MODULE_VERSION` was changed, I'll experiment a bit before opening the PR for review.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run on a `release-` branch. [CI run](https://github.com/stackrox/collector/actions/runs/6704112012)
- [x] Run on a tag. [CI run](https://github.com/stackrox/collector/actions/runs/6704118388)
