### PR TITLE
Fixes duplicate s390x builds on master

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Build images
         if: |
-          github.event_name == 'push' ||
+          (github.event_name == 'push' && matrix.arch != 's390x') ||
           matrix.arch == 'amd64' ||
           (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
         timeout-minutes: 480
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build s390x images
         if: |
-          github.event_name == 'push' ||
+          (github.event_name == 'push' && matrix.arch == 's390x') ||
           (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
         timeout-minutes: 480
         run: |

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build images
         if: |
-          github.event_name == 'push' ||
+          (github.event_name == 'push' && matrix.arch != 's390x') ||
           matrix.arch == 'amd64' ||
           (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
         timeout-minutes: 480
@@ -130,7 +130,7 @@ jobs:
 
       - name: Build s390x image
         if: |
-          github.event_name == 'push' ||
+          (github.event_name == 'push' && matrix.arch == 's390x') ||
           (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
         timeout-minutes: 480
         run: |


### PR DESCRIPTION
## Description 

Fixes a slight bug in the if statements for builder and slim image builds, which were running the s390x builds twice (once in qemu, once natively) but only on master.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Can only rely on CI for this
