### PR TITLE
Switches ansible dev inventory to acs-team-sandbox

### DIFF
--- a/ansible/dev/group_vars/all.yml
+++ b/ansible/dev/group_vars/all.yml
@@ -1,7 +1,7 @@
 ---
 
 # GCP setup
-gcp_project: "stackrox-dev"
+gcp_project: "acs-team-sandbox"
 gcp_auth_kind: "application"
 gcp_service_account_file: null
 gcp_instance_prefix: collector-dev

--- a/ansible/dev/inventory_gcp.yml
+++ b/ansible/dev/inventory_gcp.yml
@@ -2,7 +2,7 @@
 
 plugin: gcp_compute
 projects:
-  - stackrox-dev
+  - acs-team-sandbox
 filters:
   - name = collector-dev-*
 keyed_groups:


### PR DESCRIPTION
## Description

Now that the stackrox-dev project is being deleted, we need to shift the development inventory to the new project. There may be a follow up in the coming weeks to do the same for stackrox-ci

If any of these don't apply, please comment below.

## Testing Performed

Tested locally. This PR does not affect anything beyond local testing.