### PR TITLE
Reduce integration test retries

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -30,7 +30,7 @@ const (
 
 	containerStatsName = "container-stats"
 
-	defaultWaitTickSeconds = 30 * time.Second
+	defaultWaitTickSeconds = 5 * time.Second
 )
 
 type IntegrationTestSuiteBase struct {
@@ -259,9 +259,7 @@ func (s *IntegrationTestSuiteBase) launchContainer(name string, args ...string) 
 	cmd := []string{common.RuntimeCommand, "run", "-d", "--name", name}
 	cmd = append(cmd, args...)
 
-	output, err := common.Retry(func() (string, error) {
-		return s.Executor().Exec(cmd...)
-	})
+	output, err := s.Executor().Exec(cmd...)
 
 	outLines := strings.Split(output, "\n")
 	return outLines[len(outLines)-1], err
@@ -388,20 +386,20 @@ func (s *IntegrationTestSuiteBase) execContainerShellScript(containerName string
 
 func (s *IntegrationTestSuiteBase) cleanupContainers(containers ...string) {
 	for _, container := range containers {
-		s.Executor().Exec(common.RuntimeCommand, "kill", container)
-		s.Executor().Exec(common.RuntimeCommand, "rm", container)
+		s.Executor().KillContainer(container)
+		s.Executor().RemoveContainer(container)
 	}
 }
 
 func (s *IntegrationTestSuiteBase) stopContainers(containers ...string) {
 	for _, container := range containers {
-		s.Executor().Exec(common.RuntimeCommand, "stop", "-t", config.StopTimeout(), container)
+		s.Executor().StopContainer(container)
 	}
 }
 
 func (s *IntegrationTestSuiteBase) removeContainers(containers ...string) {
 	for _, container := range containers {
-		s.Executor().Exec(common.RuntimeCommand, "rm", container)
+		s.Executor().RemoveContainer(container)
 	}
 }
 

--- a/integration-tests/suites/common/collector_manager.go
+++ b/integration-tests/suites/common/collector_manager.go
@@ -220,8 +220,8 @@ func (c *CollectorManager) captureLogs(containerName string) (string, error) {
 }
 
 func (c *CollectorManager) killContainer(name string) error {
-	_, err1 := c.executor.Exec(RuntimeCommand, "kill", name)
-	_, err2 := c.executor.Exec(RuntimeCommand, "rm", "-fv", name)
+	_, err1 := c.executor.KillContainer(name)
+	_, err2 := c.executor.RemoveContainer(name)
 
 	var result error
 	if err1 != nil {
@@ -235,7 +235,7 @@ func (c *CollectorManager) killContainer(name string) error {
 }
 
 func (c *CollectorManager) stopContainer(name string) error {
-	_, err := c.executor.Exec(RuntimeCommand, "stop", name)
+	_, err := c.executor.StopContainer(name)
 	return err
 }
 

--- a/integration-tests/suites/common/executor.go
+++ b/integration-tests/suites/common/executor.go
@@ -99,7 +99,7 @@ func NewExecutor() Executor {
 	return &e
 }
 
-// Exec executes the provided command with retries with non-zero error from the command.
+// Exec executes the provided command with retries on non-zero error from the command.
 func (e *executor) Exec(args ...string) (string, error) {
 	if args[0] == RuntimeCommand && RuntimeAsRoot {
 		args = append([]string{"sudo"}, args...)

--- a/integration-tests/suites/common/executor.go
+++ b/integration-tests/suites/common/executor.go
@@ -130,7 +130,7 @@ func (e *executor) RunCommand(cmd *exec.Cmd) (string, error) {
 		return "", nil
 	}
 	commandLine := strings.Join(cmd.Args, " ")
-	if true { // debug {
+	if debug {
 		fmt.Printf("Run: %s\n", commandLine)
 	}
 	stdoutStderr, err := cmd.CombinedOutput()

--- a/integration-tests/suites/common/retry.go
+++ b/integration-tests/suites/common/retry.go
@@ -10,12 +10,18 @@ const (
 )
 
 type retryable = func() (string, error)
+type errorchecker = func(string, error) error
 
 // Simple retry in loop for commands produce only one string output and error
 func Retry(f retryable) (output string, err error) {
+	return RetryWithErrorCheck(func(s string, e error) error { return e }, f)
+}
+
+// Simple retry with error checker
+func RetryWithErrorCheck(ec errorchecker, f retryable) (output string, err error) {
 	for i := 0; i < max_retries; i++ {
 		output, err = f()
-		if err == nil {
+		if ec(output, err) == nil {
 			return output, nil
 		} else if i != max_retries-1 {
 			time.Sleep(retry_wait_time)

--- a/integration-tests/suites/config/config.go
+++ b/integration-tests/suites/config/config.go
@@ -152,7 +152,7 @@ func RuntimeInfo() *Runtime {
 func CollectorInfo() *CollectorOptions {
 	if collector_options == nil {
 		collector_options = &CollectorOptions{
-			LogLevel:     ReadEnvVarWithDefault(envCollectorLogLevel, "info"),
+			LogLevel:     ReadEnvVarWithDefault(envCollectorLogLevel, "debug"),
 			Offline:      ReadBoolEnvVar(envCollectorOfflineMode),
 			PreArguments: ReadEnvVar(envCollectorPreArguments),
 		}

--- a/integration-tests/suites/config/config.go
+++ b/integration-tests/suites/config/config.go
@@ -152,7 +152,7 @@ func RuntimeInfo() *Runtime {
 func CollectorInfo() *CollectorOptions {
 	if collector_options == nil {
 		collector_options = &CollectorOptions{
-			LogLevel:     ReadEnvVarWithDefault(envCollectorLogLevel, "debug"),
+			LogLevel:     ReadEnvVarWithDefault(envCollectorLogLevel, "info"),
 			Offline:      ReadBoolEnvVar(envCollectorOfflineMode),
 			PreArguments: ReadEnvVar(envCollectorPreArguments),
 		}

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -28,6 +28,5 @@ func (s *ImageLabelJSONTestSuite) TestRunImageWithJSONLabel() {
 }
 
 func (s *ImageLabelJSONTestSuite) TearDownSuite() {
-	s.StopCollector()
-	s.cleanupContainers("json-label")
+	s.cleanupContainers("jsonlabel")
 }

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -69,8 +69,6 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 }
 
 func (s *ProcessNetworkTestSuite) TearDownSuite() {
-	s.StopCollector()
-	s.cleanupContainers("nginx", "nginx-curl")
 	s.WritePerfResults()
 }
 


### PR DESCRIPTION
## Description
### Problem
Integration tests were taking an excessive amount of time due to retries on operations involving removed containers, as well as unnecessarily long health checks and redundant cleanups.

### Solution
* Implemented early exits in retry functions for remove, stop, and kill container operations if the container is no longer present based on the output message.
* Reduced collector health check wait time from 30s to 5s. This improves the common case where collector is healthier before 30 sec has elapsed.
* Eliminated redundant calls to collector cleanup functions.
* Corrected an error in the container name for jsonlabel, ending repeated cleanup retries.

### Impact
Integration test suite execution time (including VM provisioning) decreased significantly, from approximately 77 minutes to 29 minutes, representing a ~2.75x speedup.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
