### PR TITLE
Fixes duplicate driver artifacts when build uses multiple GHA runners

### DIFF
--- a/.github/workflows/check-drivers-failures.yml
+++ b/.github/workflows/check-drivers-failures.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Restore failure files
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.logs-artifact }}
+          pattern: ${{ inputs.logs-artifact }}
+          merge-multiple: true
           path: /tmp/FAILURES
 
       - name: Check build failures

--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -71,7 +71,8 @@ jobs:
         uses: actions/download-artifact@v4
         if: matrix.arch == 'amd64' && !inputs.skip-built-drivers
         with:
-          name: built-drivers
+          pattern: built-drivers-*
+          merge-multiple: true
           path: /tmp/built-drivers/
 
       - name: Set environment variables

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Store built drivers
         uses: actions/upload-artifact@v4
         with:
-          name: built-drivers
+          name: built-drivers-${{ matrix.builder }}
           path: /tmp/output
           if-no-files-found: ignore
           retention-days: 1
@@ -246,7 +246,7 @@ jobs:
       - name: Store build failures
         uses: actions/upload-artifact@v4
         with:
-          name: driver-build-failures
+          name: driver-build-failures-${{ matrix.builder }}
           path: /tmp/FAILURES
           if-no-files-found: ignore
           retention-days: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     if: ${{ needs.build-drivers.outputs.parallel-jobs > 0 }}
     secrets: inherit
     with:
-      logs-artifact: driver-build-failures
+      logs-artifact: driver-build-failures-*
 
   build-builder-image:
     uses: ./.github/workflows/collector-builder.yml

--- a/.github/workflows/upload-drivers.yml
+++ b/.github/workflows/upload-drivers.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Restore built drivers
         uses: actions/download-artifact@v4
         with:
-          name: built-drivers
+          pattern: built-drivers-*
+          merge-multiple: true
           path: /tmp/output/
 
       - name: Authenticate with GCP


### PR DESCRIPTION
## Description

When the various GHA actions were updated, I missed a couple of breaking changes in the drivers build, specifically that multiple artifacts with the same name are no longer supported. This PR handles that case by making the names unique and ensuring they're downloaded appropriately.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI with multiple driver runners should do it.
