### PR TITLE
Fix write warning in abort handler

### DIFF
--- a/collector/lib/AbortHandler.cpp
+++ b/collector/lib/AbortHandler.cpp
@@ -75,7 +75,7 @@ extern "C" void AbortHandler(int signum) {
   }
 
   if (n_frames == max_frames)
-    write(STDERR_FILENO, "[truncated]\n", 14);
+    write(STDERR_FILENO, "[truncated]\n", 13);
 
   // Write a message to stderr using only reentrant functions.
   num_bytes = snprintf(message_buffer, message_buffer_size,


### PR DESCRIPTION
## Description

Fix annoying small warning about copying one-by-off.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.