### PR TITLE
Fixes dev driver builds by copying driver config

### DIFF
--- a/kernel-modules/dev/build-drivers.sh
+++ b/kernel-modules/dev/build-drivers.sh
@@ -30,6 +30,9 @@ cmake -S ${DRIVER_DIR} \
     -DBUILD_LIBSCAP_MODERN_BPF=ON \
     -DMODERN_BPF_EXCLUDE_PROGS='^(openat2|ppoll|setsockopt|getsockopt|clone3|io_uring_setup|nanosleep)$' \
     -B ${DRIVER_DIR}/build
+
+cp "${DRIVER_DIR}/build/driver/src/driver_config.h" "${DRIVER_DIR}/driver/driver_config.h"
+
 make -C ${PROBE_DIR} FALCO_DIR="${DRIVER_DIR}/driver/bpf"
 
 mkdir -p "${OUTPUT_DIR}"


### PR DESCRIPTION
## Description

From a clean state, the driver config is not copied into the source tree like it is for CI builds. This PR simply copied the file over. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed\

Tested locally. Should not affect CI.
