### PR TITLE
Ensure driver archive is created in the right directory

### DIFF
--- a/kernel-modules/build/prepare-src
+++ b/kernel-modules/build/prepare-src
@@ -129,4 +129,5 @@ else
     cp "${LEGACY_DIR}/kernel-modules/probe/collector_probe.h" "${DRIVER_SCRATCH}/driver/collector-probe/collector_probe.h"
 fi
 
+cd "${DRIVER_SCRATCH}/driver"
 archive_files


### PR DESCRIPTION
## Description

Some code moved around in prepare-src which meant that the source archive is sometimes created from the wrong directory. This simply fixes that.
