### PR TITLE
Bump health check timeout

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -84,7 +84,7 @@ func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool, options *com
 		_, err := s.waitForContainerToBecomeHealthy(
 			"collector",
 			s.Collector().ContainerID,
-			defaultWaitTickSeconds, 1*time.Minute)
+			defaultWaitTickSeconds, 5*time.Minute)
 		s.Require().NoError(err)
 	} else {
 		fmt.Println("No HealthCheck found, do not wait for collector to become healthy")


### PR DESCRIPTION
## Description

It seems that waiting for Collector to become healthy for 1 minute is not stable enough, so bump the timeout.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.