### PR TITLE
Reduce sinsp_thread_cache_size

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -118,7 +118,7 @@ class CollectorConfig {
   // the upper boundary for memory consumption. Note that Falco puts it's own
   // upper limit on top of this value, m_thread_table_absolute_max_size, which
   // is 2^17 (131072) and twice as large.
-  unsigned int sinsp_thread_cache_size_ = 65536;
+  unsigned int sinsp_thread_cache_size_ = 32768;
 
   Json::Value tls_config_;
 


### PR DESCRIPTION
## Description

Limit the default amount of threads cached further, to make sure we're on the safe side. Benchmarks show that the CPU overhead is minimal in comparison with EBPF, as CO-RE BPF brings certain performance improvements that balance it out.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

CI is sufficient.