### PR TITLE
Test container builds now respect run-multiarch-build label

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         required: true
         description: Whether the QA containers should be rebuilt
+      build-multi-arch:
+        type: boolean
+        required: true
+        description: Whether to build multi-arch containers
 
 jobs:
   build-test-image:
@@ -49,6 +53,7 @@ jobs:
           ansible-playbook \
             --connection local -i localhost, --limit localhost \
             -e test_image='quay.io/rhacs-eng/qa-multi-arch:collector-tests-${{ inputs.collector-tag }}' \
+            -e build_multi_arch="${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') }}" \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-tests.yml
 

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -16,10 +16,6 @@ on:
         type: boolean
         required: true
         description: Whether the QA containers should be rebuilt
-      build-multi-arch:
-        type: boolean
-        required: true
-        description: Whether to build multi-arch containers
 
 jobs:
   build-test-image:

--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -7,11 +7,11 @@
   tasks:
     - set_fact:
         platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-      when: bool(build_multi_arch)
+      when: build_multi_arch|bool
 
     - set_fact:
         platforms: "linux/amd64"
-      when: not bool(build_multi_arch)
+      when: not (build_multi_arch|bool)
 
     - set_fact:
         collector_root: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"

--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -7,11 +7,11 @@
   tasks:
     - set_fact:
         platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-      when: build_multi_arch
+      when: bool(build_multi_arch)
 
     - set_fact:
         platforms: "linux/amd64"
-      when: not build_multi_arch
+      when: not bool(build_multi_arch)
 
     - set_fact:
         collector_root: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"

--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -3,9 +3,16 @@
   hosts: all
 
   environment:
-    PLATFORMS: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
 
   tasks:
+    - set_fact:
+        platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
+      when: build_multi_arch
+
+    - set_fact:
+        platforms: "linux/amd64"
+      when: not build_multi_arch
+
     - set_fact:
         collector_root: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
 
@@ -24,7 +31,7 @@
         #   - we can push the images and manifest in a single command. The make
         #     target can be used for local development and testing.
         docker buildx build --push \
-          --platform "${PLATFORMS}" \
+          --platform "{{ platforms }}" \
           -t '{{ test_image }}' \
           {{ collector_root }}/integration-tests
       register: build_result


### PR DESCRIPTION
## Description

This should speed up the "normal" PR builds substantially.
