### PR TITLE
Fix CPaaS full images build

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -106,7 +106,7 @@ jobs:
       # a step, so... Overkill it is!
       - name: Build and push full images
         if: |
-          github.event_name == 'push' ||
+          github.event_name != 'pull_request' ||
           matrix.arch == 'amd64' ||
           contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
         run: |


### PR DESCRIPTION
## Description

CPaaS full image builds were being skipped because the trigger for them is `schedule`, but the check only accounted for `push` triggers. Changing this condition to not be a PR should work for both conditions.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Testing on schedule events is complicated, since the change is small I propose getting it merged and let the real event trigger.
