### PR TITLE
Block RHEL 9.3 kernel modules

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -80,3 +80,7 @@
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod
+# Block kernel modules for RHEL 9.3+
+# These builds are broken but we no longer support kmods
+# See: https://github.com/falcosecurity/libs/pull/1174
+~.*\.el9_[3-9]\..* * mod


### PR DESCRIPTION
## Description

These drivers are broken and require a patch, see: https://github.com/falcosecurity/libs/pull/1174

However, kernel modules are deprecated and maintained as best effort only, so for the moment we will just block the affected kernels.


## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
