### PR TITLE
Avoid kernel modules for rhel 8.9

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -84,3 +84,8 @@
 # These builds are broken but we no longer support kmods
 # See: https://github.com/falcosecurity/libs/pull/1174
 ~.*\.el9_[3-9]\..* * mod
+# Block kernel modules for RHEL 8.9
+# Those have backported the change which was already an issue here:
+# https://github.com/falcosecurity/libs/issues/918
+# Since kmods are not supported anyway, block these combination
+~.*\.el8_9\..* * mod


### PR DESCRIPTION
## Description

RHEL 8.9 with latest kernels contains backports for the once fixed issue for kernel modules [[1]]. Kernel modules are going to be deprecated soon anyway, so simply block their build for those versions with module version 2.3.0 & 2.4.0 (the last yet in build). 

[1]: https://github.com/falcosecurity/libs/issues/918