### PR TITLE
[tests] Use a specific logs entry to detect Collector readiness

### DIFF
--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -102,6 +102,8 @@ void CollectorService::RunForever() {
   sysdig_.Init(config_, conn_tracker);
   sysdig_.Start();
 
+  CLOG(INFO) << "Collector is Ready.";
+
   ControlValue cv;
   while ((cv = control_->load(std::memory_order_relaxed)) != STOP_COLLECTOR) {
     sysdig_.Run(*control_);

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -21,16 +21,9 @@ import (
 )
 
 const (
-	processBucket            = "Process"
-	processLineageInfoBucket = "LineageInfo"
-	networkBucket            = "Network"
-	endpointBucket           = "Endpoint"
-	parentUIDStr             = "ParentUid"
-	parentExecFilePathStr    = "ParentExecFilePath"
-
 	containerStatsName = "container-stats"
 
-	defaultWaitTickSeconds = 5 * time.Second
+	defaultWaitTick = 5 * time.Second
 )
 
 type IntegrationTestSuiteBase struct {
@@ -69,41 +62,7 @@ func (s *IntegrationTestSuiteBase) StartCollector(disableGRPC bool, options *com
 
 	s.Require().NoError(s.Collector().Setup(options))
 	s.Require().NoError(s.Collector().Launch())
-
-	// Verify if the image we test has a health check. There are some CI
-	// configurations, where it's not the case. If something went wrong and we
-	// get an error, treat it as no health check was found for the sake of
-	// robustness.
-	hasHealthCheck, err := s.findContainerHealthCheck("collector",
-		s.Collector().ContainerID)
-
-	if hasHealthCheck && err == nil {
-		// Wait for collector to report healthy, includes initial setup and
-		// probes loading. It doesn't make sense to wait for very long, limit
-		// it to 1 min.
-		_, err := s.waitForContainerToBecomeHealthy(
-			"collector",
-			s.Collector().ContainerID,
-			defaultWaitTickSeconds, 5*time.Minute)
-		s.Require().NoError(err)
-	} else {
-		fmt.Println("No HealthCheck found, do not wait for collector to become healthy")
-
-		// No way to figure out when all the services up and running, skip this
-		// phase.
-	}
-
-	// wait for the canary process to guarantee collector is started
-	selfCheckOk := s.Sensor().WaitProcessesN(
-		s.Collector().ContainerID, 30*time.Second, 1, func() {
-			// Self-check process is not going to be sent via GRPC, instead
-			// create at least one canary process to make sure everything is
-			// fine.
-			fmt.Println("Spawn a canary process")
-			_, err = s.execContainer("collector", []string{"echo"})
-			s.Require().NoError(err)
-		})
-	s.Require().True(selfCheckOk)
+	s.Require().NoError(s.Collector().WaitUntilReady(defaultWaitTick, 5*time.Minute))
 }
 
 // StopCollector will tear down the collector container and stop
@@ -354,16 +313,6 @@ func (s *IntegrationTestSuiteBase) findContainerHealthCheck(
 	}
 }
 
-func (s *IntegrationTestSuiteBase) waitForContainerToBecomeHealthy(
-	containerName string,
-	containerID string,
-	tickSeconds time.Duration,
-	timeoutThreshold time.Duration) (bool, error) {
-
-	return s.waitForContainerStatus(containerName, containerID, tickSeconds,
-		timeoutThreshold, "health=healthy")
-}
-
 func (s *IntegrationTestSuiteBase) waitForContainerToExit(
 	containerName string,
 	containerID string,
@@ -449,7 +398,7 @@ func (s *IntegrationTestSuiteBase) RunCollectorBenchmark() {
 	containerID, err := s.launchContainer(benchmarkName, benchmarkArgs...)
 	s.Require().NoError(err)
 
-	_, err = s.waitForContainerToExit(benchmarkName, containerID, defaultWaitTickSeconds, 0)
+	_, err = s.waitForContainerToExit(benchmarkName, containerID, defaultWaitTick, 0)
 	s.Require().NoError(err)
 
 	benchmarkLogs, err := s.containerLogs("benchmark")

--- a/integration-tests/suites/image_json.go
+++ b/integration-tests/suites/image_json.go
@@ -23,7 +23,7 @@ func (s *ImageLabelJSONTestSuite) TestRunImageWithJSONLabel() {
 	containerID, err := s.launchContainer(name, image)
 	s.Require().NoError(err)
 
-	_, err = s.waitForContainerToExit(name, containerID, defaultWaitTickSeconds, 0)
+	_, err = s.waitForContainerToExit(name, containerID, defaultWaitTick, 0)
 	s.Require().NoError(err)
 }
 


### PR DESCRIPTION
## Description

Emitting a log statement after Collector has completed its startup procedure (including connecting to Sensor)
will prevent loosing some signals during tests.

## Checklist
- [ ] Investigated and inspected CI test results
