### PR TITLE
Configurable sinsp buffer

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -162,6 +162,7 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
 
   HandleAfterglowEnvVars();
   HandleConnectionStatsEnvVars();
+  HandleSinspEnvVars();
 
   host_config_ = ProcessHostHeuristics(*this);
 }
@@ -235,6 +236,31 @@ void CollectorConfig::HandleConnectionStatsEnvVars() {
       CLOG(INFO) << "Connection statistics window: " << connection_stats_window_;
     } catch (...) {
       CLOG(ERROR) << "Invalid window length value: '" << envvar << "'";
+    }
+  }
+}
+
+void CollectorConfig::HandleSinspEnvVars() {
+  const char* envvar;
+
+  sinsp_cpu_per_buffer_ = DEFAULT_CPU_FOR_EACH_BUFFER;
+  sinsp_buffer_size_ = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
+
+  if ((envvar = std::getenv("ROX_COLLECTOR_SINSP_CPU_PER_BUFFER")) != NULL) {
+    try {
+      sinsp_cpu_per_buffer_ = std::stoi(envvar);
+      CLOG(INFO) << "Sinsp cpu per buffer: " << sinsp_cpu_per_buffer_;
+    } catch (...) {
+      CLOG(ERROR) << "Invalid cpu per buffer value: '" << envvar << "'";
+    }
+  }
+
+  if ((envvar = std::getenv("ROX_COLLECTOR_SINSP_BUFFER_SIZE")) != NULL) {
+    try {
+      sinsp_buffer_size_ = std::stoi(envvar);
+      CLOG(INFO) << "Sinsp buffer size: " << sinsp_buffer_size_;
+    } catch (...) {
+      CLOG(ERROR) << "Invalid buffer size value: '" << envvar << "'";
     }
   }
 }

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -76,6 +76,8 @@ class CollectorConfig {
   const std::vector<double>& GetConnectionStatsQuantiles() const { return connection_stats_quantiles_; }
   double GetConnectionStatsError() const { return connection_stats_error_; }
   unsigned int GetConnectionStatsWindow() const { return connection_stats_window_; }
+  unsigned int GetSinspBufferSize() const { return sinsp_buffer_size_; }
+  unsigned int GetSinspCpuPerBuffer() const { return sinsp_cpu_per_buffer_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -105,10 +107,16 @@ class CollectorConfig {
   double connection_stats_error_;
   unsigned int connection_stats_window_;
 
+  // One ring buffer will be initialized for this many CPUs
+  unsigned int sinsp_cpu_per_buffer_;
+  // Size of one ring buffer, in bytes
+  unsigned int sinsp_buffer_size_;
+
   Json::Value tls_config_;
 
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
+  void HandleSinspEnvVars();
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -43,7 +43,9 @@ class KernelDriverEBPF : public IKernelDriver {
     std::unordered_set<ppm_sc_code> ppm_sc;
 
     try {
-      inspector.open_bpf(SysdigService::kProbePath, DEFAULT_DRIVER_BUFFER_BYTES_DIM, ppm_sc, tp_set);
+      inspector.open_bpf(SysdigService::kProbePath,
+                         config.GetSinspBufferSize(),
+                         ppm_sc, tp_set);
     } catch (const sinsp_exception& ex) {
       CLOG(WARNING) << ex.what();
       return false;
@@ -99,8 +101,8 @@ class KernelDriverCOREEBPF : public IKernelDriver {
     }
 
     try {
-      inspector.open_modern_bpf(DEFAULT_DRIVER_BUFFER_BYTES_DIM,
-                                DEFAULT_CPU_FOR_EACH_BUFFER,
+      inspector.open_modern_bpf(config.GetSinspBufferSize(),
+                                config.GetSinspCpuPerBuffer(),
                                 true, ppm_sc, tp_set);
     } catch (const sinsp_exception& ex) {
       if (config.CoReBPFHardfail()) {

--- a/docs/references.md
+++ b/docs/references.md
@@ -49,6 +49,14 @@ This is enabled by default.
   - `ROX_COLLECTOR_CONNECTION_STATS_WINDOW`: the length of the sliding time window
     in minutes. Default: `60`
 
+* `ROX_COLLECTOR_SINSP_CPU_PER_BUFFER`: Allows to control how many sinsp
+buffers are going to be allocated. The resulting number of buffers will be
+calculated as the overall number of CPU cores available divided by this
+value. The default value is 1, meaning one buffer for each CPU.
+
+* `ROX_COLLECTOR_SINSP_BUFFER_SIZE`: Specifies the size of a sinsp buffer in
+bytes. The default value is 16 MB.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -52,7 +52,9 @@ This is enabled by default.
 * `ROX_COLLECTOR_SINSP_CPU_PER_BUFFER`: Allows to control how many sinsp
 buffers are going to be allocated. The resulting number of buffers will be
 calculated as the overall number of CPU cores available divided by this
-value. The default value is 1, meaning one buffer for each CPU.
+value. The default value is 1, meaning one buffer for each CPU. The value 0 is
+special, it instructs sinsp to allocate only one buffer no matter how many CPUs
+are there. This parameter affects CO-RE BPF only.
 
 * `ROX_COLLECTOR_SINSP_BUFFER_SIZE`: Specifies the size of a sinsp buffer in
 bytes. The default value is 16 MB.


### PR DESCRIPTION
## Description

Make sinsp event buffer related parameters (how many buffers to allocate and of what size) configurable via Collector config. The default values are the same as before, but it makes memory utilization more flexible. Taking into account the difference between on-demand allocation for ebpf and right-away allocation for core_bpf, this can help to address situations, when users are unhappy about Collector memory consumption, e.g. one can lower it down significantly by reducing number of buffers or their size -- the trade-off being of course higher latencies due to congestion on buffers.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing Performed

Local testing.