### PR TITLE
Optional local builder access through SSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ NPROCS ?= $(shell nproc)
 
 MOD_VER_FILE=$(CURDIR)/kernel-modules/kobuild-tmp/MODULE_VERSION.txt
 
-LOCAL_SSH_PORT ?= 2222
 DEV_SSH_SERVER_KEY ?= $(CURDIR)/.collector_dev_ssh_host_ed25519_key
 BUILD_BUILDER_IMAGE ?= false
 
@@ -110,9 +109,10 @@ endif
 
 .PHONY: start-builder
 start-builder: builder teardown-builder
-	docker run -id --entrypoint /bin/sh \
+	docker run -d \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		-v $(CURDIR):$(CURDIR) \
+		${LOCAL_SSH_PORT+-p ${LOCAL_SSH_PORT}:22} \
 		-w $(CURDIR) \
 		--cap-add sys_ptrace \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ start-builder: builder teardown-builder
 	docker run -d \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		-v $(CURDIR):$(CURDIR) \
-		${LOCAL_SSH_PORT+-p ${LOCAL_SSH_PORT}:22} \
+		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\
 		-w $(CURDIR) \
 		--cap-add sys_ptrace \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -61,10 +61,9 @@ RUN ssh-keygen -A \
     echo 'LogLevel DEBUG2'; \
     echo 'PermitRootLogin yes'; \
     echo 'PasswordAuthentication yes'; \
-    echo 'HostKey /etc/sshkeys/ssh_host_ed25519_key'; \
     echo 'HostKeyAlgorithms ssh-ed25519'; \
     echo 'Subsystem sftp /usr/libexec/openssh/sftp-server'; \
-  ) > /etc/ssh/sshd_config_remote_development \
+  ) > /etc/ssh/sshd_config \
   && mkdir /run/sshd
 
 # Add remote development user
@@ -74,4 +73,4 @@ RUN useradd -m remoteuser \
 # Create directory to copy collector source into builder container
 RUN mkdir /src && chmod a+rwx /src
 
-CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_remote_development"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
## Description

Make it easier to create a builder container that can be connected locally through SSH.

- Builder runs sshd as entrypoint.
- The port is exposed only when LOCAL_SSH_PORT is set.

This is intended to ease the use of the builder in dev environments where SSH is used
to connect to the builder container.
