### PR TITLE
Make thread cache size configurable

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -273,6 +273,8 @@ void CollectorConfig::HandleSinspEnvVars() {
 
   sinsp_cpu_per_buffer_ = DEFAULT_CPU_FOR_EACH_BUFFER;
   sinsp_buffer_size_ = DEFAULT_DRIVER_BUFFER_BYTES_DIM;
+  // the default value for sinsp_thread_cache_size_ is not picked up from
+  // Falco, but set in the CollectorConfig class.
 
   if ((envvar = std::getenv("ROX_COLLECTOR_SINSP_CPU_PER_BUFFER")) != NULL) {
     try {
@@ -289,6 +291,15 @@ void CollectorConfig::HandleSinspEnvVars() {
       CLOG(INFO) << "Sinsp buffer size: " << sinsp_buffer_size_;
     } catch (...) {
       CLOG(ERROR) << "Invalid buffer size value: '" << envvar << "'";
+    }
+  }
+
+  if ((envvar = std::getenv("ROX_COLLECTOR_SINSP_THREAD_CACHE_SIZE")) != NULL) {
+    try {
+      sinsp_thread_cache_size_ = std::stoi(envvar);
+      CLOG(INFO) << "Sinsp thread cache size: " << sinsp_thread_cache_size_;
+    } catch (...) {
+      CLOG(ERROR) << "Invalid thread cache size value: '" << envvar << "'";
     }
   }
 }

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -117,8 +117,8 @@ class CollectorConfig {
   // Max size of the thread cache. This parameter essentially translated into
   // the upper boundary for memory consumption. Note that Falco puts it's own
   // upper limit on top of this value, m_thread_table_absolute_max_size, which
-  // is 2^17 (131072).
-  unsigned int sinsp_thread_cache_size_ = 524288;
+  // is 2^17 (131072) and twice as large.
+  unsigned int sinsp_thread_cache_size_ = 65536;
 
   Json::Value tls_config_;
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -79,6 +79,7 @@ class CollectorConfig {
   unsigned int GetConnectionStatsWindow() const { return connection_stats_window_; }
   unsigned int GetSinspBufferSize() const { return sinsp_buffer_size_; }
   unsigned int GetSinspCpuPerBuffer() const { return sinsp_cpu_per_buffer_; }
+  unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -112,6 +113,12 @@ class CollectorConfig {
   unsigned int sinsp_cpu_per_buffer_;
   // Size of one ring buffer, in bytes
   unsigned int sinsp_buffer_size_;
+
+  // Max size of the thread cache. This parameter essentially translated into
+  // the upper boundary for memory consumption. Note that Falco puts it's own
+  // upper limit on top of this value, m_thread_table_absolute_max_size, which
+  // is 2^17 (131072).
+  unsigned int sinsp_thread_cache_size_ = 524288;
 
   Json::Value tls_config_;
 

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -79,7 +79,7 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
     inspector_->set_import_users(config.ImportUsers());
     inspector_->set_thread_timeout_s(30);
     inspector_->set_thread_purge_interval_s(60);
-    inspector_->m_thread_manager->set_max_thread_table_size(524288);
+    inspector_->m_thread_manager->set_max_thread_table_size(config.GetSinspThreadCacheSize());
 
     // Connection status tracking is used in NetworkSignalHandler,
     // but only when trying to handle asynchronous connections

--- a/docs/references.md
+++ b/docs/references.md
@@ -63,6 +63,12 @@ are there. This parameter affects CO-RE BPF only.
 * `ROX_COLLECTOR_SINSP_BUFFER_SIZE`: Specifies the size of a sinsp buffer in
 bytes. The default value is 16 MB.
 
+* `ROX_COLLECTOR_SINSP_THREAD_CACHE_SIZE`: Puts upper limit on how many
+thread info objects are going to be kept in memory. Since for process-based
+workloads it's the main part of memory consumption, this value effectively
+translates into the upper limit for memory usage. Note, that Falco puts it's
+own upper limit on top of that, which is 2^17.
+
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.
 


### PR DESCRIPTION
## Description

This value is important to manage memory consumption under process based loads, so expose it for configuration. The current value is in fact cut to 131072, and to address memory consumption concerns I've set the current size to the half of this value. 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing Performed

Local testing.