### PR TITLE
Bump actions versions to fix Node warnings

### DIFF
--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -19,7 +19,7 @@ jobs:
       is_external_pr: ${{ steps.check-external-pr.outputs.is_external_pr }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: check-external-pr
         run: |
           set -uo pipefail

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
     needs:
       - benchmarks
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,15 +30,15 @@ jobs:
       - benchmarks
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
-      - uses: 'google-github-actions/setup-gcloud@v1'
+      - uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/check-drivers-failures.yml
+++ b/.github/workflows/check-drivers-failures.yml
@@ -13,7 +13,7 @@ jobs:
   check-failures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Restore failure files
         uses: actions/download-artifact@v3

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -68,20 +68,20 @@ jobs:
           submodules: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
-      - uses: 'google-github-actions/setup-gcloud@v1'
+      - uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: ./.github/actions/setup-vm-creds
         with:
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
@@ -194,7 +194,7 @@ jobs:
           archs: ${{ env.ARCHS }}
 
       - name: Login to quay.io/rhacs-eng
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -26,9 +26,9 @@ jobs:
       build-image: ${{ steps.changed.outputs.builder-changed }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changed
         with:
           filters: |
@@ -63,7 +63,7 @@ jobs:
       BUILD_TYPE: ci
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -178,7 +178,7 @@ jobs:
       ARCHS: amd64 ppc64le s390x arm64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -59,7 +59,7 @@ jobs:
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -156,7 +156,7 @@ jobs:
       ARCHS: ${{ inputs.archs }}
       COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -62,10 +62,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Restore built drivers
         uses: actions/download-artifact@v3
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
@@ -179,7 +179,7 @@ jobs:
           suffix: -latest
 
       - name: Login to quay.io/rhacs-eng
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -48,15 +48,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: 'google-github-actions/auth@v1'
+      - uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
-      - uses: 'google-github-actions/setup-gcloud@v1'
+      - uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: ./.github/actions/setup-vm-creds
         with:
@@ -108,12 +108,12 @@ jobs:
           } > ${{ github.workspace }}/ansible/secrets.yml
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: Setup GCP
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Build images
         if: |
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
@@ -186,7 +186,7 @@ jobs:
           suffix: -base
 
       - name: Login to quay.io/rhacs-eng
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -38,7 +38,7 @@ jobs:
       PLATFORM: linux/${{ matrix.arch }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -162,7 +162,7 @@ jobs:
       ARCHS: amd64 ppc64le s390x arm64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Login to quay.io/stackrox-io
         uses: docker/login-action@v2

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -50,7 +50,7 @@ jobs:
         - ppc64le
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: docker/login-action@v2
         with:
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sync-drivers
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -82,7 +82,7 @@ jobs:
           touch "${TMP_DIR}/FAILURES/.dummy"
 
       - name: Upload failure logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: drivers-build-failures
           if-no-files-found: ignore

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: brew.registry.redhat.io
           username: ${{ secrets.REDHAT_USERNAME }}
@@ -91,12 +91,12 @@ jobs:
           retention-days: 7
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Push drivers
         run : |
@@ -133,7 +133,7 @@ jobs:
           support-pkg-dir: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
 
       - name: Push support-packages
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: matrix.platform != 'x86_64'
         with:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
@@ -141,7 +141,7 @@ jobs:
           destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}
 
       - name: Push support-packages to public bucket
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: github.event_name != 'pull_request' && matrix.platform != 'x86_64'
         with:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
@@ -157,12 +157,12 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: ./.github/actions/support-package-metadata
         with:
@@ -175,14 +175,14 @@ jobs:
           output-path: /tmp/support-packages/output
 
       - name: Push index.html
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: /tmp/support-packages/output/index.html
           parent: false
           destination: ${{ inputs.support-packages-index-bucket }}
 
       - name: Push index.html to public bucket
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: github.event_name != 'pull_request'
         with:
           path: /tmp/support-packages/output/index.html
@@ -195,12 +195,12 @@ jobs:
     - sync-drivers
     steps:
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Copy files to merged bucket
         run: |

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -64,7 +64,7 @@ jobs:
           - s390x
           - ppc64le
     steps:
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: brew.registry.redhat.io
           username: ${{ secrets.REDHAT_USERNAME }}

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -37,7 +37,7 @@ jobs:
       KERNELS_FILE: ${{ github.workspace }}/kernel-modules/KERNEL_VERSIONS
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Patch files
         env:
@@ -144,7 +144,7 @@ jobs:
         builder: ${{ fromJSON(needs.split-tasks.outputs.parallel-array) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Authenticate with GCP
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -122,7 +122,7 @@ jobs:
           ${{ github.workspace }}/kernel-modules/build/kernel-splitter.py
 
       - name: Store tasks and sources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tasks-and-sources
           if-no-files-found: ignore
@@ -225,7 +225,7 @@ jobs:
           done
 
       - name: Store built drivers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-drivers
           path: /tmp/output
@@ -233,7 +233,7 @@ jobs:
           retention-days: 1
 
       - name: Store build failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: driver-build-failures
           path: /tmp/FAILURES

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -60,12 +60,12 @@ jobs:
             /tmp
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Create a mock cache
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-cache') }}
@@ -147,12 +147,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Restore tasks and sources
         uses: actions/download-artifact@v3

--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -85,12 +85,12 @@ jobs:
       rebuild-qa-containers: ${{ steps.filter.outputs.container }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           list-files: shell
@@ -189,7 +189,7 @@ jobs:
     - common-variables
     if: github.event_name == 'push' && (github.ref_type == 'tag' || startsWith(github.ref_name, 'release-'))
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Ensure downstream drivers exist for releases
         run: |

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -26,7 +26,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests')
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -66,7 +66,7 @@ jobs:
       build-dirs: ${{ steps.variables.outputs.build-dirs }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set variables
         id: variables
@@ -95,7 +95,7 @@ jobs:
       COLLECTOR_QA_TAG: ${{ inputs.collector-qa-tag }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Create Ansible Vars (inc. Secrets)
         run: |
@@ -98,13 +98,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to quay.io/rhacs-eng
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.19' # to match the requirement in the integration tests
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.vm_type }}-logs
           path: |

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -50,17 +50,17 @@ jobs:
         with:
           go-version: '1.19' # to match the requirement in the integration tests
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: Setup GCP
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: ./.github/actions/setup-vm-creds
         with:

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -44,7 +44,7 @@ jobs:
       COLLECTOR_QA_TAG: ${{ inputs.collector-qa-tag }}
       TEST_IMAGE: quay.io/rhacs-eng/qa-multi-arch:collector-tests-${{ inputs.collector-tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           # fetch all to allow linting of differences between branches
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
       - uses: mfinelli/setup-shfmt@v2
 
       - name: Install actionlint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # fetch all to allow linting of differences between branches
           fetch-depth: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
         - -DADDRESS_SANITIZER=ON
         - -DUSE_VALGRIND=ON
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -39,12 +39,12 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - uses: ./.github/actions/support-package-metadata
         with:
@@ -72,14 +72,14 @@ jobs:
           support-pkg-dir: /tmp/support-packages/output
 
       - name: Push support-packages
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: /tmp/support-packages/output
           parent: false
           destination: ${{ inputs.support-packages-bucket }}/x86_64
 
       - name: Push support-packages to public bucket
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: github.event_name == 'push'
         with:
           path: /tmp/support-packages/output
@@ -93,14 +93,14 @@ jobs:
           output-path: /tmp/support-packages/output
 
       - name: Push index.html
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: /tmp/support-packages/output/index.html
           parent: false
           destination: ${{ inputs.support-packages-index-bucket }}
 
       - name: Push index.html to public bucket
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: github.event_name == 'push'
         with:
           path: /tmp/support-packages/output/index.html
@@ -108,14 +108,14 @@ jobs:
           destination: ${{ inputs.public-support-packages-bucket }}
 
       - name: Push driver matrix
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: /tmp/driver-matrix.json
           parent: false
           destination: ${{ inputs.support-packages-bucket }}
 
       - name: Push index.html to public bucket
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         if: github.event_name == 'push'
         with:
           path: /tmp/driver-matrix.json

--- a/.github/workflows/upload-drivers.yml
+++ b/.github/workflows/upload-drivers.yml
@@ -24,15 +24,15 @@ jobs:
           path: /tmp/output/
 
       - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Push drivers
-        uses: 'google-github-actions/upload-cloud-storage@v1'
+        uses: 'google-github-actions/upload-cloud-storage@v2'
         with:
           path: /tmp/output/
           parent: false


### PR DESCRIPTION
## Description

This should be a cosmetic change that fixes the various warnings we currently get in CI about NodeJS versions. Functionality should be unaffected.

## Testing Performed

CI will be enough.
