### PR TITLE
Skip multiarch builds as a default

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -97,7 +97,7 @@ jobs:
         if: |
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
-          !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
@@ -117,7 +117,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-       !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds'))
+       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x
@@ -159,7 +159,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-      contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
     steps:

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Build and push full images
         if: |
           matrix.arch == 'amd64' ||
-          !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
         run: |
           ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       inputs.build-full-image &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+      contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     needs:
     - build-collector-full
     env:
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       inputs.build-full-image &&
-      contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     needs:
     - build-collector-full
     steps:

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -71,7 +71,7 @@ jobs:
         if: |
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
-          !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+      contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     env:
       ARCHS: amd64 ppc64le s390x
 
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'skip-multiarch-builds')
+      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     steps:
       - name: Pull image to retag
         run: |


### PR DESCRIPTION
## Description

Multiarch builds take a pretty long time which slows down dev work. Making them opt-in for PRs should make dev a lot faster even if we might get broken builds on master every now and then.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

All tests should force the builder image to be built.
- [x] Run CI without `run-multiarch-builds` should skip P/Z. [CI run](https://github.com/stackrox/collector/actions/runs/6548585384)
- [x] Run CI with `run-multiarch-builds` should run P/Z. [CI run](https://github.com/stackrox/collector/actions/runs/6559044529?pr=1373)