### PR TITLE
Remove dependency on test_platform naming

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -5,11 +5,11 @@ ibmcloud_ssh_key_file: "{{ lookup('env', 'IBMCLOUD_SSH_KEY_FILE', default='~/.ss
 
 current_user: "{{ lookup('env', 'USER') }}"
 test_platform: "{{ lookup('env', 'VM_TYPE', default='rhel') }}"
-arch_info: "{{ 's390x' if 's390x' in test_platform else 'ppc64le' if 'ppc64le' in test_platform else 'amd64'}}"
+arch_info: "{{ virtual_machines[test_platform].arch | default('amd64') }}"
 collector_root: "{{ playbook_dir }}/.."
 collector_repo: "quay.io/stackrox-io"
 
-ansible_ssh_private_key_file: "{{ ibmcloud_ssh_key_file if arch_info != 'amd64' else gcp_ssh_key_file }}"
+ansible_ssh_private_key_file: "{{ virtual_machines[test_platform].ssh_key_file | default(gcp_ssh_key_file) }}"
 
 # These control the container runtime used on the VMs.
 # They can be overridden in platform-specific group_vars files
@@ -36,6 +36,8 @@ virtual_machines:
 
   rhel-s390x:
     project: rhel-s390x-cloud
+    arch: s390x
+    ssh_key_file: ibmcloud_ssh_key_file
     families:
       - rhel-8-6-s390x
 
@@ -43,6 +45,8 @@ virtual_machines:
   # in ibm cloud (56 chars max)
   rhel-ppc64le:
     project: rhel-ppc64le-cloud
+    arch: ppc64le
+    ssh_key_file: ibmcloud_ssh_key_file
     families:
       - p
 
@@ -65,7 +69,7 @@ virtual_machines:
         users:
           - name: core
             sshAuthorizedKeys:
-              - "{{ lookup('file', gcp_ssh_key_file + '.pub') }}"
+              - "{{ lookup('file', gcp_ssh_key_file + '.pub', errors='ignore') }}"
 
   cos:
     project: cos-cloud


### PR DESCRIPTION


## Description

Variables that used to depend on the contents of the test_platform now instead depend on the contents of the associated virtual_machines.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
