### PR TITLE
Skip integration-test container build

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -21,6 +21,9 @@ jobs:
   build-test-image:
     name: Build the integration test image
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests')
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

When skipping the integration tests on a PR, we can safely skip building the integration-test container. This container always builds as multiarch and can take quite a bit to finish.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run with `skip-integration-tests` label. [CI Run](https://github.com/stackrox/collector/actions/runs/6799896989?pr=1411)
- [x] Run without `skip-integration-tests` label. [CI Run](https://github.com/stackrox/collector/actions/runs/6798486754?pr=1411)
