### PR TITLE
ROX-20541: Temporarily exclude kernels 6.6 from build

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -72,7 +72,7 @@
 6.2.* 2.2.0 *
 6.2.* 2.1.0 *
 6.2.* 2.0.1 *
-# TODO(ROX-16705) - 6.3/6.4 kernel compilation errors
+# ROX-16705 - 6.3/6.4 kernel compilation errors
 ~6\.[3-9]\.\d+.* ~2\.[2-5]\.\d+(?:-rc\d+)?
 # TODO(ROX-20541) - 6.6 kernel compilation errors
 6.6.* *

--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -75,7 +75,7 @@
 # ROX-16705 - 6.3/6.4 kernel compilation errors
 ~6\.[3-9]\.\d+.* ~2\.[2-5]\.\d+(?:-rc\d+)?
 # TODO(ROX-20541) - 6.6 kernel compilation errors
-6.6.* *
+6.6.*
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod

--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -74,6 +74,8 @@
 6.2.* 2.0.1 *
 # TODO(ROX-16705) - 6.3/6.4 kernel compilation errors
 ~6\.[3-9]\.\d+.* ~2\.[2-5]\.\d+(?:-rc\d+)?
+# TODO(ROX-20541) - 6.6 kernel compilation errors
+6.6.* *
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod


### PR DESCRIPTION
## Description

A patch was introduced to solve build issues on earlier RC versions of 6.6, which is now causing
build issues. It has been mostly reverted upstream.

Block temporarily those kernels while we work on pulling upstream.

## Testing

This does not touch the Collector code, we just want to make the drivers build happy.