### PR TITLE
Bump disk size for s390x VM when running in dev mode

### DIFF
--- a/ansible/ci/group_vars/all.yml
+++ b/ansible/ci/group_vars/all.yml
@@ -15,3 +15,4 @@ gcp_default_labels:
   stackrox-ci: "true"
 
 ibm_output_inventory_file: "{{ lookup('env', 'PWD') }}/ci/inventory_ibmcloud.yml"
+ibm_disk_size: 10

--- a/ansible/dev/group_vars/all.yml
+++ b/ansible/dev/group_vars/all.yml
@@ -16,3 +16,4 @@ gcp_default_labels:
   stackrox-ci: "false"
 
 ibm_output_inventory_file: "{{ lookup('env', 'PWD') }}/dev/inventory_ibmcloud.yml"
+ibm_disk_size: 20

--- a/ansible/roles/create-vm/tasks/create-s390x-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-s390x-vm.yml
@@ -22,8 +22,10 @@
     keys:
       - "{{ s390x.ssh_key_id }}"
     primary_network_interface:
-     - subnet: "{{ s390x.subnet_id }}"
+      - subnet: "{{ s390x.subnet_id }}"
     zone: "{{ s390x.zone }}"
+    boot_volume:
+      - size: "{{ s390x.disk_size }}"
   register: vsi
 
 - name: Check for existing Floating IP

--- a/ansible/roles/create-vm/vars/s390x.yml
+++ b/ansible/roles/create-vm/vars/s390x.yml
@@ -15,3 +15,4 @@ s390x:
   ssh_key_id: r038-fb0260c7-c01d-45c8-8026-7d50042943b9
   # vsi_resource_group: stackrox-ci-resource-group
   vsi_resource_group_id: 1a33a6a9bd6e498f8115e9b1064bfa97
+  disk_size: "{{ ibm_disk_size }}"


### PR DESCRIPTION
## Description

IBM cloud VMs are created with 10GB disks by default, this is enough for our tests but it's also a heavy limitation when trying to use one of these VMs for dev work. This patch bumps the size of the created disk to 20GB, which is not huge, but enough for creating a few images and running some tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Create a VM manually and check its disk size is 20GB.
