### PR TITLE
Fix multiarch full image builds on PRs

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -27,6 +27,8 @@ jobs:
     - should-run
     if: needs.should-run.outputs.should-run == 'true'
     uses: ./.github/workflows/init.yml
+    with:
+      cpaas-workflow: true
 
   sync-drivers-and-support-packages:
     uses: ./.github/workflows/cpaas-sync-drivers.yml

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -2,6 +2,11 @@ name: Run global initialization of CI
 
 on:
   workflow_call:
+    inputs:
+      cpaas-workflow:
+        description: true if running from the CPaaS workflow
+        type: boolean
+        required: true
     outputs:
       collector-tag:
         description: The tag used when building collector
@@ -153,7 +158,8 @@ jobs:
               echo "push-drivers-bucket=${STAGING_DRIVER_BUCKET}"
               echo "merged-drivers-bucket=${STAGING_MERGED_DRIVER_BUCKET}"
               echo "support-packages-bucket=${STAGING_SUPPORT_PACKAGES_BUCKET}"
-              if [[ ${{ contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps') }} == "true" ]]; then
+              if [[ "${{ inputs.cpaas-workflow }}" == "true" &&
+                    "${{ contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps') }}" == "true" ]]; then
                   echo "cpaas-drivers-bucket=${CPAAS_STAGING_DRIVERS_BUCKET}"
                   echo "cpaas-all-archs-drivers-bucket=${CPAAS_STAGING_ALL_ARCHS_DRIVERS_BUCKET}"
                   echo "cpaas-support-packages-bucket=${CPAAS_STAGING_SUPPORT_PACKAGES_BUCKET}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
   init:
     uses: ./.github/workflows/init.yml
     secrets: inherit
+    with:
+      cpaas-workflow: false
 
   build-drivers:
     uses: ./.github/workflows/drivers.yml


### PR DESCRIPTION
## Description

There's a bug when building full multiarch images on PRs. The bucket used for pulling drivers is changed in the main CI workflow to use a staging bucket, but the main CI never pushes drivers for P/Z to this bucket, so it fails because it find no drivers to add into the image. Changing to the staging bucket should only be done by the CPaaS workflow, so an additional condition for this is added.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run CI with `build-full-images`, `run-multiarch-builds` and `run-cpaas-steps`. Ensure all used buckets are the expected ones.
