### PR TITLE
Add retries

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,11 +1,11 @@
 [defaults]
-stdout_callback=debug
-stderr_callback=debug
-display_skipped_hosts=false
-host_key_checking=False
+stdout_callback = debug
+stderr_callback = debug
+display_skipped_hosts = false
+host_key_checking = False
 remote_tmp = /tmp/ansible
 forks = 20
 
 [ssh_connection]
 ssh_args = -o StrictHostKeyChecking=no -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=30 -o ServerAliveCountMax=10
-retries=5
+retries = 5

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -8,3 +8,4 @@ forks = 20
 
 [ssh_connection]
 ssh_args = -o StrictHostKeyChecking=no -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=30 -o ServerAliveCountMax=10
+retries=5

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -2,7 +2,7 @@
 stdout_callback = debug
 stderr_callback = debug
 display_skipped_hosts = false
-host_key_checking = False
+host_key_checking = false
 remote_tmp = /tmp/ansible
 forks = 20
 


### PR DESCRIPTION
## Description

We frequently observe issues with spinning up new test VMs, that manifests itself as a non-reachable host. Try to reduce the problem via increasing number of retries (the default value seems to be 0 [[1]]).

[1]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/ssh_connection.html#parameter-reconnection_retries

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

CI is sufficient.