### PR TITLE
Add ARM64 to the platforms used for the integration test container

### DIFF
--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -3,7 +3,7 @@
   hosts: all
 
   environment:
-    PLATFORMS: "linux/amd64,linux/ppc64le,linux/s390x"
+    PLATFORMS: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
 
   tasks:
     - set_fact:

--- a/ansible/group_vars/platform_fcarm.yml
+++ b/ansible/group_vars/platform_fcarm.yml
@@ -1,2 +1,4 @@
 ---
 ansible_user: core
+
+needs_selinux_permissive: true


### PR DESCRIPTION
## Description

The integration test container is not being build for ARM64 and it's causing failures on the main branch, this should fix it.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run ARM tests.
