### PR TITLE
Native multiarch image builds

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -11,7 +11,7 @@ on:
     outputs:
       collector-builder-tag:
         description: The builder tag used by the build
-        value: ${{ jobs.builder-setup-environment.outputs.collector-builder-tag }}
+        value: ${{ jobs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       build-image: ${{ steps.changed.outputs.builder-changed }}
+      collector-builder-tag: ${{ steps.set-builder-tag.outputs.collector-builder-tag || 'master' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,14 +39,14 @@ jobs:
               - builder/Dockerfile
               - .github/workflows/collector-builder.yml
 
-  builder-setup-environment:
-    name: Setup environment
-    runs-on: ubuntu-latest
-    outputs:
-      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
-    steps:
-      - name: Define builder tag
-        id: builder-tag
+      - name: Set builder tag
+        id: set-builder-tag
+        if: |
+          steps.changed.outputs.builder-changed == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'build-builder-image') || (
+            github.event_name == 'push' && (
+              github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
+          ))
         run: |
           COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
           if [[ "${{ github.event_name }}" == 'pull_request' || \
@@ -62,7 +63,6 @@ jobs:
     timeout-minutes: 480
     needs:
     - builder-needs-rebuilding
-    - builder-setup-environment
     if: |
       needs.builder-needs-rebuilding.outputs.build-image == 'true' ||
       (github.event_name == 'push' && (
@@ -72,12 +72,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
       BUILD_TYPE: ci
-      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -104,10 +104,6 @@ jobs:
           EOF
 
       - name: Build images
-        if: |
-          github.event_name == 'push' ||
-          matrix.arch == 'amd64' ||
-          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
@@ -126,7 +122,6 @@ jobs:
     timeout-minutes: 480
     needs:
     - builder-needs-rebuilding
-    - builder-setup-environment
     if: |
       needs.builder-needs-rebuilding.outputs.build-image == 'true' || (
         github.event_name == 'push' && (
@@ -138,12 +133,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ppc64le, s390x]
+        arch: [ppc64le, s390x, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
       BUILD_TYPE: ci
-      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -206,18 +201,18 @@ jobs:
 
   create-multiarch-manifest:
     needs:
-    - builder-setup-environment
+    - builder-needs-rebuilding
     - build-builder-image
     - build-builder-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' || (
-        needs.builder-setup-environment.outputs.collector-builder-tag != 'master' &&
-       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+        needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
       )
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x arm64
 
     steps:
@@ -251,16 +246,16 @@ jobs:
 
   retag-x86-image:
     needs:
-    - builder-setup-environment
+    - builder-needs-rebuilding
     - build-builder-image
     name: Retag x86 builder image
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' &&
-      needs.builder-setup-environment.outputs.collector-builder-tag != 'master' &&
+      needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
       !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
     steps:
       - name: Pull image to retag
         run: |

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -73,6 +73,64 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create ansible vars
+        run: |
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_git_sha: ${{ github.sha }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          EOF
+
+      - name: Build images
+        if: |
+          github.event_name == 'push' ||
+          matrix.arch == 'amd64' ||
+          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+        timeout-minutes: 480
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e arch='${{ matrix.arch }}' \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-builder.yml
+
+  build-builder-image-remote-vm:
+    name: Build the builder image
+    runs-on: ubuntu-latest
+    # Multiarch builds sometimes take for eeeeeeeeeever
+    timeout-minutes: 480
+    needs:
+    - builder-needs-rebuilding
+    - builder-setup-environment
+    if: |
+      needs.builder-needs-rebuilding.outputs.build-image == 'true' || (
+        github.event_name == 'push' && (
+        github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
+      )) || (
+        contains(github.event.pull_request.labels.*.name, 'build-builder-image') &&
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ppc64le, s390x]
+
+    env:
+      PLATFORM: linux/${{ matrix.arch }}
+      BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -94,7 +152,7 @@ jobs:
           ppc64le-key: ${{ secrets.IBM_CLOUD_POWER_API_KEY }}
           redhat-username: ${{ secrets.REDHAT_USERNAME }}
           redhat-password: ${{ secrets.REDHAT_PASSWORD }}
-          vm-type: all
+          vm-type: rhel-${{ matrix.arch }}
           job-tag: builder
 
       - name: Create Build VMs

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -11,7 +11,7 @@ on:
     outputs:
       collector-builder-tag:
         description: The builder tag used by the build
-        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag || 'master' }}
+        value: ${{ jobs.builder-setup-environment.outputs.collector-builder-tag }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -38,6 +38,23 @@ jobs:
               - builder/Dockerfile
               - .github/workflows/collector-builder.yml
 
+  builder-setup-environment:
+    name: Setup environment
+    runs-on: ubuntu-latest
+    outputs:
+      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
+    steps:
+      - name: Define builder tag
+        id: builder-tag
+        run: |
+          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
+          if [[ "${{ github.event_name }}" == 'pull_request' || \
+                "${{ github.ref_type }}" == 'tag' || \
+                "${{ github.ref_name }}" =~ ^release- ]]; then
+            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
+          fi
+          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
+
   build-builder-image:
     name: Build the builder image
     runs-on: ubuntu-latest
@@ -45,22 +62,22 @@ jobs:
     timeout-minutes: 480
     needs:
     - builder-needs-rebuilding
+    - builder-setup-environment
     if: |
       needs.builder-needs-rebuilding.outputs.build-image == 'true' ||
       (github.event_name == 'push' && (
         github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
       )) ||
       contains(github.event.pull_request.labels.*.name, 'build-builder-image')
-    outputs:
-      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, s390x, arm64]
+        arch: [amd64, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
       BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -156,58 +173,23 @@ jobs:
           job-tag: builder
 
       - name: Create Build VMs
-        if: |
-          matrix.arch == 's390x' &&
-          (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
 
-      - name: Define builder tag
-        id: builder-tag
-        run: |
-          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
-          if [[ "${{ github.event_name }}" == 'pull_request' || \
-                "${{ github.ref_type }}" == 'tag' || \
-                "${{ github.ref_name }}" =~ ^release- ]]; then
-            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
-          fi
-
-          echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
-          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Create ansible vars
         run: |
-          {
-            echo "---"
-            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
-            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
-            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
-            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
-            echo "collector_git_ref: ${{ github.ref }}"
-            echo "collector_git_sha: ${{ github.sha }}"
-            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
-          } > ${{ github.workspace }}/ansible/secrets.yml
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_git_sha: ${{ github.sha }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          EOF
 
       - name: Build images
-        if: |
-          (github.event_name == 'push' && matrix.arch != 's390x') ||
-          matrix.arch == 'amd64' ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
-        timeout-minutes: 480
-        run: |
-          ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook \
-            --connection local \
-            -i localhost, \
-            --limit localhost \
-            -e arch='${{ matrix.arch }}' \
-            -e @'${{ github.workspace }}/ansible/secrets.yml' \
-            ansible/ci-build-builder.yml
-
-      - name: Build s390x images
-        if: |
-          (github.event_name == 'push' && matrix.arch == 's390x') ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
         timeout-minutes: 480
         run: |
           ansible-playbook \
@@ -218,21 +200,24 @@ jobs:
             ansible/ci-build-builder.yml
 
       - name: Destroy VMs
-        if: always() && matrix.arch == 's390x'
+        if: always()
         run: |
           make -C ansible destroy-vms
 
   create-multiarch-manifest:
     needs:
+    - builder-setup-environment
     - build-builder-image
+    - build-builder-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'push' ||
-      (needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
+      github.event_name == 'push' || (
+        needs.builder-setup-environment.outputs.collector-builder-tag != 'master' &&
+       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x arm64
 
     steps:
@@ -266,15 +251,16 @@ jobs:
 
   retag-x86-image:
     needs:
+    - builder-setup-environment
     - build-builder-image
     name: Retag x86 builder image
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request' &&
-      needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
+      needs.builder-setup-environment.outputs.collector-builder-tag != 'master' &&
       !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-setup-environment.outputs.collector-builder-tag }}
     steps:
       - name: Pull image to retag
         run: |

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -101,6 +101,7 @@ jobs:
           collector_git_ref: ${{ github.ref }}
           collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          clone_repository: false
           EOF
 
       - name: Build images
@@ -182,6 +183,7 @@ jobs:
           collector_git_ref: ${{ github.ref }}
           collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          clone_repository: true
           EOF
 
       - name: Build images

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, arm64]
+        arch: [amd64, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
@@ -125,6 +125,8 @@ jobs:
       - name: Create Build VMs
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
+        env:
+          VM_TYPE: rhel-${{ matrix.arch }}
 
       - name: Create ansible vars
         run: |
@@ -137,7 +139,7 @@ jobs:
           collector_git_ref: ${{ github.ref }}
           collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
-          disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}
+          disable_profiling: true
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
           collector_image: ${{ inputs.collector-image }}
           collector_tag: ${{ inputs.collector-tag }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64, ppc64le]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
@@ -62,18 +62,18 @@ jobs:
           collector_git_ref: ${{ github.ref }}
           collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
-          disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}
+          disable_profiling: ${{ matrix.arch == 'amd64' }}
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
           collector_image: ${{ inputs.collector-image }}
           collector_tag: ${{ inputs.collector-tag }}
           EOF
 
       - name: Build images
+        timeout-minutes: 480
         if: |
           github.event_name == 'push' ||
           matrix.arch == 'amd64' ||
           contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-        timeout-minutes: 480
         run: |
           ansible-playbook \
             --connection local \
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [s390x]
+        arch: [ppc64le, s390x, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
@@ -125,8 +125,6 @@ jobs:
       - name: Create Build VMs
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
-        env:
-          VM_TYPE: rhel-${{ matrix.arch }}
 
       - name: Create ansible vars
         run: |
@@ -139,7 +137,7 @@ jobs:
           collector_git_ref: ${{ github.ref }}
           collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
-          disable_profiling: true
+          disable_profiling: ${{ matrix.arch == 'arm64' }}
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
           collector_image: ${{ inputs.collector-image }}
           collector_tag: ${{ inputs.collector-tag }}

--- a/.github/workflows/collector-slim.yml
+++ b/.github/workflows/collector-slim.yml
@@ -66,6 +66,7 @@ jobs:
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
           collector_image: ${{ inputs.collector-image }}
           collector_tag: ${{ inputs.collector-tag }}
+          clone_repository: false
           EOF
 
       - name: Build images
@@ -90,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ppc64le, s390x, arm64]
+        arch: [s390x, arm64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
@@ -141,6 +142,7 @@ jobs:
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
           collector_image: ${{ inputs.collector-image }}
           collector_tag: ${{ inputs.collector-tag }}
+          clone_repository: true
           EOF
 
       - name: Build ${{ matrix.arch }} image

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -18,7 +18,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch != "amd64"
+      when: clone_repository
 
     - name: Build the collector builder image
       community.general.make:

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -18,7 +18,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch == "s390x"
+      when: arch == "s390x" or arch == "ppc64le"
 
     - name: Build the collector builder image
       community.general.make:

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -16,7 +16,7 @@
         repo: https://github.com/stackrox/collector
         dest: "{{ collector_root }}"
         version: "{{ collector_git_sha }}"
-        refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
+        refspec: "+{{ collector_git_ref }}"
         recursive: true
       when: clone_repository
 

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -18,7 +18,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch == "s390x" or arch == "ppc64le"
+      when: arch != "amd64"
 
     - name: Build the collector builder image
       community.general.make:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -20,7 +20,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch == "s390x" or arch == "ppc64le"
+      when: arch != "amd64"
 
     - name: Run the builder image
       community.general.make:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -20,7 +20,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch != "amd64"
+      when: clone_repository
 
     - name: Run the builder image
       community.general.make:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -20,7 +20,7 @@
         version: "{{ collector_git_sha }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
         recursive: true
-      when: arch == "s390x"
+      when: arch == "s390x" or arch == "ppc64le"
 
     - name: Run the builder image
       community.general.make:

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -18,7 +18,7 @@
         repo: https://github.com/stackrox/collector
         dest: "{{ collector_root }}"
         version: "{{ collector_git_sha }}"
-        refspec: "+{{ collector_git_ref | replace('refs/', '') }}"
+        refspec: "+{{ collector_git_ref }}"
         recursive: true
       when: clone_repository
 

--- a/ansible/ci-create-build-vms.yml
+++ b/ansible/ci-create-build-vms.yml
@@ -9,6 +9,10 @@
         name: create-all-vms
       vars:
         vm_list: "{{ virtual_machines }}"
+  post_tasks:
+    # We have all the VMs created now, so refresh the inventory - this allows
+    # us to use the provisioning role on the VMs we just created
+    - meta: refresh_inventory
 
 - name: Provision Build VMs
   hosts: "job_id_{{ job_id }}"

--- a/ansible/ci-create-build-vms.yml
+++ b/ansible/ci-create-build-vms.yml
@@ -8,9 +8,7 @@
       include_role:
         name: create-all-vms
       vars:
-        vm_list:
-          # s390x
-          rhel-s390x: "{{ virtual_machines['rhel-s390x'] }}"
+        vm_list: "{{ virtual_machines }}"
 
 - name: Provision Build VMs
   hosts: "job_id_{{ job_id }}"


### PR DESCRIPTION
## Description

Rework de builder image workflow in a way similar to the slim image build on #1585. Move multiarch image builds so they are built as fast as possible. After some testing, most multiarch images are substantially faster on remote VMs, except for the slim image for ppc64le, which takes longer than building on GHA due to it taking a long time to provision.

There's a couple potential follow ups to this PR:
- Improve ppc64le VMs provisioning times.
- Unify builder and slim image builds so VMs can be reused when both images are needed to be built. This can be achieved by either moving more logic into ansible or brute forcing GHA.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed
- [x] Run with no labels. ([CI run](https://github.com/stackrox/collector/actions/runs/8296681816?pr=1593))
- [x] Run with the `build-builder-image` label. ([CI run](https://github.com/stackrox/collector/actions/runs/8297092431?pr=1593))
- [x] Run with the `run-multiarch-builds` label. ([CI run](https://github.com/stackrox/collector/actions/runs/8295721795?pr=1593))
- [x] Run with both the `build-builder-image` and `run-multiarch-builds` labels. ([CI run](https://github.com/stackrox/collector/actions/runs/8293080107?pr=1593))
