### PR TITLE
Enable s390x always in CPaaS workflows

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -99,6 +99,7 @@ jobs:
         vm_type:
           - rhel
           - rhel-sap
+          - rhel-s390x
     with:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
@@ -110,7 +111,7 @@ jobs:
     - build-collector-full
     secrets: inherit
 
-  # Isolating multi-arch testing temporarily while fixes are found for s390x
+  # Isolating multi-arch testing temporarily while fixes are found for ppc64le
   multiarch-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') &&
@@ -121,7 +122,6 @@ jobs:
       fail-fast: false
       matrix:
         vm_type:
-          - rhel-s390x
           - rhel-ppc64le
     with:
       vm_type: ${{ matrix.vm_type }}

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -36,7 +36,7 @@ virtual_machines:
   rhel-s390x:
     project: rhel-s390x-cloud
     arch: s390x
-    ssh_key_file: ibmcloud_ssh_key_file
+    ssh_key_file: "{{ ibmcloud_ssh_key_file }}"
     families:
       - rhel-8-6-s390x
 
@@ -45,7 +45,7 @@ virtual_machines:
   rhel-ppc64le:
     project: rhel-ppc64le-cloud
     arch: ppc64le
-    ssh_key_file: ibmcloud_ssh_key_file
+    ssh_key_file: "{{ ibmcloud_ssh_key_file }}"
     families:
       - p
 


### PR DESCRIPTION
## Description

Enables s390x testing in CPaaS workflow.

There is an ongoing workflow to add it to PRs as well as on the CPaaS schedule, but this will give us some idea of what's affecting s390x more frequently than currently.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Updated documentation accordingly~

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
