### PR TITLE
Block probes <=2.9.0 for linux >=6.7

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -77,6 +77,8 @@
 # ROX-20541 - 6.6 kernel compilation errors
 6.6.* 2.6.0
 6.6.* 2.7.0
+# kernel 6.7 compilation errors fixed in 2.9.1
+~6\.[7-9]\.\d+.* ~(?:2\.[0-8]\.\d+(?:-rc\d+)?|2\.9\.0)
 # Block kernel module builds on all kernels
 # for module versions newer than 2.4.0
 * ~2\.[5-9]\.\d+(?:-rc\d+)? mod


### PR DESCRIPTION
## Description

6.7 fix is only available from 2.9.1 and on, for now.

## Checklist
- [x] Investigated and inspected CI test results
