### PR TITLE
Make tests verbose about startup failures

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -30,6 +30,7 @@ COPY LICENSE-kernel-modules.txt /kernel-modules/LICENSE
 COPY container/libs/libsinsp-wrapper.so /usr/local/lib/
 COPY container/bin/collector /usr/local/bin/
 COPY container/bin/self-checks /usr/local/bin/self-checks
+COPY container/status-check.sh /usr/local/bin/status-check.sh
 
 RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && \
     ldconfig && \
@@ -37,6 +38,14 @@ RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && \
     chmod 700 bootstrap.sh
 
 EXPOSE 8080 9090
+
+HEALTHCHECK	\
+	# health checks within the first 5s are not counted as failure
+	--start-period=5s \
+	# perform health check every 5s
+	--interval=5s \
+	# the command uses /ready API
+	CMD /usr/local/bin/status-check.sh
 
 ENTRYPOINT ["/bootstrap.sh"]
 

--- a/collector/container/status-check.sh
+++ b/collector/container/status-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# /ready API will return the following formatted response:
+# {
+#    "collector" : {
+#       "drops" : 0,
+#       "events" : 9330070,
+#       "node" : "node.name",
+#       "preemptions" : 0
+#    },
+#    "status" : "ok"
+# }
+#
+# Take the status line, split it by ":" and trim spaces and quotes.
+STATUS=$(curl -s localhost:8080/ready | grep 'status' | awk -F ':' '{print $2}' | xargs)
+
+if [[ "${STATUS}" = "ok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/collector/container/status-check.sh
+++ b/collector/container/status-check.sh
@@ -12,7 +12,7 @@
 # }
 #
 # Take the status line, split it by ":" and trim spaces and quotes.
-STATUS=$(curl -s localhost:8080/ready | grep 'status' | awk -F ':' '{print $2}' | xargs)
+STATUS=$(curl -s localhost:8080/ready | grep 'status' | awk -F ':' '{print $2}' | tr -d '"' | tr -d ' ')
 
 if [[ "${STATUS}" = "ok" ]]; then
     exit 0

--- a/integration-tests/suites/benchmark.go
+++ b/integration-tests/suites/benchmark.go
@@ -81,7 +81,7 @@ func (b *BenchmarkTestSuiteBase) RunInitContainer() {
 	containerID, err := b.launchContainer("host-init", cmd...)
 	require.NoError(b.T(), err)
 
-	if finished, _ := b.waitForContainerToExit("host-init", containerID, 5*time.Second); !finished {
+	if finished, _ := b.waitForContainerToExit("host-init", containerID, 5*time.Second, 0); !finished {
 		logs, err := b.containerLogs("host-init")
 		if err == nil {
 			fmt.Println(logs)

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -23,7 +23,7 @@ func (s *ImageLabelJSONTestSuite) TestRunImageWithJSONLabel() {
 	containerID, err := s.launchContainer(name, image)
 	s.Require().NoError(err)
 
-	_, err = s.waitForContainerToExit(name, containerID, defaultWaitTickSeconds)
+	_, err = s.waitForContainerToExit(name, containerID, defaultWaitTickSeconds, 0)
 	s.Require().NoError(err)
 }
 

--- a/integration-tests/suites/mock_sensor/expect_proc.go
+++ b/integration-tests/suites/mock_sensor/expect_proc.go
@@ -18,7 +18,7 @@ func (s *MockSensor) ExpectProcessesN(t *testing.T, containerID string, timeout 
 }
 
 func (s *MockSensor) WaitProcessesN(containerID string, timeout time.Duration, n int) bool {
-	return len(s.waitProcessesN(func() {}, containerID, timeout, n)) == n
+	return len(s.waitProcessesN(func() {}, containerID, timeout, n)) >= n
 }
 
 func (s *MockSensor) ExpectProcesses(
@@ -101,7 +101,7 @@ func (s *MockSensor) ExpectLineages(t *testing.T, containerID string, timeout ti
 }
 
 func (s *MockSensor) waitProcessesN(timeoutFn func(), containerID string, timeout time.Duration, n int) []types.ProcessInfo {
-	if len(s.Processes(containerID)) == n {
+	if len(s.Processes(containerID)) >= n {
 		return s.Processes(containerID)
 	}
 
@@ -116,7 +116,7 @@ loop:
 				continue loop
 			}
 
-			if len(s.Processes(containerID)) == n {
+			if len(s.Processes(containerID)) >= n {
 				return s.Processes(containerID)
 			}
 		}

--- a/integration-tests/suites/perf_event_open.go
+++ b/integration-tests/suites/perf_event_open.go
@@ -30,7 +30,7 @@ func (s *PerfEventOpenTestSuite) TestReadingTracepoints() {
 	containerID, err := s.launchContainer("perf-event-open", "--privileged", image, "", "STDOUT")
 	s.Require().NoError(err)
 
-	if finished, _ := s.waitForContainerToExit("perf-event-open", containerID, 5*time.Second); finished {
+	if finished, _ := s.waitForContainerToExit("perf-event-open", containerID, 5*time.Second, 0); finished {
 		logs, err := s.containerLogs("perf-event-open")
 		if err != nil {
 			fmt.Println(logs)


### PR DESCRIPTION
## Description

In the past we've got situations when the CI integration tests reports were not extensive enough to clarify what's going on, and we were launching a full-blown debugging process just to find out that the probes were missing.

To make initialization issues more visible, make integration tests verbose about them:

* Introduce a HEALTHCHECK for the Collector docker image, based on the /ready Civet API. This command would be ignored on K8S, but we could use it on CI for containers filtering.

* Wait for Collector container to become healthy first before proceeding with the rest of tests. This will make it immediately clear if the test is failing due to missing probes.

* Make self-checks verification a hard failure. Currently, we wait for the self-checks, but do not report if they're missing. This change will make it clear if something is badly broken to the extent that we don't receive any events.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Local testing, but CI is sufficient.