### PR TITLE
Enable debug stdout callback in ansible when GHA is in debug mode

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -84,7 +84,7 @@ jobs:
           echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
           echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Create secrets.yml
+      - name: Create Ansible Vars (inc. secrets)
         run: |
           {
             echo "---"
@@ -94,6 +94,10 @@ jobs:
             echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
           } > ${{ github.workspace }}/ansible/secrets.yml
 
+          if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+            echo "ANSIBLE_STDOUT_CALLBACK=debug" >> "${GITHUB_ENV}"
+          fi
+
       - name: Build images
         if: |
           github.event_name == 'push' ||
@@ -102,6 +106,7 @@ jobs:
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
+
           ansible-playbook \
             --connection local \
             -i localhost, \

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -109,7 +109,7 @@ jobs:
           gsutil -m rsync -r "${GCP_BUCKET}/${DRIVER_VERSION}/" \
             "${CONTEXT_DRIVERS_DIR}"
 
-      - name: Create secrets.yml
+      - name: Create Ansible Vars (inc. secrets)
         run: |
           {
             echo "---"
@@ -118,6 +118,10 @@ jobs:
             echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
             echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
           } > ${{ github.workspace }}/ansible/secrets.yml
+
+          if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+            echo "ANSIBLE_STDOUT_CALLBACK=debug" >> "${GITHUB_ENV}"
+          fi
 
       # Ansible here is overkill, but GHA doesn't let me call a workflow from
       # a step, so... Overkill it is!

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -57,7 +57,7 @@ jobs:
             fi
           fi
 
-      - name: Create secrets.yml
+      - name: Create Ansible Vars (inc. secrets)
         run: |
           {
             echo "---"
@@ -66,6 +66,10 @@ jobs:
             echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
             echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
           } > ${{ github.workspace }}/ansible/secrets.yml
+
+          if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+            echo "ANSIBLE_STDOUT_CALLBACK=debug" >> "${GITHUB_ENV}"
+          fi
 
       - name: Build images
         if: |

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -34,13 +34,17 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Create secrets.yml
+      - name: Create Ansible Vars (inc. Secrets)
         run: |
           {
             echo "---"
             echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
             echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
           } > ${{ github.workspace }}/ansible/secrets.yml
+
+          if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+            echo "ANSIBLE_STDOUT_CALLBACK=debug" >> "${GITHUB_ENV}"
+          fi
 
       - name: Build images
         run: |

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -148,8 +148,13 @@ jobs:
               echo "REDHAT_PASSWORD=${{ secrets.REDHAT_PASSWORD }}"
             } >> "${GITHUB_ENV}"
           fi
-      #Added workaround for ssh connection issue with power vm from ubuntu machine.
-      #Changing mtu works in resolving the issue
+
+          if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+            echo "ANSIBLE_STDOUT_CALLBACK=debug" >> "${GITHUB_ENV}"
+          fi
+
+      # Workaround for ssh connection issue with power vm from ubuntu machine.
+      # Changing mtu works in resolving the issue
       - name: Set MTU for Power VMs
         if: ${{ contains(inputs.vm_type, 'ppc64le') }}
         run: sudo ifconfig eth0 mtu 1000 up


### PR DESCRIPTION
## Description

With the move to the selective callback in ansible, we sometimes lose some valuable information about certain error conditions. This PR will switch the callback to `debug` when we re-run the workflow with debug logging in GHA. 
