### PR TITLE
Skip health check for CPaaS workflow

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -88,10 +88,19 @@ func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool, options *com
 		s.Require().NoError(err)
 	} else {
 		fmt.Println("No HealthCheck found, do not wait for collector to become healthy")
+
+		// No way to figure out when all the services up and running, so give
+		// Collector a bit of time to spin up GRPC connection.
+		time.Sleep(10 * time.Second)
 	}
 
-	// wait for self-check process to guarantee collector is started
-	selfCheckOk := s.Sensor().WaitProcessesN(s.Collector().ContainerID, 180*time.Second, 1)
+	// Self-check process is not going to be sent via GRPC, instead create at
+	// least one canary process to make sure everything is fine.
+	_, err = s.execContainer("collector", []string{"echo"})
+	s.Require().NoError(err)
+
+	// wait for the canary process to guarantee collector is started
+	selfCheckOk := s.Sensor().WaitProcessesN(s.Collector().ContainerID, 30*time.Second, 1)
 	s.Require().True(selfCheckOk)
 }
 

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -91,7 +91,7 @@ func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool, options *com
 	}
 
 	// wait for self-check process to guarantee collector is started
-	selfCheckOk := s.Sensor().WaitProcessesN(s.Collector().ContainerID, 30*time.Second, 1)
+	selfCheckOk := s.Sensor().WaitProcessesN(s.Collector().ContainerID, 180*time.Second, 1)
 	s.Require().True(selfCheckOk)
 }
 

--- a/integration-tests/suites/mock_sensor/expect_proc.go
+++ b/integration-tests/suites/mock_sensor/expect_proc.go
@@ -14,11 +14,11 @@ import (
 func (s *MockSensor) ExpectProcessesN(t *testing.T, containerID string, timeout time.Duration, n int) []types.ProcessInfo {
 	return s.waitProcessesN(func() {
 		assert.FailNowf(t, "timed out", "found %d processes (expected %d)", len(s.Processes(containerID)), n)
-	}, containerID, timeout, n)
+	}, containerID, timeout, n, 0, func() {})
 }
 
-func (s *MockSensor) WaitProcessesN(containerID string, timeout time.Duration, n int) bool {
-	return len(s.waitProcessesN(func() {}, containerID, timeout, n)) >= n
+func (s *MockSensor) WaitProcessesN(containerID string, timeout time.Duration, n int, tickFn func()) bool {
+	return len(s.waitProcessesN(func() {}, containerID, timeout, n, 0, tickFn)) >= n
 }
 
 func (s *MockSensor) ExpectProcesses(
@@ -100,14 +100,37 @@ func (s *MockSensor) ExpectLineages(t *testing.T, containerID string, timeout ti
 
 }
 
-func (s *MockSensor) waitProcessesN(timeoutFn func(), containerID string, timeout time.Duration, n int) []types.ProcessInfo {
+// Wait for expected number of processes to show up in a specified container.
+//   - timeoutFn: will be invoked after the timeout expiration
+//   - containerID: the target container for searching processes
+//   - timeout: maximum waiting time
+//   - n: expected number of processes
+//   - tickSeconds: how often to wake up within the timeout time, default is 1s
+//   - tickFn: what to do when ticking, could be used to trigger expected number
+//     of processes
+func (s *MockSensor) waitProcessesN(
+	timeoutFn func(),
+	containerID string,
+	timeout time.Duration,
+	n int,
+	tickSeconds time.Duration,
+	tickFn func()) []types.ProcessInfo {
+
 	if len(s.Processes(containerID)) >= n {
 		return s.Processes(containerID)
 	}
 
+	if tickSeconds == 0 {
+		tickSeconds = 1 * time.Second
+	}
+
+	tick := time.Tick(tickSeconds)
+
 loop:
 	for {
 		select {
+		case <-tick:
+			tickFn()
 		case <-time.After(timeout):
 			timeoutFn()
 			return make([]types.ProcessInfo, 0)


### PR DESCRIPTION
## Description

Currently, we use health check to verify Collector has started properly, but not all the pipelines have the health check enabled in the image. It's fine, because we want to use it only for testing, so make the integration tests smarter to handle situations where there is no health check in the image.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Local testing. CI is sufficient.