### PR TITLE
Use a concurrency group different from the one on main

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -12,7 +12,7 @@ on:
       - reopened
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: cpaas-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

#1359 added a concurrency group to the cpaas workflow. Unfortunately, since it's the same as the one in the main workflow, they are colliding when running from PRs. This small change should stop the collision.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Ensure both the main and cpaas steps run when using the `run-cpaas-steps` label.
