### PR TITLE
Makes cpaas drivers failure artifacts unique for each architecture

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: 'google-github-actions/setup-gcloud@v2'
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: benchmark-logs
           path: ${{ github.workspace }}

--- a/.github/workflows/check-drivers-failures.yml
+++ b/.github/workflows/check-drivers-failures.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore failure files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.logs-artifact }}
           path: /tmp/FAILURES

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -68,7 +68,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Restore built drivers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         if: matrix.arch == 'amd64' && !inputs.skip-built-drivers
         with:
           name: built-drivers

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -148,6 +148,16 @@ jobs:
           parent: false
           destination: ${{ inputs.public-support-packages-bucket }}/${{ matrix.platform }}
 
+  merge-drivers-failures:
+    runs-on: ubuntu-latest
+    needs: sync-drivers
+    steps:
+      - name: Merge drivers failures
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: drivers-build-failures
+          pattern: drivers-build-failures-*
+
   update-index:
     runs-on: ubuntu-latest
     needs: sync-drivers

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Upload failure logs
         uses: actions/upload-artifact@v4
         with:
-          name: drivers-build-failures
+          name: drivers-build-failures-${{ matrix.platform }}
           if-no-files-found: ignore
           path: |
             ${{ env.FAILURES_DIR }}

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -48,11 +48,17 @@ jobs:
       branch-name: ${{ needs.init.outputs.branch-name }}
 
   check-drivers-failures:
+    strategy:
+      matrix:
+        platform:
+          - x86_64
+          - s390x
+          - ppc64le
     uses: ./.github/workflows/check-drivers-failures.yml
     needs: sync-drivers-and-support-packages
     with:
       logs-artifact:
-        drivers-build-failures
+        drivers-build-failures-${{ matrix.platform }}
 
   build-collector-slim:
     runs-on: ubuntu-latest

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -48,17 +48,11 @@ jobs:
       branch-name: ${{ needs.init.outputs.branch-name }}
 
   check-drivers-failures:
-    strategy:
-      matrix:
-        platform:
-          - x86_64
-          - s390x
-          - ppc64le
     uses: ./.github/workflows/check-drivers-failures.yml
     needs: sync-drivers-and-support-packages
     with:
       logs-artifact:
-        drivers-build-failures-${{ matrix.platform }}
+        drivers-build-failures
 
   build-collector-slim:
     runs-on: ubuntu-latest

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -155,7 +155,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Restore tasks and sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tasks-and-sources
           path: /tmp

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           ansible-galaxy install -r ansible/requirements.yml
 
-          BUILD_MULTI_ARCH="${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || github.event_name == 'push' || github.event_name == 'schedule' }}"
+          BUILD_MULTI_ARCH="${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || contains(github.event.pull_request.labels.*.name, 'run-cpaas-steps') || github.event_name == 'push' || github.event_name == 'schedule' }}"
 
           # build_multi_arch passed in as json to ensure boolean type
           ansible-playbook \

--- a/.github/workflows/upload-drivers.yml
+++ b/.github/workflows/upload-drivers.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Restore built drivers
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: built-drivers
           path: /tmp/output/


### PR DESCRIPTION
## Description

actions/upload-artifact@v4 no longer supports non-unique names. This PR ensures that cpaas driver failures are unique.

## Testing Performed

Run PR with cpaas label