### PR TITLE
Remove CORE_BPF available message on Power machines

### DIFF
--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -29,7 +29,7 @@ class CollectionHeuristic : public Heuristic {
     if (config.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
       if (kernel.machine == "ppc64le") {
         CLOG(FATAL) << "CORE_BPF collection method is not supported on ppc64le. "
-                    << "Please set collector.collectionMethod=EBPF.";
+                    << "HINT: Change collection method to eBPF with collector.collectionMethod=EBPF.";
       }
 
       if (!host.HasBTFSymbols()) {
@@ -42,8 +42,7 @@ class CollectionHeuristic : public Heuristic {
 
       if (!host.HasBPFRingBufferSupport()) {
         CLOG(FATAL) << "Missing RingBuffer support, core_bpf is not available. "
-                    << "HINT: You may alternatively want to use eBPF based collection "
-                    << "with collector.collectionMethod=EBPF.";
+                    << "HINT: Change collection method to eBPF with collector.collectionMethod=EBPF.";
       }
 
       if (!host.HasBPFTracingSupport()) {


### PR DESCRIPTION
## Description

When running on Power machines, we are wrongly printing a message stating that CORE_BPF is available on the platform, but we don't support it in code, so we shouldn't be printing the message. Additionally, setting CORE_BPF as the collection method should hard fail since it is unsupported.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Will try to test this on a power VM, but the change is small enough that should be good enough to be merged as is IMO.
