### PR TITLE
New metric to observe the thread cache size

### DIFF
--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -115,6 +115,7 @@ void CollectorStatsExporter::run() {
   auto& preemptions = collectorEventCounters.Add({{"type", "preemptions"}});
   auto& userspaceEvents = collectorEventCounters.Add({{"type", "userspace"}});
   auto& grpcSendFailures = collectorEventCounters.Add({{"type", "grpcSendFailures"}});
+  auto& threadTableSize = collectorEventCounters.Add({{"type", "threadCacheSize"}});
 
   auto& processSent = collectorEventCounters.Add({{"type", "processSent"}});
   auto& processSendFailures = collectorEventCounters.Add({{"type", "processSendFailures"}});
@@ -213,6 +214,7 @@ void CollectorStatsExporter::run() {
     kernel.Set(stats.nEvents);
     drops.Set(stats.nDrops);
     preemptions.Set(stats.nPreemptions);
+    threadTableSize.Set(stats.nThreadCacheSize);
 
     uint64_t nUserspace = 0;
     for (int i = 0; i < PPM_EVENT_MAX; i++) {

--- a/collector/lib/Sysdig.h
+++ b/collector/lib/Sysdig.h
@@ -25,6 +25,7 @@ struct SysdigStats {
   volatile uint64_t nFilteredEvents[PPM_EVENT_MAX] = {0};   // events post filtering
   volatile uint64_t nUserspaceEvents[PPM_EVENT_MAX] = {0};  // events processed by userspace
   volatile uint64_t nGRPCSendFailures = 0;                  // number of signals that were not sent on GRPC
+  volatile uint64_t nThreadCacheSize = 0;                   // number of thread-info entries stored in the cache
 
   // process related metrics
   volatile uint64_t nProcessSent = 0;                       // number of process signals sent

--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -330,6 +330,7 @@ bool SysdigService::GetStats(SysdigStats* stats) const {
   stats->nEvents = kernel_stats.n_evts;
   stats->nDrops = kernel_stats.n_drops;
   stats->nPreemptions = kernel_stats.n_preemptions;
+  stats->nThreadCacheSize = inspector_->m_thread_manager->get_thread_count();
 
   return true;
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -293,6 +293,7 @@ Units: occurence
 | preemptions                            | Number of preemptions (?)                                                                           |
 | userspace[syscall]                     | Number of this kind of event                                                                        |
 | grpcSendFailures                       | (not used?)                                                                                         |
+| threadCacheSize                        | Number of thread-info entries stored in the thread cache (sampled every 5s)                         |
 | processSent                            | Process signal sent with success                                                                    |
 | processSendFailures                    | Failure upon sending a process signal                                                               |
 | processResolutionFailuresByEvt         | Count of invalid process signal events received, then ignored (invalid path or name, or not execve) |


### PR DESCRIPTION
## Description

This implements a simple gauge to report the current size of the thread cache. It is sampled
by the CollectorStatsExporter every 5s.

fixes #1456

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly
- [x] Deployed and verified once that the exported value looks coherent
