### PR TITLE
Improve runc filtering

### DIFF
--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -170,7 +170,9 @@ bool SysdigService::FilterEvent(const sinsp_threadinfo* tinfo) {
   }
 
   // exclude runc events
-  if (tinfo->m_exepath == "runc" && tinfo->m_comm == "6") {
+  if ((tinfo->m_exepath == "runc" ||
+       tinfo->m_exepath == "/usr/bin/runc") &&
+      tinfo->m_comm == "6") {
     return false;
   }
 


### PR DESCRIPTION
## Description

After updating to vanilla Falco, Collector can see runc process with an absolute exepath. Filter it out as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

The change is mostly visible in flaky tests, so CI is sufficient.