### PR TITLE
Jv rox 21454 limit the afterglow period to 5 minutes

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -175,6 +175,15 @@ void CollectorConfig::HandleAfterglowEnvVars() {
     afterglow_period_micros_ = static_cast<int64_t>(atof(afterglow_period) * 1000000);
   }
 
+  int64_t max_afterglow_period_micros = 300000000;  // 5 minutes
+
+  if (afterglow_period_micros_ > max_afterglow_period_micros) {
+    CLOG(WARNING) << "User set afterglow period of " << afterglow_period_micros_ / 1000000
+                  << " is greater than the maximum allowed afterglow period of " << max_afterglow_period_micros / 1000000;
+    CLOG(WARNING) << "Setting the afterglow period to " << max_afterglow_period_micros / 1000000;
+    afterglow_period_micros_ = max_afterglow_period_micros;
+  }
+
   if (enable_afterglow_ && afterglow_period_micros_ > 0) {
     CLOG(INFO) << "Afterglow is enabled";
     return;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -175,7 +175,7 @@ void CollectorConfig::HandleAfterglowEnvVars() {
     afterglow_period_micros_ = static_cast<int64_t>(atof(afterglow_period) * 1000000);
   }
 
-  int64_t max_afterglow_period_micros = 300000000;  // 5 minutes
+  const int64_t max_afterglow_period_micros = 300000000;  // 5 minutes
 
   if (afterglow_period_micros_ > max_afterglow_period_micros) {
     CLOG(WARNING) << "User set afterglow period of " << afterglow_period_micros_ / 1000000

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -179,8 +179,8 @@ void CollectorConfig::HandleAfterglowEnvVars() {
 
   if (afterglow_period_micros_ > max_afterglow_period_micros) {
     CLOG(WARNING) << "User set afterglow period of " << afterglow_period_micros_ / 1000000
-                  << " is greater than the maximum allowed afterglow period of " << max_afterglow_period_micros / 1000000;
-    CLOG(WARNING) << "Setting the afterglow period to " << max_afterglow_period_micros / 1000000;
+                  << "s is greater than the maximum allowed afterglow period of " << max_afterglow_period_micros / 1000000 << "s";
+    CLOG(WARNING) << "Setting the afterglow period to " << max_afterglow_period_micros / 1000000 << "s";
     afterglow_period_micros_ = max_afterglow_period_micros;
   }
 


### PR DESCRIPTION
## Description

This makes it so that the afterglow period cannot be set to a value greater than five minutes. If the user tries to set the afterglow period to a value greater than five minutes, it is set to five minutes. The user is also warned of this fact.

There is a bug resulting from the fact that afterglow delays the reporting of closed connections, such that the associated service/deployment/pod may have been deleted. To fix this sensor must store information about entities for longer than the afterglow period. However, sensor does not know how long the afterglow period is. The temporary solution is for sensor to assume that the afterglow period is five minutes and to limit the afterglow period in collector to five minutes.

See below for the PR to have sensor remember entities after they are deleted https://github.com/stackrox/stackrox/pull/8782 

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Updated documentation accordingly~~

**Automated testing**
  ~~- [ ] Added unit tests~~
  ~~- [ ] Added integration tests~~
  ~~- [ ] Added regression tests~~

If any of these don't apply, please comment below.

## Testing Performed

Set the afterglow period to 400 seconds in one of the integration tests and ran it. The log had the following 
```
[WARNING 2023/12/18 23:05:19] (CollectorConfig.cpp:181) User set afterglow period of 400 is greater than the maximum allowed afterglow period of 300
[WARNING 2023/12/18 23:05:19] (CollectorConfig.cpp:183) Setting the afterglow period to 300
[INFO    2023/12/18 23:05:19] (CollectorConfig.cpp:188) Afterglow is enabled
```

When setting the afterglow period to less than five minutes the log had the following

```
[INFO    2023/12/18 23:19:40] (CollectorConfig.cpp:127) User configured collection-method=ebpf
[INFO    2023/12/18 23:19:40] (CollectorConfig.cpp:193) Afterglow is disabled
[DEBUG   2023/12/18 23:19:40] (HostInfo.h:102) Identified kernel release: '4.18.0-513.5.1.el8_9.x86_64'
```

