### PR TITLE
Ensure Collector is always cleaned up

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -164,9 +164,10 @@ func (s *IntegrationTestSuiteBase) RegisterCleanup(containers ...string) {
 		// if resources are already gone.
 		containers = append(containers, containerStatsName)
 		s.cleanupContainers(containers...)
-		if running, _ := s.Collector().IsRunning(); running {
-			s.StopCollector()
-		}
+		// StopCollector is safe when collector isn't running, so
+		// unconditionally try to stop it. This will ensure that logs
+		// are still written even when test setup fails
+		s.StopCollector()
 	})
 }
 

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -164,10 +164,11 @@ func (s *IntegrationTestSuiteBase) RegisterCleanup(containers ...string) {
 		// if resources are already gone.
 		containers = append(containers, containerStatsName)
 		s.cleanupContainers(containers...)
-		// StopCollector is safe when collector isn't running, so
-		// unconditionally try to stop it. This will ensure that logs
-		// are still written even when test setup fails
-		s.StopCollector()
+		// StopCollector is safe when collector isn't running, but the container must exist.
+		// This will ensure that logs are still written even when test setup fails
+		if exists, _ := s.Executor().ContainerExists("collector"); exists {
+			s.StopCollector()
+		}
 	})
 }
 

--- a/integration-tests/suites/common/executor.go
+++ b/integration-tests/suites/common/executor.go
@@ -24,6 +24,7 @@ type Executor interface {
 	CopyFromHost(src string, dst string) (string, error)
 	PullImage(image string) error
 	IsContainerRunning(image string) (bool, error)
+	ContainerExists(container string) (bool, error)
 	ExitCode(container string) (int, error)
 	Exec(args ...string) (string, error)
 	ExecWithStdin(pipedContent string, args ...string) (string, error)
@@ -194,6 +195,14 @@ func (e *executor) PullImage(image string) error {
 
 func (e *executor) IsContainerRunning(containerID string) (bool, error) {
 	result, err := e.Exec(RuntimeCommand, "inspect", containerID, "--format='{{.State.Running}}'")
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(strings.Trim(result, "\"'"))
+}
+
+func (e *executor) ContainerExists(container string) (bool, error) {
+	result, err := e.Exec(RuntimeCommand, "ps", "-aq", "--format=id="+container)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Description

Sometimes Collector is either expected to fail or can fail during test setup or healthchecks. We want to retain any logs from the collector container, even in these cases.

The clean up function has been changed to unconditionally clean up Collector:
- Collector is not run with `--rm` so we can get the logs. For this reason, all the collector manager functions cope with a container that is not running (which makes the check in the clean up function redundant)
- The base class should be more thorough to ensure that all resources are cleaned up

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed
CI primarily. Not able to strictly reproduce the problem seen [here](https://github.com/stackrox/collector/commit/507b1d8a3c9d861005fba71ac479fc0ebfdc0ec2/checks) but existence of logs in the right places should be enough 
