### PR TITLE
Use debug for stdout_callback

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-stdout_callback=selective
+stdout_callback=debug
 stderr_callback=debug
 display_skipped_hosts=false
 host_key_checking=False


### PR DESCRIPTION
## Description

Since integration tests are invoked from the ansible directory, they pick up configuration from `ansible.cfg`. Currently, it says that the stdout_callback has to be selective, which means only failed steps are going to be shown. An annoying consequence is that stdout will not be exposed even for failing steps (unless handled explicitly), which makes troubleshooting of some steps harder. Make it debug and verify if this will produce too much logs.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

Local testing for failing steps. Otherwise CI is sufficient.