### PR TITLE
Build test container on CPaaS workflow

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -88,6 +88,16 @@ jobs:
     - build-collector-slim
     - sync-drivers-and-support-packages
 
+  build-test-containers:
+    uses: ./.github/workflows/integration-test-containers.yml
+    needs:
+    - init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
+      collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
+      rebuild-qa-containers: ${{ needs.init.outputs.rebuild-qa-containers == 'true' }}
+    secrets: inherit
+
   integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -119,6 +119,7 @@ jobs:
     needs:
     - init
     - build-collector-full
+    - build-test-containers
     secrets: inherit
 
   # Isolating multi-arch testing temporarily while fixes are found for ppc64le

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -13,7 +13,7 @@ COPY go.* "$TEST_ROOT"
 
 WORKDIR "$TEST_ROOT"
 
-RUN CGO_ENABLED=0 go test -tags bench -c -o collector-tests
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go test -tags bench -c -o collector-tests
 
 FROM --platform=$BUILDPLATFORM alpine:3.18
 

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,6 +1,6 @@
 ARG TEST_ROOT="/tests"
 
-FROM --platform=$BUILDPLATFORM golang:1.19 as builder
+FROM golang:1.19 as builder
 
 ARG TEST_ROOT
 
@@ -13,9 +13,9 @@ COPY go.* "$TEST_ROOT"
 
 WORKDIR "$TEST_ROOT"
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go test -tags bench -c -o collector-tests
+RUN CGO_ENABLED=0 go test -tags bench -c -o collector-tests
 
-FROM --platform=$BUILDPLATFORM alpine:3.18
+FROM alpine:3.18
 
 ARG TEST_ROOT
 


### PR DESCRIPTION

## Description

Since the integration tests have been containerized, the CPaaS workflow needs to build the image in order for it to be able to run the tests.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

- [ ] Run CI with `run-cpaas-steps` label.
