### PR TITLE
Split slim builds in local gha runner and remote vm

### DIFF
--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -26,16 +26,41 @@ env:
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
 
 jobs:
+  setup-environment:
+    name: Setup environment
+    runs-on: ubuntu-latest
+    outputs:
+      collector-append-cid: ${{ steps.vars.outputs.collector-append-cid || false }}
+      trace-sinsp-events: ${{ steps.vars.outputs.trace-sinsp-events || false }}
+      address-sanitizer: ${{ steps.vars.outputs.address-sanitizer || false }}
+    steps:
+      - name: Checks PR, main and release branches
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            echo "collector-append-cid=true" >> "$GITHUB_OUTPUT"
+            echo "trace-sinsp-events=1" >> "$GITHUB_OUTPUT"
+
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
+              echo "address-sanitizer=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
   build-collector-image:
     name: Build the collector slim image
     runs-on: ubuntu-latest
+    needs:
+    - setup-environment
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, s390x, arm64]
+        arch: [amd64, ppc64le, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
+      COLLECTOR_APPEND_CID: ${{ needs.setup-environment.outputs.collector-append-cid }}
+      TRACE_SINSP_EVENTS: ${{ needs.setup-environment.outputs.trace-sinsp-events }}
+      ADDRESS_SANITIZER: ${{ needs.setup-environment.outputs.address-sanitizer }}
 
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +72,60 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Create ansible vars
+        run: |
+          {
+            echo "---"
+            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
+            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
+            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
+            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
+            echo "collector_git_ref: ${{ github.ref }}"
+            echo "collector_git_sha: ${{ github.sha }}"
+            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
+            echo "disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}"
+            echo "rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}"
+            echo "collector_image: ${{ inputs.collector-image }}"
+            echo "collector_tag: ${{ inputs.collector-tag }}"
+          } > ${{ github.workspace }}/ansible/secrets.yml
+
+      - name: Build images
+        if: |
+          github.event_name == 'push' ||
+          matrix.arch == 'amd64' ||
+          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+        timeout-minutes: 480
+        run: |
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e arch='${{ matrix.arch }}' \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-collector.yml
+
+  build-collector-image-remote-vm:
+    name: Build the collector slim image on a remote VM
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+    needs:
+    - setup-environment
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [s390x]
+
+    env:
+      PLATFORM: linux/${{ matrix.arch }}
+      COLLECTOR_APPEND_CID: ${{ needs.setup-environment.outputs.collector-append-cid }}
+      TRACE_SINSP_EVENTS: ${{ needs.setup-environment.outputs.trace-sinsp-events }}
+      ADDRESS_SANITIZER: ${{ needs.setup-environment.outputs.address-sanitizer }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/setup-python@v5
         with:
@@ -73,22 +152,8 @@ jobs:
           job-tag: builder
 
       - name: Create Build VMs
-        if: |
-          matrix.arch == 's390x' &&
-          (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
-
-      - name: Checks PR, main and release branches
-        run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            echo "COLLECTOR_APPEND_CID=true" >> "$GITHUB_ENV"
-            echo "TRACE_SINSP_EVENTS=1" >> "$GITHUB_ENV"
-
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
-              echo "ADDRESS_SANITIZER=true" >> "$GITHUB_ENV"
-            fi
-          fi
 
       - name: Create ansible vars
         run: |
@@ -107,33 +172,7 @@ jobs:
             echo "collector_tag: ${{ inputs.collector-tag }}"
           } > ${{ github.workspace }}/ansible/secrets.yml
 
-      - name: Authenticate with GCP
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
-
-      - name: Setup GCP
-        uses: 'google-github-actions/setup-gcloud@v2'
-
-      - name: Build images
-        if: |
-          (github.event_name == 'push' && matrix.arch != 's390x') ||
-          matrix.arch == 'amd64' ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
-        timeout-minutes: 480
-        run: |
-          ansible-playbook \
-            --connection local \
-            -i localhost, \
-            --limit localhost \
-            -e arch='${{ matrix.arch }}' \
-            -e @'${{ github.workspace }}/ansible/secrets.yml' \
-            ansible/ci-build-collector.yml
-
-      - name: Build s390x image
-        if: |
-          (github.event_name == 'push' && matrix.arch == 's390x') ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
+      - name: Build ${{ matrix.arch }} image
         timeout-minutes: 480
         run: |
           ansible-playbook \
@@ -143,16 +182,18 @@ jobs:
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-collector.yml
         env:
-          VM_TYPE: rhel-s390x
+          VM_TYPE: rhel-${{ matrix.arch }}
 
       - name: Destroy Build VMs
-        if: always() && matrix.arch == 's390x'
+        if: always()
         run: |
           make -C ansible destroy-vms
+
 
   create-multiarch-manifest:
     needs:
     - build-collector-image
+    - build-collector-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -24,33 +24,14 @@ env:
   COLLECTOR_BUILDER_TAG: ${{ inputs.collector-builder-tag }}
   RHACS_ENG_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
+  COLLECTOR_APPEND_CID: ${{ github.event_name == 'pull_request' }}
+  TRACE_SINSP_EVENTS: ${{ github.event_name == 'pull_request' }}
+  ADDRESS_SANITIZER: ${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}
 
 jobs:
-  setup-environment:
-    name: Setup environment
-    runs-on: ubuntu-latest
-    outputs:
-      collector-append-cid: ${{ steps.vars.outputs.collector-append-cid || false }}
-      trace-sinsp-events: ${{ steps.vars.outputs.trace-sinsp-events || false }}
-      address-sanitizer: ${{ steps.vars.outputs.address-sanitizer || false }}
-    steps:
-      - name: Checks PR, main and release branches
-        id: vars
-        run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            echo "collector-append-cid=true" >> "$GITHUB_OUTPUT"
-            echo "trace-sinsp-events=1" >> "$GITHUB_OUTPUT"
-
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}" == "true" ]]; then
-              echo "address-sanitizer=true" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
   build-collector-image:
     name: Build the collector slim image
     runs-on: ubuntu-latest
-    needs:
-    - setup-environment
     strategy:
       fail-fast: false
       matrix:
@@ -58,9 +39,6 @@ jobs:
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
-      COLLECTOR_APPEND_CID: ${{ needs.setup-environment.outputs.collector-append-cid }}
-      TRACE_SINSP_EVENTS: ${{ needs.setup-environment.outputs.trace-sinsp-events }}
-      ADDRESS_SANITIZER: ${{ needs.setup-environment.outputs.address-sanitizer }}
 
     steps:
       - uses: actions/checkout@v4
@@ -109,8 +87,6 @@ jobs:
     name: Build the collector slim image on a remote VM
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-    needs:
-    - setup-environment
     strategy:
       fail-fast: false
       matrix:
@@ -118,9 +94,6 @@ jobs:
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
-      COLLECTOR_APPEND_CID: ${{ needs.setup-environment.outputs.collector-append-cid }}
-      TRACE_SINSP_EVENTS: ${{ needs.setup-environment.outputs.trace-sinsp-events }}
-      ADDRESS_SANITIZER: ${{ needs.setup-environment.outputs.address-sanitizer }}
 
     steps:
       - uses: actions/checkout@v4
@@ -184,7 +157,6 @@ jobs:
         if: always()
         run: |
           make -C ansible destroy-vms
-
 
   create-multiarch-manifest:
     needs:

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -124,8 +124,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - uses: actions/setup-python@v5
         with:
@@ -148,7 +146,7 @@ jobs:
           ppc64le-key: ${{ secrets.IBM_CLOUD_POWER_API_KEY }}
           redhat-username: ${{ secrets.REDHAT_USERNAME }}
           redhat-password: ${{ secrets.REDHAT_PASSWORD }}
-          vm-type: all
+          vm-type: rhel-${{ matrix.arch }}
           job-tag: builder
 
       - name: Create Build VMs
@@ -181,8 +179,6 @@ jobs:
             -e build_hosts='job_id_${{ env.JOB_ID }}' \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-collector.yml
-        env:
-          VM_TYPE: rhel-${{ matrix.arch }}
 
       - name: Destroy Build VMs
         if: always()

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -75,20 +75,20 @@ jobs:
 
       - name: Create ansible vars
         run: |
-          {
-            echo "---"
-            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
-            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
-            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
-            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
-            echo "collector_git_ref: ${{ github.ref }}"
-            echo "collector_git_sha: ${{ github.sha }}"
-            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
-            echo "disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}"
-            echo "rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}"
-            echo "collector_image: ${{ inputs.collector-image }}"
-            echo "collector_tag: ${{ inputs.collector-tag }}"
-          } > ${{ github.workspace }}/ansible/secrets.yml
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_git_sha: ${{ github.sha }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}
+          rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
+          collector_image: ${{ inputs.collector-image }}
+          collector_tag: ${{ inputs.collector-tag }}
+          EOF
 
       - name: Build images
         if: |
@@ -157,20 +157,20 @@ jobs:
 
       - name: Create ansible vars
         run: |
-          {
-            echo "---"
-            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
-            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
-            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
-            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
-            echo "collector_git_ref: ${{ github.ref }}"
-            echo "collector_git_sha: ${{ github.sha }}"
-            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
-            echo "disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}"
-            echo "rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}"
-            echo "collector_image: ${{ inputs.collector-image }}"
-            echo "collector_tag: ${{ inputs.collector-tag }}"
-          } > ${{ github.workspace }}/ansible/secrets.yml
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_git_sha: ${{ github.sha }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}
+          rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
+          collector_image: ${{ inputs.collector-image }}
+          collector_tag: ${{ inputs.collector-tag }}
+          EOF
 
       - name: Build ${{ matrix.arch }} image
         timeout-minutes: 480


### PR DESCRIPTION
## Description

This separation should make it a little easier to follow the workflows, since each of them will only have the steps needed for the type of build taking place. Additional motivation for this is in having better handling of external PRs, since a PR from a fork will not have the required credentials to create a remote VM in our GCP projects.

For the time being, this is very much some personal investigating and team feedback is very much needed.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Run with the `run-multiarch-builds` label
- [x] Run without the `run-multiarch-builds` label.