### PR TITLE
Add switch event

### DIFF
--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -51,6 +51,8 @@ class IKernelDriver {
      * procexit is essential for keeping threadinfo cache under control.
      */
     ppm_sc.insert((ppm_sc_code)PPM_SC_SCHED_PROCESS_EXIT);
+
+    ppm_sc.insert((ppm_sc_code)PPM_SC_SCHED_SWITCH);
     return ppm_sc;
   }
 };

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -46,12 +46,13 @@ class IKernelDriver {
     }
 
     /*
-     * Earlier version of Falco used to include procexit by default, now we
-     * have to explicitly add it alongside with the required syscalls.
-     * procexit is essential for keeping threadinfo cache under control.
+     * Earlier version of Falco used to include procexit and sched_switch by
+     * default, now we have to explicitly add it alongside with the required
+     * syscalls. procexit is essential for keeping threadinfo cache under
+     * control, and sched_switch makes conveying process information more
+     * reliable.
      */
     ppm_sc.insert((ppm_sc_code)PPM_SC_SCHED_PROCESS_EXIT);
-
     ppm_sc.insert((ppm_sc_code)PPM_SC_SCHED_SWITCH);
     return ppm_sc;
   }

--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -142,7 +142,8 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_evt* event) {
     signal_lineage->set_parent_uid(p.parent_uid());
   }
 
-  CLOG(DEBUG) << "Process (" << signal->pid() << "): " << signal->name() << " " << signal->args();
+  CLOG(DEBUG) << "Process (" << signal->pid() << "): " << signal->name() << " (" << signal->exec_file_path() << ")"
+              << " " << signal->args();
 
   return signal;
 }
@@ -201,7 +202,8 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_threadinfo* tin
     signal_lineage->set_parent_uid(p.parent_uid());
   }
 
-  CLOG(DEBUG) << "Process (" << signal->pid() << "): " << signal->name() << " " << signal->args();
+  CLOG(DEBUG) << "Process (" << signal->pid() << "): " << signal->name() << " (" << signal->exec_file_path() << ")"
+              << " " << signal->args();
 
   return signal;
 }


### PR DESCRIPTION
## Description

After temporary disabling trusted exepath [[1]] it turns out that original
implementation of exepath resolution wasn't reliable enough, producing flaky
test results. The usual failure looks like this:

* A process (usually runc) performs a chain of clones, potentially intertwined
  with other activity we watch, e.g. closing pipes (runc is talking to clones
  using pipes) or doing networking (as in some of our integration tests).

* As a last step this process does execve to perform some workload.

* The scap events we receive could be either our of order or even missing
  sometimes. Exepath resolution relies on the presence of an enter event, thus
  we got non-deterministic failures.

The reason for that is overlooked missing `sched_switch` event, which similar
to `procexit` became non-default one in [[2]]. This event makes conveying
process information more reliable when it comes to an overloaded system and
frequent switches between processes.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Local testing, Stackrox CI testing.

[1]: https://github.com/stackrox/collector/pull/1508
[2]: https://github.com/falcosecurity/libs/pull/1001