### PR TITLE
Block Garden Linux eBPF tests

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -31,6 +31,8 @@ excluded_pairs:
   - [ 'ubuntu-2204-lts-arm64', 'ebpf' ]
   - [ 'sles-15-arm64', 'ebpf' ]
   - [ 'fedora-coreos-stable-arm64', 'ebpf' ]
+  # eBPF on Garden Linux is not supported.
+  - [ 'garden-linux', 'ebpf' ]
 
 virtual_machines:
   rhel:


### PR DESCRIPTION

## Description

After unsuccessfully trying to get upstream Garden Linux to help us crawl newer kernels, we've decided to stop maintaining eBPF probes for the distro in favour of the CO-RE BPF driver.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `all-integration-tests` label.
