### PR TITLE
chore: Remove licenses/third party notices from RHTAP collector-slim image

### DIFF
--- a/collector/container/rhtap-slim.Dockerfile
+++ b/collector/container/rhtap-slim.Dockerfile
@@ -130,10 +130,7 @@ RUN ./install.sh && rm -f install.sh
 
 COPY collector/container/scripts/collector-wrapper.sh /usr/local/bin/
 COPY collector/container/scripts/bootstrap.sh /
-COPY collector/LICENSE-kernel-modules.txt /kernel-modules/LICENSE
 COPY kernel-modules/MODULE_VERSION /kernel-modules/MODULE_VERSION.txt
-COPY --from=builder /THIRD_PARTY_NOTICES/ /THIRD_PARTY_NOTICES/
-COPY --from=builder /collector/NOTICE-sysdig.txt /THIRD_PARTY_NOTICES/sysdig
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/collector /usr/local/bin/
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
 


### PR DESCRIPTION
## Description

Neither of the removed files is present in the downstream image (checked `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.3.2`).

These files are needed for open source compliance purposes in the upstream images which we build and distribute as a community product.

The files are absent in the downstream images because there we get _source containers_ automatically produced by the system. As Connor and I clarified at some point with a Red Hat lawyer, source containers fit the compliance and make `THIRD_PARTY_NOTICES` thing not required.

RHTAP/Konflux gives us source containers too, therefore the suggestion is to drop these files there too.

This follows up on my comments in earlier PR
* https://github.com/stackrox/collector/pull/1407/files#r1404290865
* https://github.com/stackrox/collector/pull/1407/files#r1404230895

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Only CI.
