### PR TITLE
Update peter-evans/create-pull-request action to latest version

### DIFF
--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -3,7 +3,6 @@ name: Garden Linux VM bumper
 on:
   schedule:
     - cron: '0 6 * * *'
-  pull_request:
 
 jobs:
   run-bumper:
@@ -34,7 +33,6 @@ jobs:
           committer: RoxBot <roxbot@stackrox.com>
           author: RoxBot <roxbot@stackrox.com>
           branch: roxbot/gardenlinux-bump
-          base: master
           signoff: false
           delete-branch: true
           title: Update Garden Linux VM

--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -3,6 +3,7 @@ name: Garden Linux VM bumper
 on:
   schedule:
     - cron: '0 6 * * *'
+  pull_request:
 
 jobs:
   run-bumper:
@@ -26,7 +27,7 @@ jobs:
             ${{ github.workspace }}/ansible/group_vars/gardenlinux-image.txt
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: '${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}'
           commit-message: Update Garden Linux VM

--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -34,6 +34,7 @@ jobs:
           committer: RoxBot <roxbot@stackrox.com>
           author: RoxBot <roxbot@stackrox.com>
           branch: roxbot/gardenlinux-bump
+          base: master
           signoff: false
           delete-branch: true
           title: Update Garden Linux VM


### PR DESCRIPTION
## Description

This should fix an error with a change to a GH API that broke the action.

See https://newreleases.io/project/github/peter-evans/create-pull-request/release/v6.0.1 for more details.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Run the bumper action from this PR. ([CI run](https://github.com/stackrox/collector/actions/runs/8154331183/job/22287533439?pr=1586)) ([PR created](https://github.com/stackrox/collector/pull/1587))
