### PR TITLE
ROX-21403: Add fe80::/10 to the networks ignored by default.

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -23,6 +23,7 @@ BoolEnvVar ports_feature_flag("ROX_NETWORK_GRAPH_PORTS", true);
 BoolEnvVar network_drop_ignored("ROX_NETWORK_DROP_IGNORED", true);
 
 // Connection endpoints matching a network prefix listed here will be ignored.
+// The default value contains link-local addresses for IPv4 (RFC3927) and IPv6 (RFC2462)
 StringListEnvVar ignored_networks("ROX_IGNORE_NETWORKS", std::vector<std::string>({"169.254.0.0/16", "fe80::/10"}));
 
 // If true, set curl to be verbose, adding further logging that might be useful for debugging.

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -23,7 +23,7 @@ BoolEnvVar ports_feature_flag("ROX_NETWORK_GRAPH_PORTS", true);
 BoolEnvVar network_drop_ignored("ROX_NETWORK_DROP_IGNORED", true);
 
 // Connection endpoints matching a network prefix listed here will be ignored.
-StringListEnvVar ignored_networks("ROX_IGNORE_NETWORKS", std::vector<std::string>({"169.254.0.0/16"}));
+StringListEnvVar ignored_networks("ROX_IGNORE_NETWORKS", std::vector<std::string>({"169.254.0.0/16", "fe80::/10"}));
 
 // If true, set curl to be verbose, adding further logging that might be useful for debugging.
 BoolEnvVar set_curl_verbose("ROX_COLLECTOR_SET_CURL_VERBOSE", false);

--- a/docs/references.md
+++ b/docs/references.md
@@ -19,7 +19,7 @@ port pairs (at the moment only `udp/9`). The default is true.
 
 * `ROX_IGNORE_NETWORKS`: A coma-separated list of network prefixes to ignore.
 Any connection with a remote peer matching this list will not be reported.
-The default is `169.254.0.0/16`
+The default is `169.254.0.0/16,fe80::/10`
 
 * `ROX_NETWORK_GRAPH_PORTS`: Controls whether to retrieve TCP listening
 sockets, while reading connection information from procfs. The default is true.


### PR DESCRIPTION
## Description

Link-local addresses are defined for IPv6 and was overlooked in #1511 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly
