### PR TITLE
Count the number of throttled log message and print it.

### DIFF
--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -113,7 +113,7 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
     return;
   }
 
-  collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
+  collector::logging::LogMessage(__FILE__, __LINE__, collector_severity) << msg;
 }
 
 const char* GetGlobalLogPrefix() {

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -122,16 +122,16 @@ class LogMessage {
 
 #define CLOG(lvl) CLOG_IF(true, lvl)
 
-#define CLOG_THROTTLED_IF(cond, lvl, interval)                                          \
-  static std::chrono::steady_clock::time_point _clog_lastlog_##__LINE__;                \
-  static unsigned long _clog_lastlog_##__LINE__##_times_ = 0;                           \
-  if (collector::logging::CheckLogLevel(collector::logging::LogLevel::lvl) && (cond)) { \
-    if (std::chrono::steady_clock::now() - _clog_lastlog_##__LINE__ < interval)         \
-      _clog_lastlog_##__LINE__##_times_++;                                              \
-  } else                                                                                \
-    _clog_lastlog_##__LINE__ = std::chrono::steady_clock::now(),                        \
-    _clog_lastlog_##__LINE__##_times_ = 0,                                              \
-    collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, _clog_lastlog_##__LINE__##_times_)
+#define CLOG_THROTTLED_IF(cond, lvl, interval)                                        \
+  static std::chrono::steady_clock::time_point _clog_lastlog_##__LINE__;              \
+  static unsigned long _clog_lastlog_##__LINE__##_times_ = 0;                         \
+  if (collector::logging::CheckLogLevel(collector::logging::LogLevel::lvl) && (cond)) \
+    if (std::chrono::steady_clock::now() - _clog_lastlog_##__LINE__ < interval)       \
+      _clog_lastlog_##__LINE__##_times_++;                                            \
+    else                                                                              \
+      _clog_lastlog_##__LINE__ = std::chrono::steady_clock::now(),                    \
+      _clog_lastlog_##__LINE__##_times_ = 0,                                          \
+      collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, _clog_lastlog_##__LINE__##_times_)
 
 #define CLOG_THROTTLED(lvl, interval) CLOG_THROTTLED_IF(true, lvl, interval)
 

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -127,15 +127,16 @@ class LogMessage {
 
 #define CLOG(lvl) CLOG_IF(true, lvl)
 
-#define CLOG_THROTTLED_IF(cond, lvl, interval)                                        \
-  static std::chrono::steady_clock::time_point _clog_lastlog_##__LINE__;              \
-  static unsigned long _clog_lastlog_##__LINE__##_times_ = 0;                         \
-  if (collector::logging::CheckLogLevel(collector::logging::LogLevel::lvl) && (cond)) \
-    if (std::chrono::steady_clock::now() - _clog_lastlog_##__LINE__ < interval)       \
-      _clog_lastlog_##__LINE__##_times_++;                                            \
-    else                                                                              \
-      _clog_lastlog_##__LINE__ = std::chrono::steady_clock::now(),                    \
-      collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, &_clog_lastlog_##__LINE__##_times_)
+#define CLOG_THROTTLED_IF(cond, lvl, interval)                                                                                 \
+  static std::chrono::steady_clock::time_point _clog_lastlog_##__LINE__;                                                       \
+  static unsigned long _clog_throttle_times_##__LINE__ = 0;                                                                    \
+  std::chrono::duration _clog_elapsed_##__LINE__ = std::chrono::steady_clock::now() - _clog_lastlog_##__LINE__;                \
+  if (collector::logging::CheckLogLevel(collector::logging::LogLevel::lvl) && (cond) && _clog_elapsed_##__LINE__ < interval) { \
+    _clog_throttle_times_##__LINE__++;                                                                                         \
+  }                                                                                                                            \
+  if (collector::logging::CheckLogLevel(collector::logging::LogLevel::lvl) && (cond) && _clog_elapsed_##__LINE__ >= interval)  \
+  _clog_lastlog_##__LINE__ = std::chrono::steady_clock::now(),                                                                 \
+  collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, &_clog_throttle_times_##__LINE__)
 
 #define CLOG_THROTTLED(lvl, interval) CLOG_THROTTLED_IF(true, lvl, interval)
 

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -57,7 +57,7 @@ const size_t LevelPaddingWidth = 7;
 class LogMessage {
  public:
   LogMessage(const char* file, int line, LogLevel level, unsigned long* throttled_times = 0)
-      : file_(file), line_(line), level_(level), throttled_times_(throttled_times) {
+      : file_(file), line_(line), level_(level), throttled_times_(0) {
     // if in debug mode, output file names associated with log messages
     include_file_ = CheckLogLevel(LogLevel::DEBUG);
     if (throttled_times) {
@@ -112,7 +112,7 @@ class LogMessage {
   LogLevel level_;
   std::stringstream buf_;
   bool include_file_;
-  bool throttled_times_;
+  unsigned long throttled_times_;
 };
 
 }  // namespace logging

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -56,10 +56,15 @@ const size_t LevelPaddingWidth = 7;
 
 class LogMessage {
  public:
-  LogMessage(const char* file, int line, LogLevel level, unsigned long throttled_times = 0)
+  LogMessage(const char* file, int line, LogLevel level, unsigned long* throttled_times = 0)
       : file_(file), line_(line), level_(level), throttled_times_(throttled_times) {
     // if in debug mode, output file names associated with log messages
     include_file_ = CheckLogLevel(LogLevel::DEBUG);
+    if (throttled_times) {
+      // this is a throttled message, take the occurrences number and reset it
+      throttled_times_ = *throttled_times;
+      *throttled_times = 0;
+    }
   }
 
   ~LogMessage() {
@@ -130,8 +135,7 @@ class LogMessage {
       _clog_lastlog_##__LINE__##_times_++;                                            \
     else                                                                              \
       _clog_lastlog_##__LINE__ = std::chrono::steady_clock::now(),                    \
-      _clog_lastlog_##__LINE__##_times_ = 0,                                          \
-      collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, _clog_lastlog_##__LINE__##_times_)
+      collector::logging::LogMessage(__FILE__, __LINE__, collector::logging::LogLevel::lvl, &_clog_lastlog_##__LINE__##_times_)
 
 #define CLOG_THROTTLED(lvl, interval) CLOG_THROTTLED_IF(true, lvl, interval)
 


### PR DESCRIPTION
## Description

We have recently increased significantly the delay for some throttled messages.

In order to get a better idea of the amount of messages, this PR adds a counter.

## Checklist
inspected CI test results for throttled messages:
- [x] Seen a message not throttled.
- [x] Seen a message which was throttled.

## Testing

With a container generating 100 zombie processes, the collector contains:
```
...
[INFO    2024/07/05 19:12:09] Successfully established GRPC stream for signals.
[INFO    2024/07/05 19:12:09] Found self-check process event.
[ERROR   2024/07/05 19:12:09] Could not determine network namespace: No such file or directory
[INFO    2024/07/05 19:12:10] Found self-check connection event.
[INFO    2024/07/05 19:12:19] self-check (pid=76) exited with status: 0
[INFO    2024/07/05 19:12:39] Flushing thread table
[INFO    2024/07/05 19:12:39] Flushing container table
[ERROR   2024/07/05 19:12:39] [Throttled 99 messages] Could not determine network namespace: No such file or directory
[INFO    2024/07/05 19:13:09] Flushing container table
[ERROR   2024/07/05 19:13:09] [Throttled 99 messages] Could not determine network namespace: No such file or directory
...
```
