### PR TITLE
ROX-19778: Load metrics for connections

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -52,7 +52,6 @@ class CollectorConfig {
 
   std::string asString() const;
 
-  void HandleAfterglowEnvVars();
   bool TurnOffScrape() const;
   bool ScrapeListenEndpoints() const { return scrape_listen_endpoints_; }
   int ScrapeInterval() const;
@@ -107,6 +106,9 @@ class CollectorConfig {
   unsigned int connection_stats_window_;
 
   Json::Value tls_config_;
+
+  void HandleAfterglowEnvVars();
+  void HandleConnectionStatsEnvVars();
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -73,6 +73,10 @@ class CollectorConfig {
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
   bool EnableExternalIPs() const { return enable_external_ips_; }
+  bool EnableConnectionStats() const { return enable_connection_stats_; }
+  const std::vector<double>& GetConnectionStatsQuantiles() const { return connection_stats_quantiles_; }
+  double GetConnectionStatsError() const { return connection_stats_error_; }
+  unsigned int GetConnectionStatsWindow() const { return connection_stats_window_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -97,6 +101,10 @@ class CollectorConfig {
   bool import_users_;
   bool collect_connection_status_;
   bool enable_external_ips_;
+  bool enable_connection_stats_;
+  std::vector<double> connection_stats_quantiles_;
+  double connection_stats_error_;
+  unsigned int connection_stats_window_;
 
   Json::Value tls_config_;
 };

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -85,9 +85,10 @@ void CollectorService::RunForever() {
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
 
-    net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
-                                                            conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
+    net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
+                                                            conn_tracker,
                                                             network_connection_info_service_comm,
+                                                            config_,
                                                             config_.EnableConnectionStats() ? exporter.GetConnectionsTotalReporter() : 0,
                                                             config_.EnableConnectionStats() ? exporter.GetConnectionsRateReporter() : 0);
     net_status_notifier->Start();

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -88,8 +88,8 @@ void CollectorService::RunForever() {
     net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper, config_.ScrapeInterval(), config_.ScrapeListenEndpoints(), config_.TurnOffScrape(),
                                                             conn_tracker, config_.AfterglowPeriod(), config_.EnableAfterglow(),
                                                             network_connection_info_service_comm,
-                                                            exporter.GetConnectionsTotalReporter(),
-                                                            exporter.GetConnectionsRateReporter());
+                                                            config_.EnableConnectionStats() ? exporter.GetConnectionsTotalReporter() : 0,
+                                                            config_.EnableConnectionStats() ? exporter.GetConnectionsRateReporter() : 0);
     net_status_notifier->Start();
   }
 

--- a/collector/lib/CollectorStats.h
+++ b/collector/lib/CollectorStats.h
@@ -93,6 +93,14 @@ class CollectorStats {
   CollectorStats(){};
 };
 
+template <typename T>
+class CollectorConnectionStats {
+ public:
+  virtual void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) = 0;
+
+  virtual ~CollectorConnectionStats() {}
+};
+
 namespace internal {
 
 template <typename T>

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -48,10 +48,12 @@ class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
 
     result.reserve(quantiles.size());
 
-    std::transform(quantiles.begin(), quantiles.end(), std::back_inserter(result),
-                   [error](double q) -> prometheus::detail::CKMSQuantiles::Quantile {
-                     return {q, error};
-                   });
+    auto make_quantile = [error](double q) -> prometheus::detail::CKMSQuantiles::Quantile {
+      return {q, error};
+    };
+
+    std::transform(quantiles.begin(), quantiles.end(), std::back_inserter(result), make_quantile);
+
     return result;
   }
 };

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -17,15 +17,17 @@ namespace collector {
 template <typename T>
 class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
  public:
-  CollectorConnectionStatsPrometheus(std::shared_ptr<prometheus::Registry> registry, std::string name, std::string help, std::chrono::milliseconds max_age)
-      : family_(prometheus::BuildSummary()
-                    .Name(name)
-                    .Help(help)
-                    .Register(*registry)),
-        inbound_private_summary_(family_.Add({{"dir", "in"}, {"peer", "private"}}, prometheus::Summary::Quantiles{{0.5, 0.01}, {0.9, 0.01}, {0.95, 0.01}}, max_age)),
-        inbound_public_summary_(family_.Add({{"dir", "in"}, {"peer", "public"}}, prometheus::Summary::Quantiles{{0.5, 0.01}, {0.9, 0.01}, {0.95, 0.01}}, max_age)),
-        outbound_private_summary_(family_.Add({{"dir", "out"}, {"peer", "private"}}, prometheus::Summary::Quantiles{{0.5, 0.01}, {0.9, 0.01}, {0.95, 0.01}}, max_age)),
-        outbound_public_summary_(family_.Add({{"dir", "out"}, {"peer", "public"}}, prometheus::Summary::Quantiles{{0.5, 0.01}, {0.9, 0.01}, {0.95, 0.01}}, max_age)) {}
+  CollectorConnectionStatsPrometheus(
+      std::shared_ptr<prometheus::Registry> registry,
+      std::string name,
+      std::string help,
+      std::chrono::milliseconds max_age,
+      const std::vector<double>& quantiles,
+      double error) : family_(prometheus::BuildSummary().Name(name).Help(help).Register(*registry)),
+                      inbound_private_summary_(family_.Add({{"dir", "in"}, {"peer", "private"}}, MakeQuantiles(quantiles, error), max_age)),
+                      inbound_public_summary_(family_.Add({{"dir", "in"}, {"peer", "public"}}, MakeQuantiles(quantiles, error), max_age)),
+                      outbound_private_summary_(family_.Add({{"dir", "out"}, {"peer", "private"}}, MakeQuantiles(quantiles, error), max_age)),
+                      outbound_public_summary_(family_.Add({{"dir", "out"}, {"peer", "public"}}, MakeQuantiles(quantiles, error), max_age)) {}
 
   void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) override {
     inbound_private_summary_.Observe(inbound_private);
@@ -40,14 +42,38 @@ class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
   prometheus::Summary& inbound_public_summary_;
   prometheus::Summary& outbound_private_summary_;
   prometheus::Summary& outbound_public_summary_;
+
+  prometheus::Summary::Quantiles MakeQuantiles(std::vector<double> quantiles, double error) {
+    prometheus::Summary::Quantiles result;
+
+    result.reserve(quantiles.size());
+
+    std::transform(quantiles.begin(), quantiles.end(), std::back_inserter(result),
+                   [error](double q) -> prometheus::detail::CKMSQuantiles::Quantile {
+                     return {q, error};
+                   });
+    return result;
+  }
 };
 
 CollectorStatsExporter::CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, SysdigService* sysdig)
     : registry_(std::move(registry)),
       config_(config),
       sysdig_(sysdig),
-      connections_total_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<unsigned int>>(registry_, "rox_connections_total", "Amount of stored connections over time", std::chrono::hours{1})),
-      connections_rate_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<float>>(registry_, "rox_connections_rate", "Rate of connections over time", std::chrono::hours{1})) {}
+      connections_total_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<unsigned int>>(
+          registry_,
+          "rox_connections_total",
+          "Amount of stored connections over time",
+          std::chrono::minutes{config->GetConnectionStatsWindow()},
+          config->GetConnectionStatsQuantiles(),
+          config->GetConnectionStatsError())),
+      connections_rate_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<float>>(
+          registry_,
+          "rox_connections_rate",
+          "Rate of connections over time",
+          std::chrono::minutes{config->GetConnectionStatsWindow()},
+          config->GetConnectionStatsQuantiles(),
+          config->GetConnectionStatsError())) {}
 
 bool CollectorStatsExporter::start() {
   if (!thread_.Start(&CollectorStatsExporter::run, this)) {

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -28,6 +28,10 @@ class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
         outbound_public_summary_(family_.Add({{"dir", "out"}, {"peer", "public"}}, prometheus::Summary::Quantiles{{0.5, 0.01}, {0.9, 0.01}, {0.95, 0.01}}, max_age)) {}
 
   void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) override {
+    inbound_private_summary_.Observe(inbound_private);
+    inbound_public_summary_.Observe(inbound_public);
+    outbound_private_summary_.Observe(outbound_private);
+    outbound_public_summary_.Observe(outbound_public);
   }
 
  private:

--- a/collector/lib/CollectorStatsExporter.h
+++ b/collector/lib/CollectorStatsExporter.h
@@ -19,10 +19,15 @@ class CollectorStatsExporter {
   void run();
   void stop();
 
+  std::shared_ptr<CollectorConnectionStats<unsigned int>> GetConnectionsTotalReporter() { return connections_total_reporter_; }
+  std::shared_ptr<CollectorConnectionStats<float>> GetConnectionsRateReporter() { return connections_rate_reporter_; }
+
  private:
   std::shared_ptr<prometheus::Registry> registry_;
   const CollectorConfig* config_;
   SysdigService* sysdig_;
+  std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter_;
+  std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter_;
   StoppableThread thread_;
 };
 

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -145,7 +145,7 @@ bool EmplaceOrUpdate(UnorderedMap<T, ConnStatus>* m, const T& obj, ConnStatus st
 void ConnectionTracker::EmplaceOrUpdateNoLock(const Connection& conn, ConnStatus status) {
   COUNTER_INC(CollectorStats::net_conn_updates);
   if (EmplaceOrUpdate(&conn_state_, conn, status)) {
-    ClassifyConnectionStats(conn, inserted_connections_counters_);
+    IncrementConnectionStats(conn, inserted_connections_counters_);
   }
 }
 
@@ -325,7 +325,7 @@ void ConnectionTracker::UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPa
 }
 
 // Increment the stat counter matching the connection's characteristics
-inline void ConnectionTracker::ClassifyConnectionStats(Connection conn, ConnectionTracker::Stats& stats) const {
+inline void ConnectionTracker::IncrementConnectionStats(Connection conn, ConnectionTracker::Stats& stats) const {
   auto& direction = conn.is_server() ? stats.inbound : stats.outbound;
 
   if (!ShouldFetchConnection(conn)) {
@@ -346,7 +346,7 @@ ConnectionTracker::Stats ConnectionTracker::GetConnectionStats_StoredConnections
 
   WITH_LOCK(mutex_) {
     for (auto& conn : conn_state_) {
-      ClassifyConnectionStats(conn.first, stats);
+      IncrementConnectionStats(conn.first, stats);
     }
   }
 

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -147,9 +147,10 @@ class ConnectionTracker {
       unsigned int private_;
     } inbound, outbound;
   };
-  // Retrieve the number of connections currently known to ConnTracker, indexed by in/out and public/private nature.
+  // Retrieve the number of connections currently stored in ConnTracker, indexed by in/out and public/private nature.
   Stats GetConnectionStats_StoredConnections();
   // Retrieve the value of the ever-increasing counters of new connection insertion, indexed by in/out and public/private nature.
+  // Those counters are updated as new connections are reported by the system.
   Stats GetConnectionStats_NewConnectionCounters();
 
  private:

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -185,7 +185,7 @@ class ConnectionTracker {
     return !IsIgnoredL4ProtoPortPair(L4ProtoPortPair(cep.l4proto(), cep.endpoint().port()));
   }
 
-  inline void ClassifyConnectionStats(Connection conn, ConnectionTracker::Stats& stats) const;
+  inline void IncrementConnectionStats(Connection conn, ConnectionTracker::Stats& stats) const;
 
   std::mutex mutex_;
   ConnMap conn_state_;

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -138,6 +138,20 @@ class ConnectionTracker {
   // recent than the stored one.
   void EmplaceOrUpdateNoLock(const ContainerEndpoint& ep, ConnStatus status);
 
+  //
+  // Statistics on the number of stored connections and their rate creation.
+  //
+  struct Stats {
+    struct {
+      unsigned int public_;
+      unsigned int private_;
+    } inbound, outbound;
+  };
+  // Retrieve the number of connections currently known to ConnTracker, indexed by in/out and public/private nature.
+  Stats GetConnectionStats_StoredConnections();
+  // Retrieve the value of the ever-increasing counters of new connection insertion, indexed by in/out and public/private nature.
+  Stats GetConnectionStats_NewConnectionCounters();
+
  private:
   // NormalizeConnection transforms a connection into a normalized form.
   Connection NormalizeConnectionNoLock(const Connection& conn) const;
@@ -171,6 +185,8 @@ class ConnectionTracker {
     return !IsIgnoredL4ProtoPortPair(L4ProtoPortPair(cep.l4proto(), cep.endpoint().port()));
   }
 
+  inline void ClassifyConnectionStats(Connection conn, ConnectionTracker::Stats& stats) const;
+
   std::mutex mutex_;
   ConnMap conn_state_;
   ContainerEndpointMap endpoint_state_;
@@ -180,6 +196,8 @@ class ConnectionTracker {
   bool enable_external_ips_ = false;
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
+
+  Stats inserted_connections_counters_ = {};
 };
 
 /* static */

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -16,8 +16,19 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
  public:
   NetworkStatusNotifier(std::shared_ptr<IConnScraper> conn_scraper, int scrape_interval, bool scrape_listen_endpoints, bool turn_off_scrape,
                         std::shared_ptr<ConnectionTracker> conn_tracker, int64_t afterglow_period_micros, bool use_afterglow,
-                        std::shared_ptr<INetworkConnectionInfoServiceComm> comm)
-      : conn_scraper_(conn_scraper), scrape_interval_(scrape_interval), turn_off_scraping_(turn_off_scrape), scrape_listen_endpoints_(scrape_listen_endpoints), conn_tracker_(std::move(conn_tracker)), afterglow_period_micros_(afterglow_period_micros), enable_afterglow_(use_afterglow), comm_(comm) {
+                        std::shared_ptr<INetworkConnectionInfoServiceComm> comm,
+                        std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter = 0,
+                        std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter = 0)
+      : conn_scraper_(conn_scraper),
+        scrape_interval_(scrape_interval),
+        turn_off_scraping_(turn_off_scrape),
+        scrape_listen_endpoints_(scrape_listen_endpoints),
+        conn_tracker_(std::move(conn_tracker)),
+        afterglow_period_micros_(afterglow_period_micros),
+        enable_afterglow_(use_afterglow),
+        comm_(comm),
+        connections_total_reporter_(connections_total_reporter),
+        connections_rate_reporter_(connections_rate_reporter) {
   }
 
   void Start();
@@ -54,6 +65,12 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   int64_t afterglow_period_micros_;
   bool enable_afterglow_;
   std::shared_ptr<INetworkConnectionInfoServiceComm> comm_;
+
+  std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter_;
+  std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter_;
+  std::chrono::steady_clock::time_point connections_last_report_time_;     // time delta between the current reporting and the previous (rate computation)
+  std::optional<ConnectionTracker::Stats> connections_rate_counter_last_;  // previous counter values (rate computation)
+  void ReportConnectionStats();
 };
 
 }  // namespace collector

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "CollectorConfig.h"
 #include "CollectorStats.h"
 #include "ConnTracker.h"
 #include "NetworkConnectionInfoServiceComm.h"
@@ -14,18 +15,19 @@ namespace collector {
 
 class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnectionInfoMessage> {
  public:
-  NetworkStatusNotifier(std::shared_ptr<IConnScraper> conn_scraper, int scrape_interval, bool scrape_listen_endpoints, bool turn_off_scrape,
-                        std::shared_ptr<ConnectionTracker> conn_tracker, int64_t afterglow_period_micros, bool use_afterglow,
+  NetworkStatusNotifier(std::shared_ptr<IConnScraper> conn_scraper,
+                        std::shared_ptr<ConnectionTracker> conn_tracker,
                         std::shared_ptr<INetworkConnectionInfoServiceComm> comm,
+                        const CollectorConfig& config,
                         std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter = 0,
                         std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter = 0)
       : conn_scraper_(conn_scraper),
-        scrape_interval_(scrape_interval),
-        turn_off_scraping_(turn_off_scrape),
-        scrape_listen_endpoints_(scrape_listen_endpoints),
+        scrape_interval_(config.ScrapeInterval()),
+        turn_off_scraping_(config.TurnOffScrape()),
+        scrape_listen_endpoints_(config.ScrapeListenEndpoints()),
         conn_tracker_(std::move(conn_tracker)),
-        afterglow_period_micros_(afterglow_period_micros),
-        enable_afterglow_(use_afterglow),
+        afterglow_period_micros_(config.AfterglowPeriod()),
+        enable_afterglow_(config.EnableAfterglow()),
         comm_(comm),
         connections_total_reporter_(connections_total_reporter),
         connections_rate_reporter_(connections_rate_reporter) {

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1586,6 +1586,22 @@ TEST(ConnTrackerTest, TestConnectionStats) {
   EXPECT_EQ(stats.inbound.public_, 2);
   EXPECT_EQ(stats.outbound.private_, 1);
   EXPECT_EQ(stats.outbound.public_, 2);
+
+  tracker.Update({conn1, conn2, conn3, conn4, conn6}, {}, 0);
+  tracker.UpdateConnection(conn5, 0, true);  // inserted
+  tracker.UpdateConnection(conn3, 0, true);  // already known
+
+  stats = tracker.GetConnectionStats_StoredConnections();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 2);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 2);
+
+  stats = tracker.GetConnectionStats_NewConnectionCounters();
+  EXPECT_EQ(stats.inbound.private_, 2);
+  EXPECT_EQ(stats.inbound.public_, 4);
+  EXPECT_EQ(stats.outbound.private_, 2);
+  EXPECT_EQ(stats.outbound.public_, 4);
 }
 
 }  // namespace

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -1525,6 +1525,69 @@ TEST(ConnTrackerTest, TestAdvertisedEndpointEquality) {
       ContainerEndpoint("container", a, L4Proto::TCP, processWithDifferentArgs)));
 }
 
+TEST(ConnTrackerTest, TestConnectionStats) {
+  Endpoint local_ep(Address(10, 1, 1, 8), 1234);
+  Endpoint remote_pub(Address(35, 127, 0, 15), 1234);
+  Endpoint remote_priv(Address(10, 1, 1, 9), 1234);
+  Endpoint remote_altpub(Address(35, 127, 0, 16), 1234);
+
+  // Connection(container, local, remote, proto, is_server)
+  Connection conn1("xyz", local_ep, remote_pub, L4Proto::TCP, true);
+  Connection conn2("xyz", local_ep, remote_priv, L4Proto::TCP, true);
+  Connection conn3("xyz", local_ep, remote_pub, L4Proto::TCP, false);
+  Connection conn4("xyz", local_ep, remote_priv, L4Proto::TCP, false);
+  Connection conn5("xyz", local_ep, remote_altpub, L4Proto::TCP, false);
+  Connection conn6("xyz", local_ep, remote_altpub, L4Proto::TCP, true);
+
+  ConnectionTracker tracker;
+  tracker.Update({conn1, conn2, conn3, conn4}, {}, 0);
+
+  ConnectionTracker::Stats stats;
+
+  stats = tracker.GetConnectionStats_StoredConnections();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 1);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 1);
+
+  stats = tracker.GetConnectionStats_NewConnectionCounters();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 1);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 1);
+
+  tracker.Update({conn1, conn2, conn3, conn4, conn5}, {}, 0);
+  tracker.UpdateConnection(conn6, 0, true);  // inserted
+  tracker.UpdateConnection(conn1, 0, true);  // already known
+
+  stats = tracker.GetConnectionStats_StoredConnections();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 2);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 2);
+
+  stats = tracker.GetConnectionStats_NewConnectionCounters();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 2);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 2);
+
+  tracker.Update({}, {}, 0);
+  tracker.FetchConnState(true);  // clear
+
+  stats = tracker.GetConnectionStats_StoredConnections();
+  EXPECT_EQ(stats.inbound.private_, 0);
+  EXPECT_EQ(stats.inbound.public_, 0);
+  EXPECT_EQ(stats.outbound.private_, 0);
+  EXPECT_EQ(stats.outbound.public_, 0);
+
+  stats = tracker.GetConnectionStats_NewConnectionCounters();
+  EXPECT_EQ(stats.inbound.private_, 1);
+  EXPECT_EQ(stats.inbound.public_, 2);
+  EXPECT_EQ(stats.outbound.private_, 1);
+  EXPECT_EQ(stats.outbound.public_, 2);
+}
+
 }  // namespace
 
 }  // namespace collector

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -222,11 +222,9 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
   });
 
   auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
-                                                               config_.ScrapeInterval(), config_.ScrapeListenEndpoints(),
-                                                               config_.TurnOffScrape(),
                                                                conn_tracker,
-                                                               config_.AfterglowPeriod(), config_.EnableAfterglow(),
-                                                               comm);
+                                                               comm,
+                                                               config_);
 
   net_status_notifier->Start();
 
@@ -324,11 +322,9 @@ TEST(NetworkStatusNotifier, UpdateIPnoAfterglow) {
   });
 
   auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
-                                                               config.ScrapeInterval(), config.ScrapeListenEndpoints(),
-                                                               config.TurnOffScrape(),
                                                                conn_tracker,
-                                                               config.AfterglowPeriod(), config.EnableAfterglow(),
-                                                               comm);
+                                                               comm,
+                                                               config);
 
   net_status_notifier->Start();
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -37,8 +37,17 @@ The default is true.
 * `ROX_COLLECTOR_ENABLE_CONNECTION_STATS`: Instructs Collector to harvest
 and publish metrics regarding the
 [network connections](troubleshooting.md#connection-statistics) handled by the
-connection tracker.
-The default is true.
+connection tracker. The data is summarized in quantiles published by prometheus.
+This is enabled by default.
+
+  - `ROX_COLLECTOR_CONNECTION_STATS_QUANTILES`: a coma separated list of decimals
+    defining the quantiles for all connection metrics. Default: `0.5,0.90,0.95`
+
+  - `ROX_COLLECTOR_CONNECTION_STATS_ERROR`: the allowed error for the quantiles
+    (used to aggregate observations). Default: `0.01`
+
+  - `ROX_COLLECTOR_CONNECTION_STATS_WINDOW`: the length of the sliding time window
+    in minutes. Default: `60`
 
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.

--- a/docs/references.md
+++ b/docs/references.md
@@ -34,6 +34,12 @@ connections status. With this enabled, advertising of asynchronous connections
 will be postponed until their status is known and they are successful.
 The default is true.
 
+* `ROX_COLLECTOR_ENABLE_CONNECTION_STATS`: Instructs Collector to harvest
+and publish metrics regarding the
+[network connections](troubleshooting.md#connection-statistics) handled by the
+connection tracker.
+The default is true.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -347,8 +347,8 @@ Units: bytes
 Those metrics sample values regarding connections stored in the ConnectionTracker
 at every reporting interval (=scrape interval), and over a sliding time window.
 
-They configured using [environment variables](references.md#environment-variables)
-(`ROX_COLLECTOR_CONNECTION_STATS*`).
+They can be configured using
+[environment variables](references.md#environment-variables)(`ROX_COLLECTOR_CONNECTION_STATS*`).
 
 Each metric is declined for both ingoing/outgoing direction, and private/public
 peer location. Corresponding labels are added to the reported values.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -347,16 +347,8 @@ Units: bytes
 Those metrics sample values regarding connections stored in the ConnectionTracker
 at every reporting interval (=scrape interval), and over a sliding time window.
 
-They are enabled by default and can be disabled with the
-`ROX_COLLECTOR_ENABLE_CONNECTION_STATS` environment variable.
-
-Parameters:
-- `ROX_COLLECTOR_CONNECTION_STATS_QUANTILES`: a coma separated list of decimals
-  defining the quantiles for all connection metrics. Default: `0.5,0.90,0.95`.
-- `ROX_COLLECTOR_CONNECTION_STATS_ERROR`: the allowed error for the quantiles
-  (used to aggregate observations). Default: `0.01`
-- `ROX_COLLECTOR_CONNECTION_STATS_WINDOW`: the length of the sliding time window
-  in minutes. Default: `60`.
+They configured using [environment variables](references.md#environment-variables)
+(`ROX_COLLECTOR_CONNECTION_STATS*`).
 
 Each metric is declined for both ingoing/outgoing direction, and private/public
 peer location. Corresponding labels are added to the reported values.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -342,3 +342,93 @@ Units: bytes
 - `lineage_avg_string_len`: overall average length of the lineage description string
 - `std_dev`: standard deviation of the lineage description string length
 
+### Connection statistics
+
+Those metrics sample values regarding connections stored in the ConnectionTracker
+at every reporting interval (=scrape interval), and over a sliding time window.
+
+They are enabled by default and can be disabled with the
+`ROX_COLLECTOR_ENABLE_CONNECTION_STATS` environment variable.
+
+Parameters:
+- `ROX_COLLECTOR_CONNECTION_STATS_QUANTILES`: a coma separated list of decimals
+  defining the quantiles for all connection metrics. Default: `0.5,0.90,0.95`.
+- `ROX_COLLECTOR_CONNECTION_STATS_ERROR`: the allowed error for the quantiles
+  (used to aggregate observations). Default: `0.01`
+- `ROX_COLLECTOR_CONNECTION_STATS_WINDOW`: the length of the sliding time window
+  in minutes. Default: `60`.
+
+Each metric is declined for both ingoing/outgoing direction, and private/public
+peer location. Corresponding labels are added to the reported values.
+
+#### Total number of known connections
+
+```
+Component: ConnectionTracker
+Prometheus names: rox_connections_total
+Units: count
+```
+
+This is the number of connections known to the ConnectionTracker during a reporting interval.
+
+Example output:
+```
+# HELP rox_connections_total Amount of stored connections over time
+# TYPE rox_connections_total summary
+rox_connections_total_count{dir="out",peer="public"} 36
+rox_connections_total_sum{dir="out",peer="public"} 18
+rox_connections_total{dir="out",peer="public",quantile="0.5"} 0
+rox_connections_total{dir="out",peer="public",quantile="0.9"} 1
+rox_connections_total{dir="out",peer="public",quantile="0.95"} 3
+rox_connections_total_count{dir="out",peer="private"} 36
+rox_connections_total_sum{dir="out",peer="private"} 59537
+rox_connections_total{dir="out",peer="private",quantile="0.5"} 1558
+rox_connections_total{dir="out",peer="private",quantile="0.9"} 2067
+rox_connections_total{dir="out",peer="private",quantile="0.95"} 2119
+rox_connections_total_count{dir="in",peer="public"} 36
+rox_connections_total_sum{dir="in",peer="public"} 0
+rox_connections_total{dir="in",peer="public",quantile="0.5"} 0
+rox_connections_total{dir="in",peer="public",quantile="0.9"} 0
+rox_connections_total{dir="in",peer="public",quantile="0.95"} 0
+rox_connections_total_count{dir="in",peer="private"} 36
+rox_connections_total_sum{dir="in",peer="private"} 5009
+rox_connections_total{dir="in",peer="private",quantile="0.5"} 101
+rox_connections_total{dir="in",peer="private",quantile="0.9"} 179
+rox_connections_total{dir="in",peer="private",quantile="0.95"} 180
+```
+
+#### Rate of connection creation
+
+```
+Component: ConnectionTracker
+Prometheus names: rox_connections_rate
+Units: connections per second
+```
+
+This is the rate of connections created during a reporting interval.
+
+Example output:
+```
+# HELP rox_connections_rate Rate of connections over time
+# TYPE rox_connections_rate summary
+rox_connections_rate_count{dir="out",peer="public"} 35
+rox_connections_rate_sum{dir="out",peer="public"} 0.06666667014360428
+rox_connections_rate{dir="out",peer="public",quantile="0.5"} 0
+rox_connections_rate{dir="out",peer="public",quantile="0.9"} 0
+rox_connections_rate{dir="out",peer="public",quantile="0.95"} 0
+rox_connections_rate_count{dir="out",peer="private"} 35
+rox_connections_rate_sum{dir="out",peer="private"} 1947.28048324585
+rox_connections_rate{dir="out",peer="private",quantile="0.5"} 51.43333435058594
+rox_connections_rate{dir="out",peer="private",quantile="0.9"} 67.80000305175781
+rox_connections_rate{dir="out",peer="private",quantile="0.95"} 69.53333282470703
+rox_connections_rate_count{dir="in",peer="public"} 35
+rox_connections_rate_sum{dir="in",peer="public"} 0
+rox_connections_rate{dir="in",peer="public",quantile="0.5"} 0
+rox_connections_rate{dir="in",peer="public",quantile="0.9"} 0
+rox_connections_rate{dir="in",peer="public",quantile="0.95"} 0
+rox_connections_rate_count{dir="in",peer="private"} 35
+rox_connections_rate_sum{dir="in",peer="private"} 119.9425313472748
+rox_connections_rate{dir="in",peer="private",quantile="0.5"} 2.17241382598877
+rox_connections_rate{dir="in",peer="private",quantile="0.9"} 4.800000190734863
+rox_connections_rate{dir="in",peer="private",quantile="0.95"} 4.833333492279053
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -350,7 +350,7 @@ at every reporting interval (=scrape interval), and over a sliding time window.
 They can be configured using
 [environment variables](references.md#environment-variables)(`ROX_COLLECTOR_CONNECTION_STATS*`).
 
-Each metric is declined for both ingoing/outgoing direction, and private/public
+Each metric keeps track of both incoming/outgoing direction, and private/public
 peer location. Corresponding labels are added to the reported values.
 
 #### Total number of known connections
@@ -362,6 +362,11 @@ Units: count
 ```
 
 This is the number of connections known to the ConnectionTracker during a reporting interval.
+
+Example: `rox_connections_total{dir="in",peer="private",quantile="0.5"} 101`
+means that 50% of the values for the number of connections are lower than 101 in the time window
+(typically 1 hour). This specific entry reflects the connections received by the host (`in`), from
+a private IP.
 
 Example output:
 ```


### PR DESCRIPTION
## Description

We add a set of new Prometheus metrics reporting the total amount of connections known by collector and their creation rate over a reporting-period (scrape-interval).

These metrics are split per connection direction (inbound, outbound) and the location of the peer address (private or remote IP).

## Checklist
- [x] Investigated and inspected CI test results

**Automated testing**
  - [x] Added unit tests
 
Excerpt on an idle single-node k8s:
```
# HELP rox_connections_total Amount of stored connections over time
# TYPE rox_connections_total summary
rox_connections_total_count{dir="out",peer="public"} 36
rox_connections_total_sum{dir="out",peer="public"} 18
rox_connections_total{dir="out",peer="public",quantile="0.5"} 0
rox_connections_total{dir="out",peer="public",quantile="0.9"} 1
rox_connections_total{dir="out",peer="public",quantile="0.95"} 3
rox_connections_total_count{dir="out",peer="private"} 36
rox_connections_total_sum{dir="out",peer="private"} 59537
rox_connections_total{dir="out",peer="private",quantile="0.5"} 1558
rox_connections_total{dir="out",peer="private",quantile="0.9"} 2067
rox_connections_total{dir="out",peer="private",quantile="0.95"} 2119
rox_connections_total_count{dir="in",peer="public"} 36
rox_connections_total_sum{dir="in",peer="public"} 0
rox_connections_total{dir="in",peer="public",quantile="0.5"} 0
rox_connections_total{dir="in",peer="public",quantile="0.9"} 0
rox_connections_total{dir="in",peer="public",quantile="0.95"} 0
rox_connections_total_count{dir="in",peer="private"} 36
rox_connections_total_sum{dir="in",peer="private"} 5009
rox_connections_total{dir="in",peer="private",quantile="0.5"} 101
rox_connections_total{dir="in",peer="private",quantile="0.9"} 179
rox_connections_total{dir="in",peer="private",quantile="0.95"} 180
# HELP rox_connections_rate Rate of connections over time
# TYPE rox_connections_rate summary
rox_connections_rate_count{dir="out",peer="public"} 35
rox_connections_rate_sum{dir="out",peer="public"} 0.06666667014360428
rox_connections_rate{dir="out",peer="public",quantile="0.5"} 0
rox_connections_rate{dir="out",peer="public",quantile="0.9"} 0
rox_connections_rate{dir="out",peer="public",quantile="0.95"} 0
rox_connections_rate_count{dir="out",peer="private"} 35
rox_connections_rate_sum{dir="out",peer="private"} 1947.28048324585
rox_connections_rate{dir="out",peer="private",quantile="0.5"} 51.43333435058594
rox_connections_rate{dir="out",peer="private",quantile="0.9"} 67.80000305175781
rox_connections_rate{dir="out",peer="private",quantile="0.95"} 69.53333282470703
rox_connections_rate_count{dir="in",peer="public"} 35
rox_connections_rate_sum{dir="in",peer="public"} 0
rox_connections_rate{dir="in",peer="public",quantile="0.5"} 0
rox_connections_rate{dir="in",peer="public",quantile="0.9"} 0
rox_connections_rate{dir="in",peer="public",quantile="0.95"} 0
rox_connections_rate_count{dir="in",peer="private"} 35
rox_connections_rate_sum{dir="in",peer="private"} 119.9425313472748
rox_connections_rate{dir="in",peer="private",quantile="0.5"} 2.17241382598877
rox_connections_rate{dir="in",peer="private",quantile="0.9"} 4.800000190734863
rox_connections_rate{dir="in",peer="private",quantile="0.95"} 4.833333492279053
```

## Testing performed

- setting `ROX_COLLECTOR_ENABLE_CONNECTION_STATS` to _false_ shows all the metrics value as NaN or 0.
- the values of `ROX_COLLECTOR_CONNECTION_STATS_QUANTILES`, `ROX_COLLECTOR_CONNECTION_STATS_ERROR` and `ROX_COLLECTOR_CONNECTION_STATS_WINDOW` are parsed and appear in the logs.