### PR TITLE
Enable slim threadinfo option

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -84,6 +84,7 @@ set(USE_BUNDLED_CARES OFF CACHE BOOL "Enable bundled dependencies instead of usi
 set(WITH_CHISEL OFF CACHE BOOL "Include chisel implementation" FORCE)
 set(BUILD_LIBSCAP_GVISOR OFF CACHE BOOL "Do not build gVisor support" FORCE)
 set(MINIMAL_BUILD OFF CACHE BOOL "Minimal" FORCE)
+set(SINSP_SLIM_THREADINFO ON CACHE BOOL "Slim threadinfo" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build position independent libraries and executables" FORCE)
 set(LIBELF_LIB_SUFFIX ".so" CACHE STRING "Use libelf.so" FORCE)
 

--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -183,8 +183,8 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_threadinfo* tin
   signal->set_pid(tinfo->m_pid);
 
   // set user and group id credentials
-  signal->set_uid(tinfo->m_user.uid);
-  signal->set_gid(tinfo->m_group.gid);
+  signal->set_uid(tinfo->m_user.uid());
+  signal->set_gid(tinfo->m_group.gid());
 
   // set time
   auto timestamp = Allocate<Timestamp>();
@@ -300,7 +300,7 @@ void ProcessSignalFormatter::GetProcessLineage(sinsp_threadinfo* tinfo,
     // Collapse parent child processes that have the same path
     if (lineage.empty() || (lineage.back().parent_exec_file_path() != pt->m_exepath)) {
       LineageInfo info;
-      info.set_parent_uid(pt->m_user.uid);
+      info.set_parent_uid(pt->m_user.uid());
       info.set_parent_exec_file_path(pt->m_exepath);
       lineage.push_back(info);
     }

--- a/collector/lib/system-inspector/EventExtractor.h
+++ b/collector/lib/system-inspector/EventExtractor.h
@@ -78,10 +78,21 @@ class EventExtractor {
     if (!event) return nullptr;                             \
     sinsp_threadinfo* tinfo = event->get_thread_info(true); \
     if (!tinfo) return nullptr;                             \
-    return &tinfo->m_##fieldname;                           \
+    return &tinfo->fieldname;                               \
   }
 
-#define TINFO_FIELD(id) TINFO_FIELD_RAW(id, id, decltype(std::declval<sinsp_threadinfo>().m_##id))
+#define TINFO_FIELD_RAW_GETTER(id, getter, type)            \
+ public:                                                    \
+  type internal_##id;                                       \
+  const type* get_##id(sinsp_evt* event) {                  \
+    if (!event) return nullptr;                             \
+    sinsp_threadinfo* tinfo = event->get_thread_info(true); \
+    if (!tinfo) return nullptr;                             \
+    internal_##id = tinfo->getter();                        \
+    return &internal_##id;                                  \
+  }
+
+#define TINFO_FIELD(id) TINFO_FIELD_RAW(id, m_##id, decltype(std::declval<sinsp_threadinfo>().m_##id))
 
   // Fields can be made available for querying by using a number of macros:
   // - TINFO_FIELD_RAW(id, fieldname, type): exposes the m_<fieldname> field of threadinfo via get_<id>()
@@ -102,8 +113,8 @@ class EventExtractor {
   TINFO_FIELD(exe);
   TINFO_FIELD(exepath);
   TINFO_FIELD(pid);
-  TINFO_FIELD_RAW(uid, user.uid, uint32_t);
-  TINFO_FIELD_RAW(gid, group.gid, uint32_t);
+  TINFO_FIELD_RAW_GETTER(uid, m_user.uid, uint32_t);
+  TINFO_FIELD_RAW_GETTER(gid, m_group.gid, uint32_t);
   FIELD_CSTR(proc_args, "proc.args");
 
   // General event information

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -78,7 +78,7 @@ bool Service::InitKernel(const CollectorConfig& config, const DriverCandidate& c
     inspector_->disable_log_timestamps();
     inspector_->set_log_callback(logging::InspectorLogCallback);
 
-    inspector_->set_import_users(config.ImportUsers());
+    inspector_->set_import_users(config.ImportUsers(), false);
     inspector_->set_thread_timeout_s(30);
     inspector_->set_auto_threads_purging_interval_s(60);
     inspector_->m_thread_manager->set_max_thread_table_size(config.GetSinspThreadCacheSize());

--- a/collector/test/ProcessSignalFormatterTest.cpp
+++ b/collector/test/ProcessSignalFormatterTest.cpp
@@ -50,7 +50,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithoutParentTest) {
   tinfo->m_tid = 0;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 2;
-  tinfo->m_user.uid = 7;
+  tinfo->m_user.set_uid(7);
   tinfo->m_exepath = "qwerty";
 
   inspector->add_thread(std::move(tinfo));
@@ -84,14 +84,14 @@ TEST(ProcessSignalFormatterTest, ProcessWithParentTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "asdf";
   auto tinfo2 = inspector->build_threadinfo();
   tinfo2->m_pid = 1;
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "qwerty";
   inspector->add_thread(std::move(tinfo));
   inspector->add_thread(std::move(tinfo2));
@@ -167,14 +167,14 @@ TEST(ProcessSignalFormatterTest, ProcessWithParentWithSameNameTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 43;
+  tinfo->m_user.set_uid(43);
   tinfo->m_exepath = "asdf";
   auto tinfo2 = inspector->build_threadinfo();
   tinfo2->m_pid = 1;
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 42;
+  tinfo2->m_user.set_uid(42);
   tinfo2->m_exepath = "asdf";
   inspector->add_thread(std::move(tinfo));
   inspector->add_thread(std::move(tinfo2));
@@ -211,7 +211,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "asdf";
 
   auto tinfo2 = inspector->build_threadinfo();
@@ -219,7 +219,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsTest) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "qwerty";
 
   auto tinfo3 = inspector->build_threadinfo();
@@ -227,7 +227,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsTest) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 9;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_exepath = "uiop";
 
   inspector->add_thread(std::move(tinfo));
@@ -269,7 +269,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsWithTheSameNameTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "asdf";
 
   auto tinfo2 = inspector->build_threadinfo();
@@ -277,7 +277,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsWithTheSameNameTest) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "asdf";
 
   auto tinfo3 = inspector->build_threadinfo();
@@ -285,7 +285,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsWithTheSameNameTest) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 9;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_exepath = "asdf";
 
   inspector->add_thread(std::move(tinfo));
@@ -324,7 +324,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "asdf";
 
   auto tinfo2 = inspector->build_threadinfo();
@@ -332,7 +332,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "asdf";
 
   auto tinfo3 = inspector->build_threadinfo();
@@ -340,7 +340,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 9;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_exepath = "asdf";
 
   auto tinfo4 = inspector->build_threadinfo();
@@ -348,7 +348,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
   tinfo4->m_tid = 5;
   tinfo4->m_ptid = 4;
   tinfo4->m_vpid = 10;
-  tinfo4->m_user.uid = 9;
+  tinfo4->m_user.set_uid(9);
   tinfo4->m_exepath = "qwerty";
 
   inspector->add_thread(std::move(tinfo));
@@ -388,7 +388,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "qwerty";
 
   auto tinfo2 = inspector->build_threadinfo();
@@ -396,7 +396,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "asdf";
 
   auto tinfo3 = inspector->build_threadinfo();
@@ -404,7 +404,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 9;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_exepath = "asdf";
 
   auto tinfo4 = inspector->build_threadinfo();
@@ -412,7 +412,7 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
   tinfo4->m_tid = 5;
   tinfo4->m_ptid = 4;
   tinfo4->m_vpid = 10;
-  tinfo4->m_user.uid = 9;
+  tinfo4->m_user.set_uid(9);
   tinfo4->m_exepath = "asdf";
 
   inspector->add_thread(std::move(tinfo));
@@ -455,7 +455,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 1;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_exepath = "qwerty";
 
   auto tinfo2 = inspector->build_threadinfo();
@@ -463,7 +463,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 2;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_exepath = "asdf";
 
   auto tinfo3 = inspector->build_threadinfo();
@@ -471,7 +471,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 9;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_exepath = "uiop";
 
   auto tinfo4 = inspector->build_threadinfo();
@@ -479,7 +479,7 @@ TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
   tinfo4->m_tid = 5;
   tinfo4->m_ptid = 555;
   tinfo4->m_vpid = 10;
-  tinfo4->m_user.uid = 9;
+  tinfo4->m_user.set_uid(9);
   tinfo4->m_exepath = "jkl;";
 
   inspector->add_thread(std::move(tinfo));
@@ -522,7 +522,7 @@ TEST(ProcessSignalFormatterTest, CountTwoCounterCallsTest) {
   tinfo->m_tid = 1;
   tinfo->m_ptid = 555;
   tinfo->m_vpid = 10;
-  tinfo->m_user.uid = 9;
+  tinfo->m_user.set_uid(9);
   tinfo->m_exepath = "jkl;";
 
   inspector->add_thread(std::move(tinfo));
@@ -535,7 +535,7 @@ TEST(ProcessSignalFormatterTest, CountTwoCounterCallsTest) {
   tinfo2->m_tid = 2;
   tinfo2->m_ptid = 555;
   tinfo2->m_vpid = 10;
-  tinfo2->m_user.uid = 9;
+  tinfo2->m_user.set_uid(9);
   tinfo2->m_exepath = "jkl;";
 
   inspector->add_thread(std::move(tinfo2));
@@ -569,7 +569,7 @@ TEST(ProcessSignalFormatterTest, Rox3377ProcessLineageWithNoVPidTest) {
   tinfo->m_tid = 3;
   tinfo->m_ptid = -1;
   tinfo->m_vpid = 0;
-  tinfo->m_user.uid = 42;
+  tinfo->m_user.set_uid(42);
   tinfo->m_container_id = "";
   tinfo->m_exepath = "qwerty";
 
@@ -578,7 +578,7 @@ TEST(ProcessSignalFormatterTest, Rox3377ProcessLineageWithNoVPidTest) {
   tinfo2->m_tid = 1;
   tinfo2->m_ptid = 3;
   tinfo2->m_vpid = 0;
-  tinfo2->m_user.uid = 7;
+  tinfo2->m_user.set_uid(7);
   tinfo2->m_container_id = "id";
   tinfo2->m_exepath = "asdf";
 
@@ -587,7 +587,7 @@ TEST(ProcessSignalFormatterTest, Rox3377ProcessLineageWithNoVPidTest) {
   tinfo3->m_tid = 4;
   tinfo3->m_ptid = 1;
   tinfo3->m_vpid = 0;
-  tinfo3->m_user.uid = 8;
+  tinfo3->m_user.set_uid(8);
   tinfo3->m_container_id = "id";
   tinfo3->m_exepath = "uiop";
 


### PR DESCRIPTION
## Description

In order to reduce memory footprint, enable slim threadinfo option.


## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing.