### PR TITLE
Use a logging callback for Falco log messages

### DIFF
--- a/collector/lib/FileDownloader.cpp
+++ b/collector/lib/FileDownloader.cpp
@@ -60,7 +60,7 @@ int DebugCallback(CURL*, curl_infotype type, char* data, size_t size, void*) {
     return CURLE_OK;
   }
 
-  if (logging::GetLogLevel() > logging::LogLevel::TRACE) {
+  if (!logging::CheckLogLevel(logging::LogLevel::TRACE)) {
     // Skip other types of messages if we are not tracing
     return CURLE_OK;
   }
@@ -250,7 +250,7 @@ bool FileDownloader::SetConnectTo(const std::string& host, const std::string& ta
 }
 
 void FileDownloader::SetVerboseMode(bool verbose) {
-  if (logging::GetLogLevel() <= logging::LogLevel::DEBUG && verbose) {
+  if (logging::CheckLogLevel(logging::LogLevel::DEBUG) && verbose) {
     curl_easy_setopt(curl_, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl_, CURLOPT_DEBUGFUNCTION, DebugCallback);
   } else {

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -100,6 +100,56 @@ bool ParseLogLevelName(std::string name, LogLevel* level) {
   return true;
 }
 
+void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
+  auto collector_severity = logging::InspectorSeverityToLogLevel(severity);
+
+  if (!collector_severity) {
+    return;
+  }
+
+  collector::logging::LogMessage(__FILE__, __LINE__, false, *collector_severity) << msg;
+}
+
+std::optional<sinsp_logger::severity> LogLevelToInspectorSeverity(LogLevel level) {
+  switch (level) {
+    case LogLevel::TRACE:
+      return sinsp_logger::SEV_TRACE;
+    case LogLevel::DEBUG:
+      return sinsp_logger::SEV_DEBUG;
+    case LogLevel::INFO:
+      return sinsp_logger::SEV_INFO;
+    case LogLevel::WARNING:
+      return sinsp_logger::SEV_WARNING;
+    case LogLevel::ERROR:
+      return sinsp_logger::SEV_ERROR;
+    case LogLevel::FATAL:
+      return sinsp_logger::SEV_FATAL;
+    default:
+      return {};
+  };
+}
+
+std::optional<LogLevel> InspectorSeverityToLogLevel(sinsp_logger::severity severity) {
+  switch (severity) {
+    case sinsp_logger::SEV_FATAL:
+      return LogLevel::FATAL;
+    case sinsp_logger::SEV_CRITICAL:
+    case sinsp_logger::SEV_ERROR:
+      return LogLevel::ERROR;
+    case sinsp_logger::SEV_WARNING:
+      return LogLevel::WARNING;
+    case sinsp_logger::SEV_NOTICE:
+    case sinsp_logger::SEV_INFO:
+      return LogLevel::INFO;
+    case sinsp_logger::SEV_DEBUG:
+      return LogLevel::DEBUG;
+    case sinsp_logger::SEV_TRACE:
+      return LogLevel::TRACE;
+    default:
+      return {};
+  }
+}
+
 const char* GetGlobalLogPrefix() {
   return g_log_prefix.load(std::memory_order_relaxed);
 }

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -48,7 +48,7 @@ void SetLogLevel(LogLevel level) {
 }
 
 bool CheckLogLevel(LogLevel level) {
-  return level >= GetLogLevel();
+  return level <= GetLogLevel();
 }
 
 const char* GetLogLevelName(LogLevel level) {
@@ -101,53 +101,8 @@ bool ParseLogLevelName(std::string name, LogLevel* level) {
 }
 
 void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
-  auto collector_severity = logging::InspectorSeverityToLogLevel(severity);
-
-  if (!collector_severity) {
-    return;
-  }
-
-  collector::logging::LogMessage(__FILE__, __LINE__, false, *collector_severity) << msg;
-}
-
-std::optional<sinsp_logger::severity> LogLevelToInspectorSeverity(LogLevel level) {
-  switch (level) {
-    case LogLevel::TRACE:
-      return sinsp_logger::SEV_TRACE;
-    case LogLevel::DEBUG:
-      return sinsp_logger::SEV_DEBUG;
-    case LogLevel::INFO:
-      return sinsp_logger::SEV_INFO;
-    case LogLevel::WARNING:
-      return sinsp_logger::SEV_WARNING;
-    case LogLevel::ERROR:
-      return sinsp_logger::SEV_ERROR;
-    case LogLevel::FATAL:
-      return sinsp_logger::SEV_FATAL;
-    default:
-      return {};
-  };
-}
-
-std::optional<LogLevel> InspectorSeverityToLogLevel(sinsp_logger::severity severity) {
-  switch (severity) {
-    case sinsp_logger::SEV_FATAL:
-      return LogLevel::FATAL;
-    case sinsp_logger::SEV_CRITICAL:
-    case sinsp_logger::SEV_ERROR:
-      return LogLevel::ERROR;
-    case sinsp_logger::SEV_WARNING:
-      return LogLevel::WARNING;
-    case sinsp_logger::SEV_NOTICE:
-    case sinsp_logger::SEV_INFO:
-      return LogLevel::INFO;
-    case sinsp_logger::SEV_DEBUG:
-      return LogLevel::DEBUG;
-    case sinsp_logger::SEV_TRACE:
-      return LogLevel::TRACE;
-    default:
-      return {};
-  }
+  auto collector_severity = (LogLevel)severity;
+  collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
 }
 
 const char* GetGlobalLogPrefix() {

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -16,13 +16,27 @@ namespace collector {
 namespace logging {
 
 enum class LogLevel : uint32_t {
-  TRACE = 10,
-  DEBUG = 20,
-  INFO = 30,
-  WARNING = 40,
-  ERROR = 50,
-  FATAL = 60
+  FATAL = 1,
+  CRITICAL = 2,
+  ERROR = 3,
+  WARNING = 4,
+  NOTICE = 5,
+  INFO = 6,
+  DEBUG = 7,
+  TRACE = 8,
 };
+
+// Static checks helping to keep the inspector and our logging levels synced.
+static_assert(static_cast<int>(LogLevel::TRACE) == sinsp_logger::SEV_TRACE);
+static_assert(static_cast<int>(LogLevel::DEBUG) == sinsp_logger::SEV_DEBUG);
+static_assert(static_cast<int>(LogLevel::INFO) == sinsp_logger::SEV_INFO);
+static_assert(static_cast<int>(LogLevel::NOTICE) == sinsp_logger::SEV_NOTICE);
+static_assert(static_cast<int>(LogLevel::WARNING) == sinsp_logger::SEV_WARNING);
+static_assert(static_cast<int>(LogLevel::ERROR) == sinsp_logger::SEV_ERROR);
+static_assert(static_cast<int>(LogLevel::CRITICAL) == sinsp_logger::SEV_CRITICAL);
+static_assert(static_cast<int>(LogLevel::FATAL) == sinsp_logger::SEV_FATAL);
+static_assert(static_cast<int>(LogLevel::FATAL) == sinsp_logger::SEV_MIN);
+static_assert(static_cast<int>(LogLevel::TRACE) == sinsp_logger::SEV_MAX);
 
 LogLevel GetLogLevel();
 void SetLogLevel(LogLevel level);
@@ -33,8 +47,6 @@ char GetLogLevelShortName(LogLevel level);
 bool ParseLogLevelName(std::string name, LogLevel* level);
 
 void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity);
-std::optional<sinsp_logger::severity> LogLevelToInspectorSeverity(LogLevel level);
-std::optional<LogLevel> InspectorSeverityToLogLevel(sinsp_logger::severity severity);
 
 const char* GetGlobalLogPrefix();
 void SetGlobalLogPrefix(const char* prefix);

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
-#include <optional>
 #include <sstream>
 #include <string.h>
 

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -5,8 +5,11 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string.h>
+
+#include "logger.h"
 
 namespace collector {
 
@@ -28,6 +31,10 @@ bool CheckLogLevel(LogLevel level);
 const char* GetLogLevelName(LogLevel level);
 char GetLogLevelShortName(LogLevel level);
 bool ParseLogLevelName(std::string name, LogLevel* level);
+
+void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity);
+std::optional<sinsp_logger::severity> LogLevelToInspectorSeverity(LogLevel level);
+std::optional<LogLevel> InspectorSeverityToLogLevel(sinsp_logger::severity severity);
 
 const char* GetGlobalLogPrefix();
 void SetGlobalLogPrefix(const char* prefix);

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -24,6 +24,7 @@
 #include "SelfChecks.h"
 #include "TimeUtil.h"
 #include "Utility.h"
+#include "logger.h"
 
 namespace collector {
 
@@ -71,8 +72,11 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     // peeking into arguments has a big overhead, so we prevent it from happening
     inspector_->set_snaplen(0);
 
-    if (logging::GetLogLevel() == logging::LogLevel::TRACE) {
-      inspector_->set_log_stderr();
+    auto log_level = logging::LogLevelToInspectorSeverity(logging::GetLogLevel());
+    if (log_level) {
+      inspector_->set_min_log_severity(*log_level);
+      inspector_->disable_log_timestamps();
+      inspector_->set_log_callback(logging::InspectorLogCallback);
     }
 
     inspector_->set_import_users(config.ImportUsers());

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -72,12 +72,10 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     // peeking into arguments has a big overhead, so we prevent it from happening
     inspector_->set_snaplen(0);
 
-    auto log_level = logging::LogLevelToInspectorSeverity(logging::GetLogLevel());
-    if (log_level) {
-      inspector_->set_min_log_severity(*log_level);
-      inspector_->disable_log_timestamps();
-      inspector_->set_log_callback(logging::InspectorLogCallback);
-    }
+    auto log_level = (sinsp_logger::severity)logging::GetLogLevel();
+    inspector_->set_min_log_severity(log_level);
+    inspector_->disable_log_timestamps();
+    inspector_->set_log_callback(logging::InspectorLogCallback);
 
     inspector_->set_import_users(config.ImportUsers());
 


### PR DESCRIPTION
## Description

This change unifies log severity between our code and Falco and makes it so their log messages are logged with our logging mechanism, giving a more unified look for the logs and improving debugability with additional information for all events being processed. Originally, the container engine mechanism was very noisy on debug level, but since we stopped using the default engine this noise has been reduced significantly.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Run some tests manually and checked the output on info and debug levels.

<details>
  <summary>Example log from one of the tests</summary>

```
Collector Version: 3.17.x-10-g2935f965cf
OS: Red Hat Enterprise Linux 9.2 (Plow)
Kernel Version: 5.14.0-284.30.1.el9_2.x86_64
Starting StackRox Collector...
[INFO    2023/10/27 09:47:29] Hostname: 'collector-ci-core-rhel-9-6665290025rhel.c.stackrox-ci.internal'
[INFO    2023/10/27 09:47:29] (CollectorConfig.cpp:91) User configured logLevel=debug
[INFO    2023/10/27 09:47:29] (CollectorConfig.cpp:100) User configured scrapeInterval=2
[INFO    2023/10/27 09:47:29] (CollectorConfig.cpp:106) User configured turnOffScrape=1
[INFO    2023/10/27 09:47:29] (CollectorConfig.cpp:127) User configured collection-method=core_bpf
[INFO    2023/10/27 09:47:29] (CollectorConfig.cpp:179) Afterglow is enabled
[DEBUG   2023/10/27 09:47:29] (HostInfo.h:102) Identified kernel release: '5.14.0-284.30.1.el9_2.x86_64'
[DEBUG   2023/10/27 09:47:29] (HostInfo.h:103) Identified kernel version: '#1 SMP PREEMPT_DYNAMIC Fri Aug 25 09:13:12 EDT 2023'
[DEBUG   2023/10/27 09:47:29] (HostInfo.h:104) Identified kernel machine: 'x86_64'
[DEBUG   2023/10/27 09:47:29] (HostInfo.cpp:208) BTF symbols found in /host/sys/kernel/btf/vmlinux
[DEBUG   2023/10/27 09:47:29] (collector.cpp:105) Core dumps not enabled
[INFO    2023/10/27 09:47:29] (collector.cpp:62) Sensor configured at address: localhost:9999
[INFO    2023/10/27 09:47:29] (collector.cpp:156) Attempting to connect to Sensor
[INFO    2023/10/27 09:47:29] (collector.cpp:158) Successfully connected to Sensor.
[INFO    2023/10/27 09:47:29] (collector.cpp:168) Module version: 2.7.0
[INFO    2023/10/27 09:47:29] (CollectorService.cpp:31) Config: collection_method:core_bpf, scrape_interval:2, turn_off_scrape:1, hostname:collector-ci-core-rhel-9-6665290025rhel.c.stackrox-ci.internal, processesListeningOnPorts:1, logLevel:DEBUG, set_import_users:0, collect_connection_status:1, enable_external_ips:0
[INFO    2023/10/27 09:47:29] (CollectorService.cpp:145) Candidate drivers: 
[INFO    2023/10/27 09:47:29] (CollectorService.cpp:147) CO.RE eBPF probe
[INFO    2023/10/27 09:47:29] (CollectorService.cpp:147) collector-ebpf-5.14.0-284.30.1.el9_2.x86_64.o
[INFO    2023/10/27 09:47:29] (Logging.cpp:110) Trying to open the right engine!
[DEBUG   2023/10/27 09:47:30] (Logging.cpp:110) identify_category (200666) (sh): initial process for container, assigning CAT_CONTAINER
[DEBUG   2023/10/27 09:47:30] (Logging.cpp:110) identify_category (200915) (sleep): taking parent category 1
[INFO    2023/10/27 09:47:30] (collector.cpp:113) 
[INFO    2023/10/27 09:47:30] (collector.cpp:114) This product uses ebpf subcomponents licensed under the GNU
[INFO    2023/10/27 09:47:30] (collector.cpp:115) GENERAL PURPOSE LICENSE Version 2 outlined in the /kernel-modules/LICENSE file.
[INFO    2023/10/27 09:47:30] (collector.cpp:116) Source code for the ebpf subcomponents is available at
[INFO    2023/10/27 09:47:30] (collector.cpp:117) https://github.com/stackrox/falcosecurity-libs/
[INFO    2023/10/27 09:47:30] (collector.cpp:118) 
[INFO    2023/10/27 09:47:30] (Diagnostics.h:19) 
[INFO    2023/10/27 09:47:30] (Diagnostics.h:20) == Collector Startup Diagnostics: ==
[INFO    2023/10/27 09:47:30] (Diagnostics.h:21)  Connected to Sensor?       true
[INFO    2023/10/27 09:47:30] (Diagnostics.h:23)  Kernel driver candidates:
[INFO    2023/10/27 09:47:30] (Diagnostics.h:25)    CO.RE eBPF probe (available)
[INFO    2023/10/27 09:47:30] (Diagnostics.h:25)  Driver loaded into kernel: CO.RE eBPF probe
[INFO    2023/10/27 09:47:30] (Diagnostics.h:28) ====================================
[INFO    2023/10/27 09:47:30] (Diagnostics.h:29) 
[INFO    2023/10/27 09:47:30] (CollectorService.cpp:61) Network scrape interval set to 2 seconds
[INFO    2023/10/27 09:47:30] (CollectorService.cpp:64) Waiting for Sensor to become ready ...
[INFO    2023/10/27 09:47:30] (CollectorService.cpp:69) Sensor connectivity is successful
[DEBUG   2023/10/27 09:47:30] (ConnTracker.cpp:319) ignored l4 protocol and port pairs
[DEBUG   2023/10/27 09:47:30] (ConnTracker.cpp:321) udp/9
[INFO    2023/10/27 09:47:30] (NetworkStatusNotifier.cpp:145) Started network status notifier.
[INFO    2023/10/27 09:47:30] (NetworkStatusNotifier.cpp:159) Established network connection info stream.
[INFO    2023/10/27 09:47:30] (SignalServiceClient.cpp:20) Trying to establish GRPC stream for signals ...
[INFO    2023/10/27 09:47:30] (SignalServiceClient.cpp:38) Successfully established GRPC stream for signals.
[DEBUG   2023/10/27 09:47:30] (Logging.cpp:110) identify_category (200989) (docker): taking parent category 1
[INFO    2023/10/27 09:47:30] (SelfCheckHandler.cpp:18) Found self-check process event.
[DEBUG   2023/10/27 09:47:30] (Logging.cpp:110) identify_category (200994) (docker): taking parent category 1
[INFO    2023/10/27 09:47:31] (SelfCheckHandler.cpp:43) Found self-check connection event.
[DEBUG   2023/10/27 09:47:32] (Logging.cpp:110) identify_category (201008) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:32] (Logging.cpp:110) identify_category (201008) (sleep): taking parent category 1
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:145) Process (201008): sleep --coreutils-prog-shebang=sleep /usr/bin/sleep 1
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:204) Process (201008): sleep --coreutils-prog-shebang=sleep /usr/bin/sleep 1
[DEBUG   2023/10/27 09:47:32] (SysdigService.cpp:256) Found existing process: Container: "ffc9cc5a0c2a", Name: sleep, PID: 201008, Args: /usr/bin/coreutils
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:204) Process (201001): self-checks 13037
[DEBUG   2023/10/27 09:47:32] (SysdigService.cpp:256) Found existing process: Container: "40908db4b526", Name: self-checks, PID: 201001, Args: /usr/local/bin/self-checks
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:204) Process (201000): self-checks 13037
[DEBUG   2023/10/27 09:47:32] (SysdigService.cpp:256) Found existing process: Container: "40908db4b526", Name: self-checks, PID: 201000, Args: /usr/local/bin/self-checks
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:204) Process (200915): sleep --coreutils-prog-shebang=sleep /usr/bin/sleep 1
[DEBUG   2023/10/27 09:47:32] (SysdigService.cpp:256) Found existing process: Container: "ffc9cc5a0c2a", Name: sleep, PID: 200915, Args: /usr/bin/coreutils
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:204) Process (200666): sh /stats.sh
[DEBUG   2023/10/27 09:47:32] (SysdigService.cpp:256) Found existing process: Container: "ffc9cc5a0c2a", Name: sh, PID: 200666, Args: sh
[DEBUG   2023/10/27 09:47:32] (ProcessSignalFormatter.cpp:145) Process (201008): sleep --coreutils-prog-shebang=sleep /usr/bin/sleep 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201065) (nginx): initial process for container, assigning CAT_CONTAINER
[DEBUG   2023/10/27 09:47:33] (ProcessSignalFormatter.cpp:145) Process (201065): nginx -g daemon off;
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201086) (nginx): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (ProcessSignalFormatter.cpp:145) Process (201100): sleep 5
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201106) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201108) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201106) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (ProcessSignalFormatter.cpp:145) Process (201106): docker stats --no-stream -a
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201108) (awk): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (ProcessSignalFormatter.cpp:145) Process (201108): awk {gsub(/%$/,"",$3); printf("{\"timestamp\": \"%s\",\"id\": \"%s\", \"name\": \"%s\", \"mem\": \"%s\", \"cpu\": %s}\n", strftime("%Y-%m-%d %H:%M:%S", systime(), 1), $1, $2, $4, $3 ); fflush();}
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201107) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201107) (grep): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (ProcessSignalFormatter.cpp:145) Process (201107): grep -E (benchmark|collector|grpc-server)
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201109) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201110) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201111) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201112) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:33] (Logging.cpp:110) identify_category (201113) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:36] (Logging.cpp:110) identify_category (201121) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:36] (Logging.cpp:110) identify_category (201121) (sleep): taking parent category 1
[DEBUG   2023/10/27 09:47:36] (ProcessSignalFormatter.cpp:145) Process (201121): sleep --coreutils-prog-shebang=sleep /usr/bin/sleep 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201122) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201124) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201122) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (ProcessSignalFormatter.cpp:145) Process (201122): docker stats --no-stream -a
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201124) (awk): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (ProcessSignalFormatter.cpp:145) Process (201124): awk {gsub(/%$/,"",$3); printf("{\"timestamp\": \"%s\",\"id\": \"%s\", \"name\": \"%s\", \"mem\": \"%s\", \"cpu\": %s}\n", strftime("%Y-%m-%d %H:%M:%S", systime(), 1), $1, $2, $4, $3 ); fflush();}
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201123) (sh): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201123) (grep): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (ProcessSignalFormatter.cpp:145) Process (201123): grep -E (benchmark|collector|grpc-server)
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201125) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201126) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201127) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201128) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:37] (Logging.cpp:110) identify_category (201129) (docker): taking parent category 1
[DEBUG   2023/10/27 09:47:38] (ProcessSignalFormatter.cpp:145) Process (201152): sh -c ls
[DEBUG   2023/10/27 09:47:38] (ProcessSignalFormatter.cpp:145) Process (201152): ls 
[DEBUG   2023/10/27 09:47:38] (Logging.cpp:110) identify_category (201200) (sleep): initial process for container, assigning CAT_CONTAINER
[DEBUG   2023/10/27 09:47:38] (ProcessSignalFormatter.cpp:145) Process (201200): sleep 300
[DEBUG   2023/10/27 09:47:38] (ProcessSignalFormatter.cpp:145) Process (201249): curl 172.17.0.3:80
collector pid to be stopped is 10
[DEBUG   2023/10/27 09:47:38] (CollectorService.cpp:107) Interrupted collector!
[INFO    2023/10/27 09:47:38] (CollectorService.cpp:113) Caught signal 15 (SIGTERM): Terminated
[INFO    2023/10/27 09:47:38] (CollectorService.cpp:116) Shutting down collector.
[ERROR   2023/10/27 09:47:38] (NetworkStatusNotifier.cpp:135) Error streaming network connection info: CANCELLED
[INFO    2023/10/27 09:47:38] (NetworkStatusNotifier.cpp:140) Stopped network status notifier.
[INFO    2023/10/27 09:47:40] (SignalServiceClient.cpp:48) Signal service client terminating.
[INFO    2023/10/27 09:47:40] (SelfChecks.cpp:40) self-check (pid=76) exited with status: 0
[INFO    2023/10/27 09:47:42] (collector.cpp:192) Collector exiting successfully!
```

</details>
