### PR TITLE
Adds a sentinel step to drivers build for release branches

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -25,6 +25,17 @@ env:
   DRIVERS_BUCKET: ${{ inputs.drivers-bucket }}
 
 jobs:
+  # This sentinel job exists such that this workflow call "runs" even
+  # if subsequent driver build steps are skipped. This means that other
+  # workflows can depend on this workflow and still run even if it is skipped
+  #
+  # This only affects release branches, so is limited to those.
+  sentinel:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'release-')
+    steps:
+      - run: echo Drivers Build
+
   split-tasks:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -32,7 +32,7 @@ jobs:
   # This only affects release branches, so is limited to those.
   sentinel:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'release-')
+    if: startsWith(github.ref_name, 'release-') || github.ref_type == 'tag'
     steps:
       - run: echo Drivers Build
 


### PR DESCRIPTION
## Description

Github Actions will skip a job if all of its dependencies are also skipped. This is ordinarily fine, but for release branches we don't want the drivers build to run, but we do want the full builds to run.

This adds a sentinel job in the drivers workflow to ensure that even if the driver build itself is skipped, the workflow runs at least one job, and therefore the full builds will also run.

This will not run on this PR, but I have tested the mechanism on one of my own repositories and it works: https://github.com/Stringy/wisdom/pull/10

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
Tested on my own repo here https://github.com/Stringy/wisdom/pull/10
