### PR TITLE
ROX-18383: remove upstream drivers from support packages

### DIFF
--- a/.github/actions/support-package-metadata-json/metadata.py
+++ b/.github/actions/support-package-metadata-json/metadata.py
@@ -11,19 +11,22 @@ def main():
     for mod_ver in os.listdir(support_pkg_dir):
         version_dir = os.path.join(support_pkg_dir, mod_ver)
 
-        with open(os.path.join(version_dir, 'latest'), 'r') as f:
-            latest_file = f.readline().strip()
+        try:
+            with open(os.path.join(version_dir, 'latest'), 'r') as f:
+                latest_file = f.readline().strip()
 
-            st = os.stat(os.path.join(version_dir, latest_file))
-            last_mod_time = datetime.utcfromtimestamp(st.st_mtime).strftime('%Y/%m/%d, %H:%M:%S')
+                st = os.stat(os.path.join(version_dir, latest_file))
+                last_mod_time = datetime.utcfromtimestamp(st.st_mtime).strftime('%Y/%m/%d, %H:%M:%S')
 
-            metadata = {
-                'file_name': latest_file,
-                'last_modified': last_mod_time,
-            }
+                metadata = {
+                    'file_name': latest_file,
+                    'last_modified': last_mod_time,
+                }
 
-            with open(os.path.join(version_dir, 'metadata.json'), 'w') as output:
-                json.dump(metadata, output)
+                with open(os.path.join(version_dir, 'metadata.json'), 'w') as output:
+                    json.dump(metadata, output)
+        except NotADirectoryError:
+            continue
 
 
 if __name__ == '__main__':

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -74,13 +74,10 @@ jobs:
           empty=()
           for mod_ver_dir in /tmp/support-packages/output/*; do
             mod_ver="$(basename "$mod_ver_dir")"
-            for pkg in "$mod_ver_dir"/*.zip; do
-              if ! unzip -l "$pkg" | grep -q "\.gz$"; then
-                empty+=("$mod_ver")
-                rm -rf "$mod_ver_dir"
-                break
-              fi
-            done
+            if [[ -e "$mod_ver_dir/empty" ]]; then
+              empty+=("$mod_ver")
+              rm -rf "$mod_ver_dir"
+            fi
           done
 
           if ((${#empty[@]})); then

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -68,25 +68,6 @@ jobs:
             /tmp/support-packages/output \
             gs://${{ inputs.downstream-drivers-bucket }}
 
-      - name: Check empty support packages
-        id: empty-check
-        run: |
-          empty=()
-          for mod_ver_dir in /tmp/support-packages/output/*; do
-            mod_ver="$(basename "$mod_ver_dir")"
-            if [[ -e "$mod_ver_dir/empty" ]]; then
-              empty+=("$mod_ver")
-              rm -rf "$mod_ver_dir"
-            fi
-          done
-
-          if ((${#empty[@]})); then
-            echo 2>&1 "Found empty support packages for module versions: ${empty[*]}"
-            echo "has-empty-packages=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-empty-packages=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create metadata.json
         uses: ./.github/actions/support-package-metadata-json
         with:
@@ -145,7 +126,8 @@ jobs:
 
       - name: Fail if empty support packages
         run: |
-          if [[ "${{ steps.empty-check.outputs.has-empty-packages }}" == "true" ]]; then
+          if [[ -e /tmp/support-packages/output/empty ]]; then
+            awk '{ print "[ERROR] found empty support package: ", $0 }' /tmp/support-packages/output/empty
             exit 1
           fi
 

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -68,6 +68,28 @@ jobs:
             /tmp/support-packages/output \
             gs://${{ inputs.downstream-drivers-bucket }}
 
+      - name: Check empty support packages
+        id: empty-check
+        run: |
+          empty=()
+          for mod_ver_dir in /tmp/support-packages/output/*; do
+            mod_ver="$(basename "$mod_ver_dir")"
+            for pkg in "$mod_ver_dir"/*.zip; do
+              if ! unzip -l "$pkg" | grep -q "\.gz$"; then
+                empty+=("$mod_ver")
+                rm -rf "$mod_ver_dir"
+                break
+              fi
+            done
+          done
+
+          if ((${#empty[@]})); then
+            echo 2>&1 "Found empty support packages for module versions: ${empty[*]}"
+            echo "has-empty-packages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-empty-packages=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create metadata.json
         uses: ./.github/actions/support-package-metadata-json
         with:
@@ -123,6 +145,12 @@ jobs:
           path: /tmp/driver-matrix.json
           parent: false
           destination: ${{ inputs.public-support-packages-bucket }}
+
+      - name: Fail if empty support packages
+        run: |
+          if [[ "${{ steps.empty-check.outputs.has-empty-packages }}" == "true" ]]; then
+            exit 1
+          fi
 
       - name: Slack notification
         if: failure() && github.event_name == 'push'

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -48,7 +48,12 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     # For now we create *full* kernel support packages, not only deltas, in order to
     # support the slim collector use-case.
     # Remains to be clarified; we might provide more fine granular download options in the future.
-    gsutil -m cp "${COLLECTOR_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
+
+    # From 2.9.0 support packages only include downstream built drivers
+    if ! use_downstream_only "$mod_ver"; then
+        gsutil -m cp "${COLLECTOR_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
+    fi
+
     if use_downstream "$mod_ver" && bucket_has_drivers "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz"; then
         gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
     fi

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -58,17 +58,17 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
         gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
     fi
 
-    package_out_dir="${OUT_DIR}/${mod_ver}"
-    mkdir -p "$package_out_dir"
-    filename="support-pkg-${mod_ver}-$(date '+%Y%m%d%H%M%S').zip"
-    latest_filename="support-pkg-${mod_ver}-latest.zip"
-
     if [[ -z "$(ls -A "$probe_dir")" ]]; then
         # non-fatal here to ensure all module versions are processed
         echo >&2 "[WARNING] no probes downloaded for ${mod_ver}"
         echo "${mod_ver}" >> "${OUT_DIR}/empty"
         continue
     fi
+
+    package_out_dir="${OUT_DIR}/${mod_ver}"
+    mkdir -p "$package_out_dir"
+    filename="support-pkg-${mod_ver}-$(date '+%Y%m%d%H%M%S').zip"
+    latest_filename="support-pkg-${mod_ver}-latest.zip"
 
     cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
 

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -58,6 +58,10 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
         gsutil -m cp "${DOWNSTREAM_MODULES_BUCKET}/${mod_ver}/*.gz" "$probe_dir"
     fi
 
+    if [[ -z "$(ls -A "$probe_dir")" ]]; then
+        die "No probes downloaded for ${mod_ver}"
+    fi
+
     package_out_dir="${OUT_DIR}/${mod_ver}"
     mkdir -p "$package_out_dir"
     filename="support-pkg-${mod_ver}-$(date '+%Y%m%d%H%M%S').zip"

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -66,17 +66,19 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     if [[ -z "$(ls -A "$probe_dir")" ]]; then
         # non-fatal here to ensure all module versions are processed
         echo >&2 "[WARNING] no probes downloaded for ${mod_ver}"
+        touch "${package_out_dir}/empty"
+    else
+        cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
+
+        compress_files "$package_root" "${package_out_dir}/${filename}"
+        generate_checksum "${package_out_dir}" "${filename}"
+
+        # Export the latest build filename
+        echo "${filename}" > "${package_out_dir}/latest"
+
+        cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
+        generate_checksum "${package_out_dir}" "${latest_filename}"
     fi
 
-    cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
-
-    compress_files "$package_root" "${package_out_dir}/${filename}"
-    generate_checksum "${package_out_dir}" "${filename}"
-
-    # Export the latest build filename
-    echo "${filename}" > "${package_out_dir}/latest"
-
-    cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
-    generate_checksum "${package_out_dir}" "${latest_filename}"
     rm -rf "$package_root" || true
 done

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -66,19 +66,20 @@ for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     if [[ -z "$(ls -A "$probe_dir")" ]]; then
         # non-fatal here to ensure all module versions are processed
         echo >&2 "[WARNING] no probes downloaded for ${mod_ver}"
-        touch "${package_out_dir}/empty"
-    else
-        cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
-
-        compress_files "$package_root" "${package_out_dir}/${filename}"
-        generate_checksum "${package_out_dir}" "${filename}"
-
-        # Export the latest build filename
-        echo "${filename}" > "${package_out_dir}/latest"
-
-        cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
-        generate_checksum "${package_out_dir}" "${latest_filename}"
+        echo "${mod_ver}" >> "${OUT_DIR}/empty"
+        continue
     fi
+
+    cp "${LICENSE_FILE}" "${probe_dir}"/LICENSE
+
+    compress_files "$package_root" "${package_out_dir}/${filename}"
+    generate_checksum "${package_out_dir}" "${filename}"
+
+    # Export the latest build filename
+    echo "${filename}" > "${package_out_dir}/latest"
+
+    cp "${package_out_dir}/${filename}" "${package_out_dir}/${latest_filename}"
+    generate_checksum "${package_out_dir}" "${latest_filename}"
 
     rm -rf "$package_root" || true
 done

--- a/kernel-modules/support-packages/utils.sh
+++ b/kernel-modules/support-packages/utils.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 
-use_downstream() {
-    if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(:?-rc?[0-9]+)?$ ]]; then
+_check_min_version() {
+    local version_re="^[0-9]+\.[0-9]+\.[0-9]+(:?-rc?[0-9]+)?$"
+
+    if [[ ! "$1" =~ $version_re ]]; then
         echo >&2 "Error: Invalid version number format '$1'"
         exit 1
     fi
 
+    if [[ ! "$1" =~ $version_re ]]; then
+        echo >&2 "Error: Invalid version number format '$2'"
+        exit 1
+    fi
+
     IFS='.' read -ra version <<< "${1%-*}"
-    min_version=(2 6 0)
+    IFS='.' read -ra min_version <<< "${1%-*}"
 
     for ((i = 0; i < ${#min_version[@]}; i++)); do
         if ((version[i] < min_version[i])); then
@@ -16,6 +23,14 @@ use_downstream() {
     done
 
     return 0
+}
+
+use_downstream() {
+    _check_min_version "$1" "2.6.0"
+}
+
+use_downstream_only() {
+    _check_min_version "$1" "2.9.0"
 }
 
 bucket_has_drivers() {


### PR DESCRIPTION
## Description

As part of the 4.4 release, upstream drivers are being removed from full images as well as support packages, relying instead on downstream built drivers.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
