### PR TITLE
ROX-21403: Option to ignore a set of networks.

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -164,10 +164,10 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
 
                   if (net) {
                     CLOG(INFO) << "Ignore network : " << *net;
+                    ignored_networks.emplace_back(std::move(*net));
                   } else {
                     CLOG(ERROR) << "Invalid network in ROX_IGNORE_NETWORKS : " << str;
                   }
-                  ignored_networks.emplace_back(std::move(*net));
                 });
 
   if (set_curl_verbose) {

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -162,7 +162,9 @@ CollectorConfig::CollectorConfig(CollectorArgs* args) {
 
                   std::optional<IPNet> net = IPNet::parse(str);
 
-                  if (!net) {
+                  if (net) {
+                    CLOG(INFO) << "Ignore network : " << *net;
+                  } else {
                     CLOG(ERROR) << "Invalid network in ROX_IGNORE_NETWORKS : " << str;
                   }
                   ignored_networks.emplace_back(std::move(*net));
@@ -195,9 +197,9 @@ void CollectorConfig::HandleAfterglowEnvVars() {
   const int64_t max_afterglow_period_micros = 300000000;  // 5 minutes
 
   if (afterglow_period_micros_ > max_afterglow_period_micros) {
-    CLOG(WARNING) << "User set afterglow period of " << afterglow_period_micros_ / 1000000
-                  << "s is greater than the maximum allowed afterglow period of " << max_afterglow_period_micros / 1000000 << "s";
-    CLOG(WARNING) << "Setting the afterglow period to " << max_afterglow_period_micros / 1000000 << "s";
+    CLOG(ERROR) << "User set afterglow period of " << afterglow_period_micros_ / 1000000
+                << "s is greater than the maximum allowed afterglow period of " << max_afterglow_period_micros / 1000000 << "s";
+    CLOG(ERROR) << "Setting the afterglow period to " << max_afterglow_period_micros / 1000000 << "s";
     afterglow_period_micros_ = max_afterglow_period_micros;
   }
 
@@ -212,9 +214,9 @@ void CollectorConfig::HandleAfterglowEnvVars() {
   }
 
   if (afterglow_period_micros_ < 0) {
-    CLOG(WARNING) << "Invalid afterglow period " << afterglow_period_micros_ / 1000000 << ". ROX_AFTERGLOW_PERIOD must be positive.";
+    CLOG(ERROR) << "Invalid afterglow period " << afterglow_period_micros_ / 1000000 << ". ROX_AFTERGLOW_PERIOD must be positive.";
   } else {
-    CLOG(WARNING) << "Afterglow period set to 0";
+    CLOG(ERROR) << "Afterglow period set to 0";
   }
 
   enable_afterglow_ = false;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -64,6 +64,7 @@ class CollectorConfig {
   std::string LogLevel() const;
   bool DisableNetworkFlows() const { return disable_network_flows_; }
   const UnorderedSet<L4ProtoPortPair>& IgnoredL4ProtoPortPairs() const { return ignored_l4proto_port_pairs_; }
+  const std::vector<IPNet>& IgnoredNetworks() const { return ignored_networks_; }
   bool CurlVerbose() const { return curl_verbose_; }
   bool EnableAfterglow() const { return enable_afterglow_; }
   bool IsCoreDumpEnabled() const;
@@ -92,6 +93,7 @@ class CollectorConfig {
   bool disable_network_flows_ = false;
   bool scrape_listen_endpoints_ = false;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
+  std::vector<IPNet> ignored_networks_;
   bool curl_verbose_ = false;
 
   HostConfig host_config_;

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -81,6 +81,7 @@ void CollectorService::RunForever() {
     conn_tracker = std::make_shared<ConnectionTracker>();
     UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
     conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
+    conn_tracker->UpdateIgnoredNetworks(config_.IgnoredNetworks());
     conn_tracker->EnableExternalIPs(config_.EnableExternalIPs());
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -209,7 +209,7 @@ ConnMap ConnectionTracker::FetchConnState(bool normalize, bool clear_inactive) {
   size_t state_size;
   WITH_LOCK(mutex_) {
     state_size = conn_state_.size();
-    if (HasConnectionStateFilters()) {
+    if (HasConnectionFilters()) {
       if (normalize) {
         cm = FetchState(
             &conn_state_, clear_inactive,
@@ -239,7 +239,7 @@ AdvertisedEndpointMap ConnectionTracker::FetchEndpointState(bool normalize, bool
   size_t state_size;
   WITH_LOCK(mutex_) {
     state_size = conn_state_.size();
-    if (HasConnectionStateFilters()) {
+    if (HasConnectionFilters()) {
       if (normalize) {
         cem = FetchState<ContainerEndpoint, std::function<ContainerEndpoint(const ContainerEndpoint&)>, std::function<bool(const ContainerEndpoint&)>, AdvertisedEndpointEquality>(
             &endpoint_state_, clear_inactive,
@@ -321,6 +321,12 @@ void ConnectionTracker::UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPa
         CLOG(DEBUG) << proto_port_pair.first << "/" << proto_port_pair.second;
       }
     }
+  }
+}
+
+void ConnectionTracker::UpdateIgnoredNetworks(const std::vector<IPNet>& network_list) {
+  WITH_LOCK(mutex_) {
+    ignored_networks_ = NRadixTree(network_list);
   }
 }
 

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -26,7 +26,7 @@ class EnvVar {
   const T& value() const {
     std::call_once(init_once_, [this]() {
       const char* env_val = std::getenv(env_var_name_);
-      if (!env_val || !*env_val) {
+      if (!env_val) {
         return;
       }
       if (!ParseT()(&val_, env_val)) {
@@ -50,6 +50,9 @@ namespace internal {
 
 struct ParseBool {
   bool operator()(bool* out, std::string str_val) const {
+    if (str_val.empty()) {
+      return false;
+    }
     std::transform(str_val.begin(), str_val.end(), str_val.begin(), [](char c) -> char {
       return static_cast<char>(std::tolower(c));
     });

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "Logging.h"
+#include "Utility.h"
 
 namespace collector {
 
@@ -57,9 +58,17 @@ struct ParseBool {
   }
 };
 
+struct ParseStringList {
+  bool operator()(std::vector<std::string>* out, std::string str_val) {
+    *out = SplitStringView(std::string_view(str_val), ',');
+    return true;
+  }
+};
+
 }  // namespace internal
 
 using BoolEnvVar = EnvVar<bool, internal::ParseBool>;
+using StringListEnvVar = EnvVar<std::vector<std::string>, internal::ParseStringList>;
 
 }  // namespace collector
 

--- a/collector/lib/NRadix.cpp
+++ b/collector/lib/NRadix.cpp
@@ -229,6 +229,10 @@ bool isAnyIPNetSubsetUtil(Address::Family family, const nRadixNode* n1, const nR
          isAnyIPNetSubsetUtil(family, nullptr, n2->right_, containing_net, contained_net);
 }
 
+bool NRadixTree::IsEmpty() const {
+  return root_->left_ == nullptr && root_->right_ == nullptr && root_->value_ == nullptr;
+}
+
 bool NRadixTree::IsAnyIPNetSubset(const NRadixTree& other) const {
   return this->IsAnyIPNetSubset(Address::Family::UNKNOWN, other);
 }

--- a/collector/lib/NRadix.h
+++ b/collector/lib/NRadix.h
@@ -111,6 +111,8 @@ class NRadixTree {
   IPNet Find(const Address& addr) const;
   // Returns a vector of all the stored networks.
   std::vector<IPNet> GetAll() const;
+  // Tells whether the RadixTree contains no network.
+  bool IsEmpty() const;
   // Determines whether any network in `other` is fully contained by any network in this tree.
   bool IsAnyIPNetSubset(const NRadixTree& other) const;
   // Determines whether any network in `other` is fully contained by any network in this tree, for a given family.

--- a/collector/lib/NRadix.h
+++ b/collector/lib/NRadix.h
@@ -80,7 +80,6 @@ class NRadixTree {
       auto inserted = this->Insert(network);
       if (!inserted) {
         CLOG(ERROR) << "Failed to insert CIDR " << network << " in network tree";
-        delete root_;
       }
     }
   }

--- a/collector/lib/NetworkConnection.cpp
+++ b/collector/lib/NetworkConnection.cpp
@@ -112,4 +112,27 @@ std::optional<Address> Address::parse(const std::string& address_string) {
   return std::nullopt;
 }
 
+std::optional<IPNet> IPNet::parse(const std::string& ipnet_string) {
+  std::string_view address_string = ipnet_string;
+  unsigned int prefix_length = 0;
+
+  auto slash = address_string.find("/");
+
+  if (slash != std::string_view::npos) {
+    try {
+      prefix_length = std::stol(std::string(address_string.substr(slash + 1)));
+    } catch (...) {
+      return std::nullopt;
+    }
+    address_string.remove_suffix(address_string.size() - slash);
+  }
+
+  std::optional<Address> address = Address::parse(std::string(address_string));
+  if (!address) {
+    return std::nullopt;
+  }
+
+  return IPNet(address.value(), prefix_length, prefix_length != 0);
+}
+
 }  // namespace collector

--- a/collector/lib/NetworkConnection.cpp
+++ b/collector/lib/NetworkConnection.cpp
@@ -1,5 +1,11 @@
 #include "NetworkConnection.h"
 
+#include <netdb.h>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
 #include "Process.h"
 
 namespace collector {
@@ -50,6 +56,60 @@ std::ostream& operator<<(std::ostream& os, const Connection& conn) {
     os << "6";
   }
   return os << "]";
+}
+
+static bool parse_address(const char* address, struct sockaddr_storage& sockaddr) {
+  struct addrinfo hints = {.ai_flags = AI_NUMERICHOST, 0};
+  struct addrinfo* addrinfo = NULL;
+  bool success;
+
+  success = 0 == getaddrinfo(address, NULL, &hints, &addrinfo);
+
+  if (addrinfo && addrinfo->ai_addr) {
+    memcpy(&sockaddr, reinterpret_cast<struct sockaddr_storage*>(addrinfo->ai_addr), addrinfo->ai_addrlen);
+  } else {
+    success = false;
+  }
+
+  freeaddrinfo(addrinfo);
+
+  return success;
+}
+
+static Address::Family get_family(const struct sockaddr_storage& sockaddr) {
+  switch (sockaddr.ss_family) {
+    case AF_INET:
+      return Address::Family::IPV4;
+    case AF_INET6:
+      return Address::Family::IPV6;
+    default:
+      return Address::Family::UNKNOWN;
+  }
+}
+
+static const uint8_t* get_raw_address(const struct sockaddr_storage& sockaddr) {
+  switch (sockaddr.ss_family) {
+    case AF_INET:
+      return reinterpret_cast<const uint8_t*>(&reinterpret_cast<const struct sockaddr_in&>(sockaddr).sin_addr.s_addr);
+    case AF_INET6:
+      return reinterpret_cast<const uint8_t*>(reinterpret_cast<const struct sockaddr_in6&>(sockaddr).sin6_addr.s6_addr);
+    default:
+      return NULL;
+  }
+}
+
+std::optional<Address> Address::parse(const std::string& address_string) {
+  struct sockaddr_storage sockaddr;
+
+  if (parse_address(address_string.c_str(), sockaddr)) {
+    const uint8_t* raw_address = get_raw_address(sockaddr);
+    if (raw_address == NULL) {
+      return std::nullopt;
+    }
+    return Address(get_family(sockaddr), reinterpret_cast<const std::array<uint8_t, kMaxLen>&>(*raw_address));
+  }
+
+  return std::nullopt;
 }
 
 }  // namespace collector

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <cstring>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -32,6 +33,10 @@ class Address {
   static constexpr size_t kU64MaxLen = kMaxLen / sizeof(uint64_t);
 
   static Address Any(Family family) { return Address(family); }
+
+  // Parse the string representation of an address.
+  // Returns nullopt if the parsing fails.
+  static std::optional<Address> parse(const std::string& address_string);
 
   Address() : Address(Family::UNKNOWN) {}
 

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -154,6 +154,10 @@ class Address {
 
 class IPNet {
  public:
+  // Parse the string representation of a network (<address>/<prefix>) or an address (<address>).
+  // Returns nullopt if the parsing fails.
+  static std::optional<IPNet> parse(const std::string& ipnet_string);
+
   IPNet() : IPNet(Address(), 0, false) {}
   explicit IPNet(const Address& address) : IPNet(address, 8 * address.length(), true) {}
   IPNet(const Address& address, size_t bits, bool is_addr = false)

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -154,6 +154,23 @@ TEST(ConnTrackerTest, TestUpdateIgnoredL4ProtoPortPairs) {
                          std::make_pair(conn_fe_normalized, ConnStatus(time_micros, true))));
 }
 
+TEST(ConnTrackerTest, TestUpdateIgnoredNetworks) {
+  Endpoint a(Address(192, 168, 1, 10), 9999);
+  Endpoint b(Address(169, 254, 0, 1), 80);
+
+  Connection conn1("xyz", a, b, L4Proto::TCP, false);
+
+  int64_t time_micros = 1000;
+
+  ConnectionTracker tracker;
+
+  tracker.UpdateIgnoredNetworks({IPNet(Address(169, 254, 0, 0), 16)});
+
+  tracker.Update({conn1}, {}, time_micros);
+
+  EXPECT_TRUE(tracker.FetchConnState().empty());
+}
+
 TEST(ConnTrackerTest, TestUpdateNormalized) {
   Endpoint a(Address(192, 168, 0, 1), 80);
   Endpoint b(Address(192, 168, 1, 10), 9999);

--- a/collector/test/NRadixTest.cpp
+++ b/collector/test/NRadixTest.cpp
@@ -372,6 +372,20 @@ TEST(NRadixTest, BenchMarkNetworkLookup) {
   std::cout << "Avg time to lookup " << num_nets << " addresses without network radix tree (#networks:" << num_nets << "): " << (aggr_dur_without_tree / num_nets) << "ms\n";
 }
 
+TEST(NRadixTest, IsEmpty) {
+  NRadixTree tree;
+
+  EXPECT_TRUE(tree.IsEmpty());
+
+  tree.Insert(IPNet(Address(10, 10, 0, 0), 16));
+
+  EXPECT_FALSE(tree.IsEmpty());
+
+  tree = NRadixTree(std::vector<IPNet>({IPNet(Address(10, 10, 0, 0), 16)}));
+
+  EXPECT_FALSE(tree.IsEmpty());
+}
+
 }  // namespace
 
 }  // namespace collector

--- a/collector/test/NetworkConnectionTest.cpp
+++ b/collector/test/NetworkConnectionTest.cpp
@@ -136,6 +136,32 @@ TEST(TestIPNet, TestNetworkDescComparator) {
   EXPECT_EQ(networks, expected);
 }
 
+TEST(TestIPNet, Parse) {
+  std::optional<IPNet> ip_net;
+
+  ip_net = IPNet::parse("192.168.0.1/16");
+  EXPECT_TRUE(ip_net);
+  EXPECT_EQ(ip_net.value(), IPNet(Address(192, 168, 0, 1), 16));
+  EXPECT_EQ(ip_net->family(), Address::Family::IPV4);
+
+  ip_net = IPNet::parse("not a subnet");
+  EXPECT_FALSE(ip_net);
+
+  ip_net = IPNet::parse("");
+  EXPECT_FALSE(ip_net);
+
+  ip_net = IPNet::parse("192.168.0.1");
+  EXPECT_TRUE(ip_net);
+  EXPECT_EQ(ip_net.value(), IPNet(Address(192, 168, 0, 1), 0, true));
+  EXPECT_EQ(ip_net->family(), Address::Family::IPV4);
+
+  ip_net = IPNet::parse("192.168.0.1/");
+  EXPECT_FALSE(ip_net);
+
+  ip_net = IPNet::parse("192.168.0.1/not a number");
+  EXPECT_FALSE(ip_net);
+}
+
 }  // namespace
 
 }  // namespace collector

--- a/collector/test/NetworkConnectionTest.cpp
+++ b/collector/test/NetworkConnectionTest.cpp
@@ -80,6 +80,34 @@ TEST(TestAddress, TestLoopback) {
   EXPECT_TRUE(c.IsLocal());
 }
 
+TEST(TestAddress, Parse) {
+  std::optional<Address> address;
+
+  address = Address::parse("192.168.0.1");
+  EXPECT_TRUE(address);
+  EXPECT_EQ(address.value(), Address(192, 168, 0, 1));
+  EXPECT_EQ(address->family(), Address::Family::IPV4);
+
+  address = Address::parse("not an IP");
+  EXPECT_FALSE(address);
+
+  address = Address::parse("");
+  EXPECT_FALSE(address);
+
+  address = Address::parse("192.168.0.1/16");
+  EXPECT_FALSE(address);
+
+  address = Address::parse("2001:0db8:0000:85a3:0000:0000:ac1f:8001");
+  EXPECT_TRUE(address);
+  EXPECT_EQ(address->family(), Address::Family::IPV6);
+  EXPECT_EQ(address.value(), Address(Address::Family::IPV6, std::array<uint8_t, Address::kMaxLen>{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0xac, 0x1f, 0x80, 0x01}));
+
+  address = Address::parse("2001:0db8:0000:85a3::ac1f:8001");
+  EXPECT_TRUE(address);
+  EXPECT_EQ(address->family(), Address::Family::IPV6);
+  EXPECT_EQ(address.value(), Address(Address::Family::IPV6, std::array<uint8_t, Address::kMaxLen>{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x85, 0xa3, 0x00, 0x00, 0x00, 0x00, 0xac, 0x1f, 0x80, 0x01}));
+}
+
 TEST(TestIPNet, TestNetworkDescComparator) {
   std::array<IPNet, 8> networks = {
       IPNet(Address(10, 0, 0, 0), 8),

--- a/docs/references.md
+++ b/docs/references.md
@@ -17,6 +17,10 @@ curl, when loading kernel objects. The default is false.
 * `ROX_NETWORK_DROP_IGNORED`: Ignore connections with configured protocol and
 port pairs (at the moment only `udp/9`). The default is true.
 
+* `ROX_IGNORE_NETWORKS`: A coma-separated list of network prefixes to ignore.
+Any connection with a remote peer matching this list will not be reported.
+The default is `169.254.0.0/16`
+
 * `ROX_NETWORK_GRAPH_PORTS`: Controls whether to retrieve TCP listening
 sockets, while reading connection information from procfs. The default is true.
 


### PR DESCRIPTION
## Description

Add a new Collector environment variable (ROX_IGNORE_NETWORKS) with a list of network prefixes that should be ignored by Collector;
Connections involving a matching remote address are not sent to Sensor.

The default value for the ignored network list is : 169.254.0.0/16

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - ~~Added integration tests~~
 
**Testing done**
- With the default configuration: a connection to 223.42.0.2 is reported, and a connection to 169.254.0.2 is not.
- With an empty ignore-list: everything gets reported
- With 223.42.0.0/16 and 169.254.0.0/16 in the ignore-list: nothing reported.