### PR TITLE
Ignore null events after assert

### DIFF
--- a/collector/lib/SysdigService.cpp
+++ b/collector/lib/SysdigService.cpp
@@ -115,11 +115,11 @@ bool SysdigService::InitKernel(const CollectorConfig& config, const DriverCandid
 
 sinsp_evt* SysdigService::GetNext() {
   std::lock_guard<std::mutex> lock(libsinsp_mutex_);
-  sinsp_evt* event;
+  sinsp_evt* event = nullptr;
 
   auto parse_start = NowMicros();
   auto res = inspector_->next(&event);
-  if (res != SCAP_SUCCESS) return nullptr;
+  if (res != SCAP_SUCCESS || event == nullptr) return nullptr;
 
 #ifdef TRACE_SINSP_EVENTS
   // Do not allow to change sinsp events tracing at runtime, as the output


### PR DESCRIPTION
## Description

libsinsp has some number of ASSERT(false) in places that considered to be impossible to reach, one of them in sinsp::next when doing delayed removal of fds. This approach is suboptimal, so in 01496ee1a it was modified to only log the issue and proceed.

https://github.com/stackrox/falcosecurity-libs/blob/main/userspace/libsinsp/sinsp.cpp#L1434

There seem to be a negative consequence of those two factors above combined. While considering an ASSERT impossible to reach, there is a return right after it, which we now reach if ASSERT doesn't stop the execution. This returns a current processing status (could be SUCCESS), yet the event object is not yet passed by reference back to the called, and SysdigService::GetNext ends up with a success status and null pointer for an event.

As a workaround, be more vigilant about the events we process.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Local testing triggering the issue explicitly.