### PR TITLE
Fixes garden-linux eBPF block

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -27,7 +27,7 @@ excluded_pairs:
   - [ 'sles-15-arm64', 'ebpf' ]
   - [ 'fedora-coreos-stable-arm64', 'ebpf' ]
   # eBPF on Garden Linux is not supported.
-  - [ 'garden-linux', 'ebpf' ]
+  - [ "{{ lookup('file', 'group_vars/gardenlinux-image.txt') }}", 'ebpf' ]
 
   - [ 'p', 'ebpf' ]
 


### PR DESCRIPTION
## Description

The garden linux VMs are created by image, so the image name is necessary to block the testing.
