### PR TITLE
Ensure collector-builder-tag is set when a rebuild is not needed

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -22,7 +22,7 @@ jobs:
     name: Determine if builder image needs to be built
     runs-on: ubuntu-latest
     outputs:
-      build-image: ${{ steps.changed.outputs.builder-changed }}
+      build-image: "false"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -22,7 +22,7 @@ jobs:
     name: Determine if builder image needs to be built
     runs-on: ubuntu-latest
     outputs:
-      build-image: "false"
+      build-image: ${{ steps.changed.outputs.builder-changed }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -11,7 +11,7 @@ on:
     outputs:
       collector-builder-tag:
         description: The builder tag used by the build
-        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag }}
+        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag || 'master' }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
   memory-checked-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/collector-builder:${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      image: quay.io/stackrox-io/collector-builder:${{ needs.build-builder-image.outputs.collector-builder-tag || 'master' }}
     needs:
       - build-builder-image
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
   memory-checked-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/collector-builder:${{ needs.build-builder-image.outputs.collector-builder-tag || 'master' }}
+      image: quay.io/stackrox-io/collector-builder:${{ needs.build-builder-image.outputs.collector-builder-tag }}
     needs:
       - build-builder-image
     strategy:


### PR DESCRIPTION
## Description

Ensure `collector-builder-tag` is set when a rebuild is not needed.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI should be enough.
