### PR TITLE
[rhtap] Remove libsinsp

### DIFF
--- a/collector/container/rhtap-slim.Dockerfile
+++ b/collector/container/rhtap-slim.Dockerfile
@@ -136,7 +136,6 @@ COPY --from=builder /THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
 COPY --from=builder /collector/NOTICE-sysdig.txt /THIRD_PARTY_NOTICES/sysdig
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/collector /usr/local/bin/
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
-COPY --from=builder ${CMAKE_BUILD_DIR}/collector/EXCLUDE_FROM_DEFAULT_BUILD/libsinsp/libsinsp-wrapper.so /usr/local/lib/
 
 RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && \
     ldconfig && \


### PR DESCRIPTION
## Description

After switching to vanilla Falco libsinsp is build statically. Do not copy the shared libsinsp into the final image.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.