### PR TITLE
Fix master branch retagging full image instead of creating manifests

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -8,12 +8,6 @@ on:
         required: true
         description: |
           The tag used to build the collector image
-      build-full-image:
-        type: boolean
-        required: true
-        description: |
-          If true, the full collector image will be built, else, the -slim
-          image of collector will be retagged.
       skip-built-drivers:
         type: boolean
         required: true
@@ -34,7 +28,9 @@ on:
 jobs:
   build-collector-full:
     runs-on: ubuntu-latest
-    if: inputs.build-full-image
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'build-full-images')
     strategy:
       fail-fast: false
       matrix:
@@ -129,8 +125,9 @@ jobs:
   multiarch-manifests:
     runs-on: ubuntu-latest
     if: |
-      inputs.build-full-image &&
-      contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      github.event_name != 'pull_request' ||
+      ( contains(github.event.pull_request.labels.*.name, 'build-full-images') &&
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') )
     needs:
     - build-collector-full
     env:
@@ -182,8 +179,9 @@ jobs:
   retag-collector-full:
     runs-on: ubuntu-latest
     if: |
-      inputs.build-full-image &&
-      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      github.event_name == 'pull_request' &&
+      ( contains(github.event.pull_request.labels.*.name, 'build-full-images') &&
+        !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') )
     needs:
     - build-collector-full
     steps:
@@ -224,8 +222,12 @@ jobs:
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
   retag-collector-slim:
+    # TODO: Runing without build-full-images and with run-multiarch-builds
+    # should create manifests based on the slim images.
     runs-on: ubuntu-latest
-    if: ${{ !inputs.build-full-image }}
+    if: |
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'build-full-images')
     env:
       COLLECTOR_IMAGE_SLIM: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}-slim
 

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -82,7 +82,6 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       arch-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       skip-built-drivers: true
-      build-full-image: true
     secrets: inherit
     needs:
     - init

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,6 @@ jobs:
       drivers-bucket: ${{ needs.init.outputs.drivers-bucket }}
       arch-drivers-bucket: ${{ needs.init.outputs.cpaas-drivers-bucket }}
       skip-built-drivers: ${{ needs.build-drivers.outputs.parallel-jobs == 0 }}
-      build-full-image: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'build-full-images') }}
     secrets: inherit
     needs:
     - init


### PR DESCRIPTION
## Description

After merging PR #1373, master started retagging the x86 full image instead of creating multiarch manifests. This was an unintended condition that was caused because of a previous simplification that was no longer true and did not manifest in the PR. This patch makes the conditions for the full image more strict.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Try running on a `push` event.
