### PR TITLE
Network introspection endpoints

### DIFF
--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "GetKernelObject.h"
 #include "GetStatus.h"
 #include "LogLevel.h"
+#include "NetworkStatusInspector.h"
 #include "NetworkStatusNotifier.h"
 #include "ProfilerHandler.h"
 #include "Utility.h"
@@ -61,6 +62,7 @@ void CollectorService::RunForever() {
   std::unique_ptr<NetworkStatusNotifier> net_status_notifier;
 
   std::unique_ptr<ContainerInfoInspector> container_info_inspector;
+  std::unique_ptr<NetworkStatusInspector> network_status_inspector;
 
   CLOG(INFO) << "Network scrape interval set to " << config_.ScrapeInterval() << " seconds";
 
@@ -106,6 +108,8 @@ void CollectorService::RunForever() {
   if (config_.IsIntrospectionEnabled()) {
     container_info_inspector = std::make_unique<ContainerInfoInspector>(system_inspector_.GetContainerMetadataInspector());
     server.addHandler(container_info_inspector->kBaseRoute, container_info_inspector.get());
+    network_status_inspector = std::make_unique<NetworkStatusInspector>(conn_tracker);
+    server.addHandler(network_status_inspector->kBaseRoute, network_status_inspector.get());
   }
 
   system_inspector_.Init(config_, conn_tracker);

--- a/collector/lib/NetworkStatusInspector.cpp
+++ b/collector/lib/NetworkStatusInspector.cpp
@@ -98,7 +98,7 @@ bool NetworkStatusInspector::handleGetEndpoints(struct mg_connection* conn, cons
     body_root[container_id] = container_array;
   }
 
-  std::string buffer = Json::writeString(json_stream_writer_builder_, body_root);
+  std::string buffer = writer_.write(body_root);
 
   mg_send_http_ok(conn, "application/json", buffer.size());
 
@@ -150,7 +150,7 @@ bool NetworkStatusInspector::handleGetConnections(struct mg_connection* conn, co
     body_root[container_id] = container_array;
   }
 
-  std::string buffer = Json::writeString(json_stream_writer_builder_, body_root);
+  std::string buffer = writer_.write(body_root);
 
   mg_send_http_ok(conn, "application/json", buffer.size());
 

--- a/collector/lib/NetworkStatusInspector.cpp
+++ b/collector/lib/NetworkStatusInspector.cpp
@@ -116,8 +116,9 @@ bool NetworkStatusInspector::handleGetConnections(struct mg_connection* conn, co
   std::optional<std::string> containerFilter = GetParameter(queryParams, kQueryParam_container);
 
   for (auto& connectionState : connectionStates) {
-    if (!containerFilter || *containerFilter == connectionState.first.container())
+    if (!containerFilter || *containerFilter == connectionState.first.container()) {
       byContainer[connectionState.first.container()].push_front(&connectionState);
+    }
   }
 
   for (auto& container : byContainer) {

--- a/collector/lib/NetworkStatusInspector.cpp
+++ b/collector/lib/NetworkStatusInspector.cpp
@@ -1,0 +1,177 @@
+#include "NetworkStatusInspector.h"
+
+#include <forward_list>
+#include <string>
+#include <unordered_map>
+
+#include <arpa/inet.h>
+
+#include "ConnTracker.h"
+
+namespace collector {
+
+const std::string NetworkStatusInspector::kBaseRoute = "/state/network";
+const std::string NetworkStatusInspector::kEndpointRoute = kBaseRoute + "/endpoint";
+const std::string NetworkStatusInspector::kConnectionRoute = kBaseRoute + "/connection";
+
+const std::string NetworkStatusInspector::kQueryParam_container = "container";
+
+NetworkStatusInspector::NetworkStatusInspector(const std::shared_ptr<ConnectionTracker> conntracker) : conntracker_(conntracker) {
+}
+
+static std::string IP2str(const Address& addr) {
+  switch (addr.family()) {
+    case Address::Family::IPV4: {
+      char str[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, addr.data(), str, INET_ADDRSTRLEN);
+      return str;
+    }
+    case Address::Family::IPV6: {
+      char str[INET6_ADDRSTRLEN];
+      inet_ntop(AF_INET6, addr.data(), str, INET6_ADDRSTRLEN);
+      return str;
+    }
+    default:
+      break;
+  }
+  return "unk";
+}
+
+static std::string Proto2str(L4Proto proto) {
+  switch (proto) {
+    case collector::L4Proto::TCP:
+      return "TCP";
+    case collector::L4Proto::UDP:
+      return "UDP";
+    case collector::L4Proto::ICMP:
+      return "ICMP";
+    default:
+      break;
+  }
+  return "UNKNOWN";
+}
+
+static std::string IPNet2str(const IPNet& net) {
+  return IP2str(net.address()) + (net.bits() == 0 ? "" : "/" + std::to_string(net.bits()));
+}
+
+static void SerializeEndpoint(const Endpoint& ep, Json::Value& node) {
+  node["address"] = IPNet2str(ep.network());
+  node["port"] = ep.port();
+}
+
+bool NetworkStatusInspector::handleGetEndpoints(struct mg_connection* conn, const QueryParams& queryParams) {
+  collector::AdvertisedEndpointMap endpointStates = conntracker_->FetchEndpointState(true, false);
+  Json::Value bodyRoot(Json::objectValue);
+
+  std::unordered_map<std::string, std::forward_list<collector::ContainerEndpointMap::value_type*>> byContainer;
+
+  std::optional<std::string> containerFilter = GetParameter(queryParams, kQueryParam_container);
+
+  for (auto& endpointState : endpointStates) {
+    if (!containerFilter || *containerFilter == endpointState.first.container())
+      byContainer[endpointState.first.container()].push_front(&endpointState);
+  }
+
+  for (auto& container : byContainer) {
+    const std::string& containerId = container.first;
+
+    Json::Value containerArray(Json::arrayValue);
+
+    for (auto endpointState : container.second) {
+      const collector::ContainerEndpoint& endpoint = endpointState->first;
+      const collector::ConnStatus& status = endpointState->second;
+
+      Json::Value endpointNode(Json::objectValue);
+
+      endpointNode["active"] = status.IsActive();
+
+      endpointNode["l4proto"] = Proto2str(endpoint.l4proto());
+
+      endpointNode["endpoint"] = Json::objectValue;
+      SerializeEndpoint(endpoint.endpoint(), endpointNode["endpoint"]);
+
+      containerArray.append(endpointNode);
+    }
+
+    bodyRoot[containerId] = containerArray;
+  }
+
+  std::string buffer = Json::writeString(jsonStreamWriterBuilder_, bodyRoot);
+
+  mg_send_http_ok(conn, "application/json", buffer.size());
+
+  mg_write(conn, buffer.c_str(), buffer.size());
+
+  return true;
+}
+
+bool NetworkStatusInspector::handleGetConnections(struct mg_connection* conn, const QueryParams& queryParams) {
+  collector::ConnMap connectionStates = conntracker_->FetchConnState(true, false);
+  Json::Value bodyRoot(Json::objectValue);
+
+  std::unordered_map<std::string, std::forward_list<collector::ConnMap::value_type*>> byContainer;
+
+  std::optional<std::string> containerFilter = GetParameter(queryParams, kQueryParam_container);
+
+  for (auto& connectionState : connectionStates) {
+    if (!containerFilter || *containerFilter == connectionState.first.container())
+      byContainer[connectionState.first.container()].push_front(&connectionState);
+  }
+
+  for (auto& container : byContainer) {
+    const std::string& containerId = container.first;
+
+    Json::Value containerArray(Json::arrayValue);
+
+    for (auto connectionState : container.second) {
+      const collector::Connection& connection = connectionState->first;
+      const collector::ConnStatus& status = connectionState->second;
+
+      Json::Value connectionNode(Json::objectValue);
+      std::string l4proto;
+
+      connectionNode["active"] = status.IsActive();
+
+      connectionNode["l4proto"] = Proto2str(connection.l4proto());
+
+      if (connection.is_server()) {
+        connectionNode["from"] = IPNet2str(connection.remote().network());
+        connectionNode["port"] = connection.local().port();
+      } else {
+        connectionNode["to"] = IPNet2str(connection.remote().network());
+        connectionNode["port"] = connection.remote().port();
+      }
+
+      containerArray.append(connectionNode);
+    }
+    bodyRoot[containerId] = containerArray;
+  }
+
+  std::string buffer = Json::writeString(jsonStreamWriterBuilder_, bodyRoot);
+
+  mg_send_http_ok(conn, "application/json", buffer.size());
+
+  mg_write(conn, buffer.c_str(), buffer.size());
+
+  return true;
+}
+
+bool NetworkStatusInspector::handleGet(CivetServer* server, struct mg_connection* conn) {
+  const mg_request_info* req_info = mg_get_request_info(conn);
+
+  if (req_info == nullptr) {
+    return ServerError(conn, "unable to read request");
+  }
+
+  std::string uri = req_info->local_uri;
+  auto parameters = ParseParameters(req_info->query_string);
+  if (uri == kEndpointRoute) {
+    return handleGetEndpoints(conn, parameters);
+  } else if (uri == kConnectionRoute) {
+    return handleGetConnections(conn, parameters);
+  }
+  return ClientError(conn, "unknown route");
+}
+
+}  // namespace collector

--- a/collector/lib/NetworkStatusInspector.cpp
+++ b/collector/lib/NetworkStatusInspector.cpp
@@ -69,8 +69,9 @@ bool NetworkStatusInspector::handleGetEndpoints(struct mg_connection* conn, cons
   std::optional<std::string> containerFilter = GetParameter(queryParams, kQueryParam_container);
 
   for (auto& endpointState : endpointStates) {
-    if (!containerFilter || *containerFilter == endpointState.first.container())
+    if (!containerFilter || *containerFilter == endpointState.first.container()) {
       byContainer[endpointState.first.container()].push_front(&endpointState);
+    }
   }
 
   for (auto& container : byContainer) {

--- a/collector/lib/NetworkStatusInspector.h
+++ b/collector/lib/NetworkStatusInspector.h
@@ -1,0 +1,38 @@
+#ifndef COLLECTOR_NETWORKSTATUSINSPECTOR_H
+#define COLLECTOR_NETWORKSTATUSINSPECTOR_H
+
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include <json/writer.h>
+
+#include "IntrospectionEndpoint.h"
+
+namespace collector {
+
+class ConnectionTracker;
+
+class NetworkStatusInspector : public IntrospectionEndpoint {
+ public:
+  static const std::string kBaseRoute;
+  static const std::string kEndpointRoute;
+  static const std::string kConnectionRoute;
+
+  NetworkStatusInspector(const std::shared_ptr<ConnectionTracker> conntracker);
+
+  // implementation of CivetHandler
+  bool handleGet(CivetServer* server, struct mg_connection* conn) override;
+
+ private:
+  const std::shared_ptr<ConnectionTracker> conntracker_;
+  Json::StreamWriterBuilder jsonStreamWriterBuilder_;
+
+  static const std::string kQueryParam_container;  // = "container"
+
+  bool handleGetEndpoints(struct mg_connection* conn, const QueryParams& queryParams);
+  bool handleGetConnections(struct mg_connection* conn, const QueryParams& queryParams);
+};
+}  // namespace collector
+
+#endif

--- a/collector/lib/NetworkStatusInspector.h
+++ b/collector/lib/NetworkStatusInspector.h
@@ -26,7 +26,7 @@ class NetworkStatusInspector : public IntrospectionEndpoint {
 
  private:
   const std::shared_ptr<ConnectionTracker> conntracker_;
-  Json::StreamWriterBuilder jsonStreamWriterBuilder_;
+  Json::StreamWriterBuilder json_stream_writer_builder_;
 
   static const std::string kQueryParam_container;  // = "container"
 

--- a/collector/lib/NetworkStatusInspector.h
+++ b/collector/lib/NetworkStatusInspector.h
@@ -26,7 +26,7 @@ class NetworkStatusInspector : public IntrospectionEndpoint {
 
  private:
   const std::shared_ptr<ConnectionTracker> conntracker_;
-  Json::StreamWriterBuilder json_stream_writer_builder_;
+  Json::FastWriter writer_;
 
   static const std::string kQueryParam_container;  // = "container"
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -79,7 +79,7 @@ own upper limit on top of that, which is 2^17.
 information could be useful for troubleshooting, but under normal functioning
 is quite verbose. The default is true.
 
-* `DEBUG_ENABLE_INTROSPECTION`: Enable the introspection API and publish the
+* `ROX_COLLECTOR_INTROSPECTION_ENABLE`: Enable the introspection API and publish the
 corresponding endpoints. With this API, it is possible to dump some of the
 internal state of Collector. Refer to the 
 [troubleshooting](troubleshooting.md#introspection-endpoints) section for more details.

--- a/docs/references.md
+++ b/docs/references.md
@@ -79,6 +79,12 @@ own upper limit on top of that, which is 2^17.
 information could be useful for troubleshooting, but under normal functioning
 is quite verbose. The default is true.
 
+* `DEBUG_ENABLE_INTROSPECTION`: Enable the introspection API and publish the
+corresponding endpoints. With this API, it is possible to dump some of the
+internal state of Collector. Refer to the 
+[troubleshooting](troubleshooting.md#introspection-endpoints) section for more details.
+The default is false.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -540,3 +540,35 @@ $ curl "localhost:8080/state/containers/01e8c0454972"
 Handling connection for 8080
 {"container_id":"01e8c0454972","namespace":"stackrox"}
 ```
+
+### Network endpoint
+
+This endpoint provides visibility into connections and endpoints known to
+collector.
+
+The introspection API endpoints are as follows:
+- `/state/network/endpoint` will return an array of the endpoints known
+  to collector at that point.
+- `/state/network/connection` is similar to the previous, but for connections.
+
+Afterglow is not applied to the data returned by this API.
+
+It is possible to filter the items returned per container_id by providing
+a query parameter: `container=<container_id>`
+
+Example of connection query, limited to container with identifier `c6f030bc4b42`:
+
+```
+$ curl "http://<collector>:8080/state/network/connection?container=c6f030bc4b42"
+{
+  "c6f030bc4b42" : 
+  [
+    {
+      "active" : true,
+      "l4proto" : "TCP",
+      "port" : 443,
+      "to" : "10.96.0.1"
+    }
+  ]
+}
+```

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -422,7 +422,7 @@ func TestIntrospectionAPI(t *testing.T) {
 		Port: 8080,
 		CollectorOptions: collector.StartupOptions{
 			Env: map[string]string{
-				"DEBUG_ENABLE_INTROSPECTION": "true",
+				"ROX_COLLECTOR_INTROSPECTION_ENABLE": "true",
 			},
 		},
 		Endpoints: []string{

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/stackrox/collector/integration-tests/pkg/collector"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stackrox/collector/integration-tests/pkg/types"
 	"github.com/stackrox/collector/integration-tests/suites"
@@ -414,6 +415,21 @@ func TestConnectionsAndEndpointsUDPNoFork(t *testing.T) {
 		},
 	}
 	suite.Run(t, mixedHighLowPorts)
+}
+
+func TestIntrospectionAPI(t *testing.T) {
+	endpointTestSuite := &suites.HttpEndpointAvailabilityTestSuite{
+		Port: 8080,
+		CollectorOptions: collector.StartupOptions{
+			Env: map[string]string{
+				"DEBUG_ENABLE_INTROSPECTION": "true",
+			},
+		},
+		Endpoints: []string{
+			"/state/network/connection",
+			"/state/network/endpoint",
+		}}
+	suite.Run(t, endpointTestSuite)
 }
 
 // By default, a failed connection is not reported.

--- a/integration-tests/suites/http_endpoint_availability.go
+++ b/integration-tests/suites/http_endpoint_availability.go
@@ -29,16 +29,13 @@ func (s *HttpEndpointAvailabilityTestSuite) TestAvailability() {
 		resp, err := http.Get(url)
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
-		if resp != nil {
-			s.Require().Equal(resp.StatusCode, http.StatusOK, "HTTP status code")
+		s.Require().Equal(resp.StatusCode, http.StatusOK, "HTTP status code")
 
-			var buf bytes.Buffer
-			defer resp.Body.Close()
-			_, err = buf.ReadFrom(resp.Body)
-			s.Require().NoError(err)
-			s.Require().True(json.Valid(buf.Bytes()))
-		}
-
+		var buf bytes.Buffer
+		defer resp.Body.Close()
+		_, err = buf.ReadFrom(resp.Body)
+		s.Require().NoError(err)
+		s.Require().True(json.Valid(buf.Bytes()))
 	}
 }
 

--- a/integration-tests/suites/http_endpoint_availability.go
+++ b/integration-tests/suites/http_endpoint_availability.go
@@ -1,0 +1,47 @@
+package suites
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/stackrox/collector/integration-tests/pkg/collector"
+)
+
+type HttpEndpointAvailabilityTestSuite struct {
+	IntegrationTestSuiteBase
+	Port             int
+	CollectorOptions collector.StartupOptions
+	Endpoints        []string
+}
+
+func (s *HttpEndpointAvailabilityTestSuite) SetupSuite() {
+	s.StartCollector(false, &s.CollectorOptions)
+}
+
+func (s *HttpEndpointAvailabilityTestSuite) TestAvailability() {
+	for _, endpoint := range s.Endpoints {
+		url := fmt.Sprintf("http://localhost:%d%s", s.Port, endpoint)
+
+		fmt.Println(url)
+
+		resp, err := http.Get(url)
+		s.Require().NoError(err)
+		s.Require().NotNil(resp)
+		if resp != nil {
+			s.Require().Equal(resp.StatusCode, http.StatusOK, "HTTP status code")
+
+			var buf bytes.Buffer
+			defer resp.Body.Close()
+			_, err = buf.ReadFrom(resp.Body)
+			s.Require().NoError(err)
+			s.Require().True(json.Valid(buf.Bytes()))
+		}
+
+	}
+}
+
+func (s *HttpEndpointAvailabilityTestSuite) TearDownSuite() {
+	s.StopCollector()
+}


### PR DESCRIPTION
## Description

Adds a pair of web endpoints to retrieve the internal network tables of Collector (normalized and deduplicated, same as what is sent to Sensor).

The endpoints are activated by an environment variable (~~`ROX_COLLECTOR_ENABLE_INTROSPECTION`~~ `DEBUG_ENABLE_INTROSPECTION`). The default disabled.