### PR TITLE
Only create s390x build VMs when theyre needed

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -98,7 +98,9 @@ jobs:
           job-tag: builder
 
       - name: Create Build VMs
-        if: matrix.arch == 's390x'
+        if: |
+          matrix.arch == 's390x' &&
+          (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
 

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -73,7 +73,9 @@ jobs:
           job-tag: builder
 
       - name: Create Build VMs
-        if: matrix.arch == 's390x'
+        if: |
+          matrix.arch == 's390x' &&
+          (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
 


### PR DESCRIPTION
## Description

s390x build VMs were being created always, even when multi-arch builds were not requested as part of a PR. This simple makes sure that VM creation abides by the labels.