### PR TITLE
Make test image pre-pulling more robust

### DIFF
--- a/ansible/roles/run-test-target/tasks/main.yml
+++ b/ansible/roles/run-test-target/tasks/main.yml
@@ -19,7 +19,7 @@
   # which is quite significant for a specific test suite
   # (i.e. when testing during development) but is only
   # minor when running on CI
-  when: collector_test == 'ci-integration-tests'
+  when: lookup('env', 'COLLECTOR_PRE_PULL_IMAGES', default='false') | bool
 
 #
 # Separation of collection method is only possible with a separate

--- a/ansible/roles/run-test-target/tasks/main.yml
+++ b/ansible/roles/run-test-target/tasks/main.yml
@@ -19,7 +19,7 @@
   # which is quite significant for a specific test suite
   # (i.e. when testing during development) but is only
   # minor when running on CI
-  when: lookup('env', 'COLLECTOR_PRE_PULL_IMAGES', default='false') | bool
+  when: collector_test == 'ci-integration-tests'
 
 #
 # Separation of collection method is only possible with a separate

--- a/ansible/roles/run-test-target/tasks/pull-images.yml
+++ b/ansible/roles/run-test-target/tasks/pull-images.yml
@@ -1,5 +1,10 @@
 ---
 
+# Most of this is marked ignore_errors: true, because this is a best endeavors
+# attempt to pull the tests images. In the vast majority of cases, it will work
+# but can be flaky on some platforms. If this fails, the tests will still
+# attempt to pull the missing images.
+
 - name: Load image info
   set_fact:
     images: "{{ lookup('file', collector_root + '/integration-tests/images.yml') | from_yaml }}"
@@ -13,6 +18,7 @@
   async: 300
   poll: 0
   register: qa_result
+  ignore_errors: true
 
 - name: Pull non-QA images
   command: "{{ 'sudo' if runtime_as_root else '' }} {{ runtime_command }} pull {{ item.value }}"
@@ -21,6 +27,7 @@
   async: 300
   poll: 0
   register: non_qa_result
+  ignore_errors: true
 
 - name: Await QA
   async_status:
@@ -29,6 +36,7 @@
   register: await_qa
   until: await_qa.finished
   retries: 30
+  ignore_errors: true
 
 - name: Await non-QA
   async_status:
@@ -37,3 +45,4 @@
   register: await_non_qa
   until: await_non_qa.finished
   retries: 30
+  ignore_errors: true


### PR DESCRIPTION
## Description

This PR makes it so that errors when pre-pulling images are ignored. This is to prevent some flakes on certain platforms (currently RHCOS is experiencing issues.) When pre-pulling fails, the tests will still attempt to pull missing images, so tests should be largely unaffected.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested locally.
