### PR TITLE
fix: dependency installation in collector-slim upstream build requires explicit -y

### DIFF
--- a/collector/container/rhel/install.sh
+++ b/collector/container/rhel/install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-microdnf upgrade --nobest
-microdnf install kmod findutils elfutils-libelf
+# UBI 9 requires confirmation with -y flag.
+microdnf upgrade -y --nobest
+microdnf install -y kmod findutils elfutils-libelf
 
 microdnf clean all
 rpm --query --all 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'findutils' | xargs -t rpm -e --nodeps


### PR DESCRIPTION
## Description

https://redhat-internal.slack.com/archives/CFMQ5C2TT/p1705417422117649

This was changed in #1407 in the assumption that `-y` is superfluous (https://github.com/stackrox/collector/pull/1407#discussion_r1416205667), which is true only for UBI8 images.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
