### PR TITLE
Fix container exists function in go tests

### DIFF
--- a/integration-tests/suites/common/executor.go
+++ b/integration-tests/suites/common/executor.go
@@ -204,11 +204,11 @@ func (e *executor) IsContainerRunning(containerID string) (bool, error) {
 }
 
 func (e *executor) ContainerExists(container string) (bool, error) {
-	result, err := e.Exec(RuntimeCommand, "ps", "-aq", "--format=id="+container)
+	_, err := e.ExecWithoutRetry(RuntimeCommand, "inspect", container)
 	if err != nil {
 		return false, err
 	}
-	return strconv.ParseBool(strings.Trim(result, "\"'"))
+	return true, nil
 }
 
 func (e *executor) ExitCode(containerID string) (int, error) {


### PR DESCRIPTION
## Description

Merge conflict with the exec retries changes may have surfaced the issue, it looks like the output of `docker ps` was not correctly handled, the returned output in some cases is the container id, not a boolean.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
