### PR TITLE
Add go test logging

### DIFF
--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"golang.org/x/exp/maps"
@@ -11,6 +10,7 @@ import (
 	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stackrox/collector/integration-tests/pkg/executor"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
 )
 
 type DockerCollectorManager struct {
@@ -90,7 +90,7 @@ func (c *DockerCollectorManager) Launch() error {
 func (c *DockerCollectorManager) TearDown() error {
 	isRunning, err := c.IsRunning()
 	if err != nil {
-		return fmt.Errorf("Unable to check if container is running: %s", err)
+		return log.Error("Unable to check if container is running: %s", err)
 	}
 
 	if !isRunning {
@@ -100,10 +100,10 @@ func (c *DockerCollectorManager) TearDown() error {
 			Name: "collector",
 		})
 		if err != nil {
-			return fmt.Errorf("Failed to get container exit code: %s", err)
+			return log.Error("Failed to get container exit code: %s", err)
 		}
 		if exitCode != 0 {
-			return fmt.Errorf("Collector container has non-zero exit code (%d)", exitCode)
+			return log.Error("Collector container has non-zero exit code (%d)", exitCode)
 		}
 	} else {
 		c.stopContainer("collector")
@@ -179,8 +179,7 @@ func (c *DockerCollectorManager) launchCollector() error {
 func (c *DockerCollectorManager) captureLogs(containerName string) (string, error) {
 	logs, err := c.executor.Exec(executor.RuntimeCommand, "logs", containerName)
 	if err != nil {
-		fmt.Printf(executor.RuntimeCommand+" logs error (%v) for container %s\n", err, containerName)
-		return "", err
+		return "", log.Error(executor.RuntimeCommand+" logs error (%v) for container %s\n", err, containerName)
 	}
 
 	logFile, err := common.PrepareLog(c.testName, "collector.log")

--- a/integration-tests/pkg/common/utils.go
+++ b/integration-tests/pkg/common/utils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/config"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
 	"golang.org/x/sys/unix"
 	"k8s.io/utils/strings/slices"
 )
@@ -70,6 +70,6 @@ func PrepareLog(testName string, logName string) (*os.File, error) {
 
 func Sleep(duration time.Duration) {
 	_, filename, line, _ := runtime.Caller(1)
-	fmt.Printf("%s:%d sleeping for %f s\n", filename, line, duration.Seconds())
+	log.Info("%s:%d sleeping for %f s\n", filename, line, duration.Seconds())
 	time.Sleep(duration)
 }

--- a/integration-tests/pkg/executor/executor_docker.go
+++ b/integration-tests/pkg/executor/executor_docker.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
@@ -9,11 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
 )
 
 var (
-	debug = false
-
 	RuntimeCommand = config.RuntimeInfo().Command
 	RuntimeSocket  = config.RuntimeInfo().Socket
 	RuntimeAsRoot  = config.RuntimeInfo().RunAsRoot
@@ -73,14 +71,10 @@ func (e *dockerExecutor) RunCommand(cmd *exec.Cmd) (string, error) {
 		return "", nil
 	}
 	commandLine := strings.Join(cmd.Args, " ")
-	if debug {
-		fmt.Printf("Run: %s\n", commandLine)
-	}
+	log.Info("%s\n", commandLine)
 	stdoutStderr, err := cmd.CombinedOutput()
 	trimmed := strings.Trim(string(stdoutStderr), "\"\n")
-	if debug {
-		fmt.Printf("Run Output: %s\n", trimmed)
-	}
+	log.Debug("Run Output: %s\n", trimmed)
 	if err != nil {
 		err = errors.Wrapf(err, "Command Failed: %s\nOutput: %s\n", commandLine, trimmed)
 	}
@@ -114,7 +108,7 @@ func (e *dockerExecutor) CopyFromHost(src string, dst string) (res string, err e
 	for attempt < maxAttempts {
 		cmd := e.builder.RemoteCopyCommand(src, dst)
 		if attempt > 0 {
-			fmt.Printf("Retrying (%v) (%d of %d) Error: %v\n", cmd, attempt, maxAttempts, err)
+			log.Error("Retrying (%v) (%d of %d) Error: %v\n", cmd, attempt, maxAttempts, err)
 		}
 		attempt++
 		res, err = e.RunCommand(cmd)

--- a/integration-tests/pkg/executor/retry.go
+++ b/integration-tests/pkg/executor/retry.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/common"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
 )
 
 const (
@@ -26,6 +27,7 @@ func RetryWithErrorCheck(ec errorchecker, f retryable) (output string, err error
 		if ec(output, err) == nil {
 			return output, nil
 		} else if i != max_retries-1 {
+			log.Error("Retrying (%d of %d) Error: %v\n", i, max_retries, err)
 			common.Sleep(retry_wait_time)
 		}
 	}

--- a/integration-tests/pkg/log/logging.go
+++ b/integration-tests/pkg/log/logging.go
@@ -1,0 +1,89 @@
+package log
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/stackrox/collector/integration-tests/pkg/config"
+)
+
+type LogLevel int
+
+const (
+	DebugLevel LogLevel = iota
+	InfoLevel
+	ErrorLevel
+)
+
+type Logger struct {
+	level  LogLevel
+	logger *log.Logger
+}
+
+var DefaultLogger *Logger
+
+func init() {
+	DefaultLogger = NewLogger()
+}
+
+func parseLogLevel(levelStr string) LogLevel {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return DebugLevel
+	case "info":
+		return InfoLevel
+	case "error":
+		return ErrorLevel
+	default:
+		return InfoLevel
+	}
+}
+
+func NewLogger() *Logger {
+	levelStr := config.ReadEnvVar("LOG_LEVEL")
+	level := parseLogLevel(levelStr)
+
+	return &Logger{
+		level:  level,
+		logger: log.New(os.Stdout, "", log.Ldate|log.Ltime),
+	}
+}
+
+func (l *Logger) Debug(format string, v ...interface{}) {
+	if l.level <= DebugLevel {
+		l.logger.Printf("DEBUG: "+format, v...)
+	}
+}
+
+func (l *Logger) Info(format string, v ...interface{}) {
+	if l.level <= InfoLevel {
+		l.logger.Printf("INFO: "+format, v...)
+	}
+}
+
+func (l *Logger) Log(format string, v ...interface{}) {
+	l.logger.Printf(format, v...)
+}
+
+func (l *Logger) Error(format string, v ...interface{}) error {
+	l.logger.Printf("ERROR: "+format, v...)
+	return fmt.Errorf(format, v...)
+}
+
+func Log(format string, v ...interface{}) {
+	DefaultLogger.Log(format, v...)
+}
+
+func Debug(format string, v ...interface{}) {
+	DefaultLogger.Debug(format, v...)
+}
+
+func Info(format string, v ...interface{}) {
+	DefaultLogger.Info(format, v...)
+}
+
+func Error(format string, v ...interface{}) error {
+	return DefaultLogger.Error(format, v...)
+}

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -1,7 +1,6 @@
 package suites
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
 	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
 	"github.com/stackrox/collector/integration-tests/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -90,7 +90,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection. https://issues.redhat.com/browse/ROX-17964
 		// assert.Equal(s.T(), nClientNetwork, nExpectedClientNetwork)
 		if nExpectedNetwork != nNetwork {
-			fmt.Println("WARNING: Expected " + strconv.Itoa(nExpectedNetwork) + " client network connections but found " + strconv.Itoa(nNetwork))
+			log.Error("Expected " + strconv.Itoa(nExpectedNetwork) + " client network connections but found " + strconv.Itoa(nNetwork))
 		}
 		lastNetwork := clientNetworks[nNetwork-1]
 		lastExpectedNetwork := s.Client.ExpectedNetwork[nExpectedNetwork-1]
@@ -103,7 +103,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 	}
 
 	if s.Client.ExpectedEndpoints != nil {
-		fmt.Println("Expected client endpoint should be nil")
+		log.Error("Expected client endpoint should be nil")
 	}
 
 	endpoints := s.Sensor().Endpoints(s.Client.ContainerID)
@@ -117,7 +117,7 @@ func (s *ConnectionsAndEndpointsTestSuite) TestConnectionsAndEndpoints() {
 		// TODO Get this assert to pass reliably for these tests. Don't just do the asserts for the last connection. https://issues.redhat.com/browse/ROX-18803
 		// assert.Equal(s.T(), nServerNetwork, nExpectedServerNetwork)
 		if nExpectedNetwork != nNetwork {
-			fmt.Println("WARNING: Expected " + strconv.Itoa(nExpectedNetwork) + " server network connections but found " + strconv.Itoa(nNetwork))
+			log.Error("Expected " + strconv.Itoa(nExpectedNetwork) + " server network connections but found " + strconv.Itoa(nNetwork))
 		}
 		lastNetwork := serverNetworks[nNetwork-1]
 		lastExpectedNetwork := s.Server.ExpectedNetwork[nExpectedNetwork-1]


### PR DESCRIPTION
## Description

Adds logging to the container runtime actions in collector integration tests to provide visibility and help with debugging issues. Also print last few lines of collector logs when there is a non-zero exit.

Format:
```
2024/08/22 01:31:35 INFO: docker ps -qa --filter id=a0b36d431974 --filter health=healthy
2024/08/22 01:31:35 ERROR: Waiting for container collector to become health=healthy, elapsed time: 2m0.025917497s
2024/08/22 01:31:40 INFO: docker ps -qa --filter id=a0b36d431974 --filter health=healthy
2024/08/22 01:31:45 INFO: docker ps -qa --filter id=a0b36d431974 --filter health=healthy
...
Collector container has non-zero exit code (134)
collector logs:
[WARNING 2024/08/22 01:29:36] (Logging.cpp:116) libbpf: failed to load BPF skeleton 'bpf_probe': -13


    	            	[ERROR   2024/08/22 01:29:36] (Logging.cpp:116) libpman: failed to load BPF object (errno: 13 | message: Permission denied)
    	            	terminate called after throwing an instance of &apos;sinsp_exception&apos;
    	            	  what():  Initialization issues during scap_init
    	            	collector AbortHandler 0xa6d161 + 38
    	            	/lib64/libc.so.6 (null) 0x7955a39fa6f0 + 0
    	            	/lib64/libc.so.6 (null) 0x7955a3a4794c + 0
    	            	/lib64/libc.so.6 raise 0x7955a39fa646 + 22
    	            	/lib64/libc.so.6 abort 0x7955a39e47f3 + 211
    	            	/lib64/libstdc++.so.6 (null) 0x7955a3d5cb21 + 0
    	            	/lib64/libstdc++.so.6 (null) 0x7955a3d6852c + 0
    	            	/lib64/libstdc++.so.6 (null) 0x7955a3d68597 + 0
    	            	/lib64/libstdc++.so.6 (null) 0x7955a3d687f9 + 0
    	            	collector collector::KernelDriverCOREEBPF::Setup(collector::CollectorConfig const&amp;, sinsp&amp;) 0xb1b1c9 + 303
    	            	collector collector::system_inspector::Service::InitKernel(collector::CollectorConfig const&amp;) 0xb17d98 + 1530
    	            	collector collector::CollectorService::InitKernel() 0xa7dc62 + 38
    	            	collector collector::SetupKernelDriver(collector::CollectorService&amp;, std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt; const&amp;, collector::CollectorConfig const&amp;) 0xa7de08 + 159
    	            	collector main 0xa69e1d + 1269
    	            	/lib64/libc.so.6 (null) 0x7955a39e5590 + 0
    	            	/lib64/libc.so.6 __libc_start_main 0x7955a39e5640 + 128
    	            	collector _start 0xa68c65 + 37
    	            	Caught signal 6 (SIGABRT): Aborted
    	            	/bootstrap.sh: line 85:    10 Aborted                 (core dumped) eval exec &quot;$@
    	Test:       	TestProcessNetwork</code></pre></td></tr>
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added integration tests

## Testing Performed

verified logs
