### PR TITLE
ROX- 21868: backfill RELEASED_VERSIONS 

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -35,4 +35,5 @@
 3.13.5 3.74.8  # Rox release 3.74.8 by roxbot at Sat Jan 13 01:10:57 UTC 2024
 3.17.0 4.3.3  # Rox release 4.3.3 by roxbot at Wed Jan 17 08:03:08 UTC 2024
 3.15.2 4.1.6  # Rox release 4.1.6 by roxbot at Tue Jan 16 02:50:50 UTC 2024
-
+3.16.2 4.2.4  # Rox release 4.2.4 by alwayshooin at Fri Jan 19 18:51:49 CET 2024
+3.17.0 4.3.4  # Rox release 4.3.4 by vikin91 at Mon Jan 22 10:05:32 CET 2024


### PR DESCRIPTION
## Description

These two versions were not marked as published due to a bug in the upstream release automation, see
- https://issues.redhat.com/browse/ROX-21868
- https://github.com/stackrox/stackrox/pull/9489

Timestamp and publisher are taken from the corresponding Stackrox releases.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Updated documentation accordingly~

**Automated testing**
  ~- [ ] Added unit tests~
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

No testable changes. 