### PR TITLE
Build multiarch test images on schedule

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           ansible-galaxy install -r ansible/requirements.yml
 
-          BUILD_MULTI_ARCH="${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || github.event_name == 'push' }}"
+          BUILD_MULTI_ARCH="${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || github.event_name == 'push' || github.event_name == 'schedule' }}"
 
           # build_multi_arch passed in as json to ensure boolean type
           ansible-playbook \


### PR DESCRIPTION
## Description

Currently, images for integration tests on s390x are build only if requested via label or pushed. It turns out the scheduled CPaaS related workflow does neither of those, meaning it fails on integration tests. Extend current logic to build images when the github event is 'schedule'.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.