### PR TITLE
chore: rename RHTAP references to Konflux

### DIFF
--- a/.tekton/collector-slim-pull-request.yaml
+++ b/.tekton/collector-slim-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && source_branch.contains("rhtap")
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (source_branch.contains("rhtap") || source_branch.contains("konflux"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs
@@ -22,7 +22,7 @@ spec:
 
   params:
   - name: dockerfile
-    value: collector/container/rhtap-slim.Dockerfile
+    value: collector/container/konflux-slim.Dockerfile
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/collector-slim-push.yaml
+++ b/.tekton/collector-slim-push.yaml
@@ -21,7 +21,7 @@ spec:
 
   params:
   - name: dockerfile
-    value: collector/container/rhtap-slim.Dockerfile
+    value: collector/container/konflux-slim.Dockerfile
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/collector/container/konflux-slim.Dockerfile
+++ b/collector/container/konflux-slim.Dockerfile
@@ -94,10 +94,7 @@ RUN ./builder/install/install-dependencies.sh && \
            -DTRACE_SINSP_EVENTS=${TRACE_SINSP_EVENTS} && \
     cmake --build ${CMAKE_BUILD_DIR} --target all -- -j "${NPROCS:-2}" && \
     ctest -V --test-dir ${CMAKE_BUILD_DIR} && \
-    strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector" && \
-    if [[ -f "${CMAKE_BUILD_DIR}/collector/EXCLUDE_FROM_DEFAULT_BUILD/libsinsp/libsinsp-wrapper.so" ]]; then \
-        strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/EXCLUDE_FROM_DEFAULT_BUILD/libsinsp/libsinsp-wrapper.so"; fi
-
+    strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector"
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
## Description

- RHTAP was renamed to Konflux
- remove libinsp wrapper cleanup according to https://github.com/stackrox/collector/pull/1441#discussion_r1484450706 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
