### PR TITLE
Jv ebpf deprecation cleanup

### DIFF
--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -141,7 +141,8 @@ int main(int argc, char** argv) {
     CLOG(FATAL) << "Error parsing arguments";
   }
 
-  CollectorConfig config(args);
+  CollectorConfig config;
+  config.InitCollectorConfig(args);
 
   setCoreDumpLimit(config.IsCoreDumpEnabled());
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -51,11 +51,14 @@ constexpr bool CollectorConfig::kEnableProcessesListeningOnPorts;
 const UnorderedSet<L4ProtoPortPair> CollectorConfig::kIgnoredL4ProtoPortPairs = {{L4Proto::UDP, 9}};
 ;
 
-CollectorConfig::CollectorConfig(CollectorArgs* args) {
+CollectorConfig::CollectorConfig() {
   // Set default configuration values
   scrape_interval_ = kScrapeInterval;
   turn_off_scrape_ = kTurnOffScrape;
   collection_method_ = kCollectionMethod;
+}
+
+void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
   enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
   import_users_ = set_import_users.value();
   collect_connection_status_ = collect_connection_status.value();

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -130,8 +130,8 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
       } else if (cm == "core_bpf") {
         collection_method_ = CollectionMethod::CORE_BPF;
       } else {
-        CLOG(WARNING) << "Invalid collection-method (" << cm << "), using eBPF";
-        collection_method_ = CollectionMethod::EBPF;
+        CLOG(WARNING) << "Invalid collection-method (" << cm << "), using CO-RE BPF";
+        collection_method_ = CollectionMethod::CORE_BPF;
       }
     }
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -32,8 +32,6 @@ BoolEnvVar set_enable_core_dump("ENABLE_CORE_DUMP", false);
 // If true, add originator process information in NetworkEndpoint
 BoolEnvVar set_processes_listening_on_ports("ROX_PROCESSES_LISTENING_ON_PORT", CollectorConfig::kEnableProcessesListeningOnPorts);
 
-BoolEnvVar core_bpf_hardfail("ROX_COLLECTOR_CORE_BPF_HARDFAIL", false);
-
 BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
@@ -59,7 +57,6 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
   turn_off_scrape_ = kTurnOffScrape;
   collection_method_ = kCollectionMethod;
   enable_processes_listening_on_ports_ = set_processes_listening_on_ports.value();
-  core_bpf_hardfail_ = core_bpf_hardfail.value();
   import_users_ = set_import_users.value();
   collect_connection_status_ = collect_connection_status.value();
   enable_external_ips_ = enable_external_ips.value();

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -48,8 +48,8 @@ class CollectorConfig {
   static const UnorderedSet<L4ProtoPortPair> kIgnoredL4ProtoPortPairs;
   static constexpr bool kEnableProcessesListeningOnPorts = true;
 
-  CollectorConfig() = delete;
-  CollectorConfig(CollectorArgs* collectorArgs);
+  CollectorConfig();
+  void InitCollectorConfig(CollectorArgs* collectorArgs);
 
   std::string asString() const;
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -20,7 +20,7 @@ class CollectorConfig {
  public:
   static constexpr bool kTurnOffScrape = false;
   static constexpr int kScrapeInterval = 30;
-  static constexpr CollectionMethod kCollectionMethod = CollectionMethod::EBPF;
+  static constexpr CollectionMethod kCollectionMethod = CollectionMethod::CORE_BPF;
   static constexpr const char* kSyscalls[] = {
       "accept",
       "accept4",

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -69,7 +69,6 @@ class CollectorConfig {
   bool IsCoreDumpEnabled() const;
   Json::Value TLSConfiguration() const { return tls_config_; }
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
-  bool CoReBPFHardfail() const { return core_bpf_hardfail_; }
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
   bool EnableExternalIPs() const { return enable_external_ips_; }
@@ -99,7 +98,6 @@ class CollectorConfig {
   bool enable_afterglow_ = true;
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
-  bool core_bpf_hardfail_;
   bool import_users_;
   bool collect_connection_status_;
   bool enable_external_ips_;

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -95,12 +95,7 @@ class KernelDriverCOREEBPF : public IKernelDriver {
                                 config.GetSinspCpuPerBuffer(),
                                 true, ppm_sc);
     } catch (const sinsp_exception& ex) {
-      if (config.CoReBPFHardfail()) {
-        throw ex;
-      } else {
-        CLOG(WARNING) << ex.what();
-        return false;
-      }
+      throw ex;
     }
 
     return true;

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -52,33 +52,18 @@ class MockHostInfoHeuristics : public HostInfo {
   MOCK_METHOD0(GetDistro, std::string&());
 };
 
-// Note that in every test below, ProcessHostHeuristics will be called first
-// with creation of a config mock, which is somewhat annoying, but doesn't
-// cause any serious issues.
-class MockCollectorConfig : public CollectorConfig {
- public:
-  MockCollectorConfig(CollectorArgs* collectorArgs)
-      : CollectorConfig(collectorArgs){};
-
-  MOCK_CONST_METHOD0(UseEbpf, bool());
-
-  void SetCollectionMethod(CollectionMethod cm) {
-    if (host_config_.HasCollectionMethod()) {
-      host_config_.SetCollectionMethod(cm);
-    }
-    collection_method_ = cm;
-  }
-};
-
 TEST(HostHeuristicsTest, TestS390XRHEL84) {
   MockS390xHeuristics s390xHeuristics;
   MockHostInfoHeuristics host;
   KernelVersion version = KernelVersion("4.18.0-305.88.1.el8_4.s390x", "", "s390x");
   CollectorArgs* args = CollectorArgs::getInstance();
-  MockCollectorConfig config(args);
+  int argc = 3;
+  const char* argv[] = {"collector", "--collection-method", "ebpf"};
+  int exitCode = 0;
+  args->parse(argc, const_cast<char**>(argv), exitCode);
+  CollectorConfig config(args);
   HostConfig hconfig;
 
-  config.SetCollectionMethod(CollectionMethod::EBPF);
   hconfig.SetCollectionMethod(CollectionMethod::EBPF);
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
 
@@ -92,10 +77,13 @@ TEST(HostHeuristicsTest, TestARM64Heuristic) {
   MockHostInfoHeuristics host;
   KernelVersion version = KernelVersion("6.5.5-200.fc38.aarch64", "", "aarch64");
   CollectorArgs* args = CollectorArgs::getInstance();
-  MockCollectorConfig config(args);
+  int argc = 3;
+  const char* argv[] = {"collector", "--collection-method", "ebpf"};
+  int exitCode = 0;
+  args->parse(argc, const_cast<char**>(argv), exitCode);
+  CollectorConfig config(args);
   HostConfig hconfig;
 
-  config.SetCollectionMethod(CollectionMethod::EBPF);
   hconfig.SetCollectionMethod(CollectionMethod::EBPF);
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
 

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -52,18 +52,27 @@ class MockHostInfoHeuristics : public HostInfo {
   MOCK_METHOD0(GetDistro, std::string&());
 };
 
+class MockCollectorConfig : public CollectorConfig {
+ public:
+  MockCollectorConfig()
+      : CollectorConfig(){};
+
+  void SetCollectionMethod(CollectionMethod cm) {
+    if (host_config_.HasCollectionMethod()) {
+      host_config_.SetCollectionMethod(cm);
+    }
+    collection_method_ = cm;
+  }
+};
+
 TEST(HostHeuristicsTest, TestS390XRHEL84) {
   MockS390xHeuristics s390xHeuristics;
   MockHostInfoHeuristics host;
   KernelVersion version = KernelVersion("4.18.0-305.88.1.el8_4.s390x", "", "s390x");
-  CollectorArgs* args = CollectorArgs::getInstance();
-  int argc = 3;
-  const char* argv[] = {"collector", "--collection-method", "ebpf"};
-  int exitCode = 0;
-  args->parse(argc, const_cast<char**>(argv), exitCode);
-  CollectorConfig config(args);
+  MockCollectorConfig config;
   HostConfig hconfig;
 
+  config.SetCollectionMethod(CollectionMethod::EBPF);
   hconfig.SetCollectionMethod(CollectionMethod::EBPF);
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
 
@@ -76,14 +85,10 @@ TEST(HostHeuristicsTest, TestARM64Heuristic) {
   MockARM64Heuristics heuristic;
   MockHostInfoHeuristics host;
   KernelVersion version = KernelVersion("6.5.5-200.fc38.aarch64", "", "aarch64");
-  CollectorArgs* args = CollectorArgs::getInstance();
-  int argc = 3;
-  const char* argv[] = {"collector", "--collection-method", "ebpf"};
-  int exitCode = 0;
-  args->parse(argc, const_cast<char**>(argv), exitCode);
-  CollectorConfig config(args);
+  MockCollectorConfig config;
   HostConfig hconfig;
 
+  config.SetCollectionMethod(CollectionMethod::EBPF);
   hconfig.SetCollectionMethod(CollectionMethod::EBPF);
   EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -2,7 +2,7 @@
 
 ## Data gathering methods
 ### Kernel drivers
-Collector leverages eBPF probes and kernel modules for gathering data directly
+Collector leverages a CO-RE eBPF probe and eBPF probes and kernel modules for gathering data directly
 from the kernel.
 
 #### Driver candidates

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -2,16 +2,16 @@
 
 ## Data gathering methods
 ### Kernel drivers
-Collector leverages a CO-RE eBPF probe and eBPF probes and kernel modules for gathering data directly
+Collector leverages a CO-RE eBPF probe and eBPF probes for gathering data directly
 from the kernel.
 
 #### Driver candidates
-When collector starts up, it will automatically try to download a driver
-compatible with the running kernel. For most distributions this will be
-determined with the `uname -r` command, but some special cases exist. In such
-cases, collector will create a set of potential candidates and try to find them
-sequentially, first looking for them in the filesystem and then trying to
-download them.
+When collector starts up, if the COLLECTION_METHOD is eBPF, it will
+automatically try to download a driver compatible with the running kernel.
+For most distributions this will be determined with the `uname -r` command,
+but some special cases exist. In such cases, collector will create a set of
+potential candidates and try to find them sequentially, first looking for
+them in the filesystem and then trying to download them.
 
 In cases where the auto-generated list of candidates are failing to create a
 working option, the `KERNEL_CANDIDATES` environment variable can be used to

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -56,7 +56,7 @@ services:
     environment:
       - GRPC_SERVER=localhost:9999
       - COLLECTOR_CONFIG={"logLevel":"debug","turnOffScrape":true,"scrapeInterval":2}
-      - COLLECTION_METHOD=ebpf
+      - COLLECTION_METHOD=core-bpf
       - MODULE_DOWNLOAD_BASE_URL=https://collector-modules.stackrox.io/612dd2ee06b660e728292de9393e18c81a88f347ec52a39207c5166b5302b656
       - MODULE_VERSION=b6745d795b8497aaf387843dc8aa07463c944d3ad67288389b754daaebea4b62
       - COLLECTOR_HOST_ROOT=/host

--- a/docs/references.md
+++ b/docs/references.md
@@ -77,7 +77,7 @@ seconds. The default value is 30 seconds.
 ### Other arguments
 
 * `--collection-method`: Which technology to use for data gathering. Either
-"ebpf" or "kernel_module".
+"ebpf" or "core-bpf".
 
 * `--grpc-server`: GRPC server endpoint for Collector to communicate, in the
 form "host:port".

--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -46,11 +46,10 @@ func NewCollectorManager(e Executor, name string) *CollectorManager {
 	}
 
 	env := map[string]string{
-		"GRPC_SERVER":                     "localhost:9999",
-		"COLLECTION_METHOD":               collectionMethod,
-		"COLLECTOR_PRE_ARGUMENTS":         collectorOptions.PreArguments,
-		"ENABLE_CORE_DUMP":                "false",
-		"ROX_COLLECTOR_CORE_BPF_HARDFAIL": "true",
+		"GRPC_SERVER":             "localhost:9999",
+		"COLLECTION_METHOD":       collectionMethod,
+		"COLLECTOR_PRE_ARGUMENTS": collectorOptions.PreArguments,
+		"ENABLE_CORE_DUMP":        "false",
 	}
 
 	if !collectorOptions.Offline {

--- a/integration-tests/suites/config/config.go
+++ b/integration-tests/suites/config/config.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	qa_tag            = ReadEnvVar(envQATag)
-	collection_method = ReadEnvVarWithDefault(envCollectionMethod, CollectionMethodEBPF)
+	collection_method = ReadEnvVarWithDefault(envCollectionMethod, CollectionMethodCoreBPF)
 	stop_timeout      = ReadEnvVarWithDefault(envStopTimeout, defaultStopTimeoutSeconds)
 
 	image_store       *ImageStore


### PR DESCRIPTION
## Description

Sets the default collection method to CORE_BPF for collector and the integration tests. Fixed unit tests that broke as a result of changing the default collection method to CORE_BPF. Also removed the hardfail config option for CORE_BPF. The code now behaves as though it is always true.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Ran integration tests locally
~~- [ ] Updated documentation accordingly~~

**Automated testing**
  ~~- [ ] Added unit tests~~
  ~~- [ ] Added integration tests~~
  ~~- [ ] Added regression tests~~

This changes the default collection method so testing it is not needed.

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
