### PR TITLE
POC for using stackrox/storage/ResourceCollection

### DIFF
--- a/collector/lib/ResourceSelector.cpp
+++ b/collector/lib/ResourceSelector.cpp
@@ -1,0 +1,33 @@
+//
+// Created by Robby Cochran on 3/28/24.
+//
+
+#include "ResourceSelector.h"
+
+#include <regex>
+
+namespace collector {
+
+bool ResourceSelector::IsNamespaceSelected(const storage::ResourceCollection& rc, const std::string& ns) {
+  for (const auto& rs : rc.resource_selectors()) {
+    for (const auto& rule : rs.rules()) {
+      if (rule.field_name() == "Namespace" && rule.operator_() == storage::BooleanOperator::OR) {
+        for (const auto& value : rule.values()) {
+          if (value.match_type() == storage::REGEX) {
+            std::regex pattern(value.value());
+            if (std::regex_match(ns, pattern)) {
+              return true;
+            }
+          } else {
+            if (ns == value.value()) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace collector

--- a/collector/lib/ResourceSelector.h
+++ b/collector/lib/ResourceSelector.h
@@ -1,0 +1,20 @@
+//
+// Created by Robby Cochran on 3/28/24.
+//
+
+#ifndef RESOURCESELECTOR_H
+#define RESOURCESELECTOR_H
+#include <string>
+
+#include "storage/resource_collection.pb.h"
+
+namespace collector {
+
+class ResourceSelector {
+ public:
+  static bool IsNamespaceSelected(const storage::ResourceCollection& rc, const std::string& ns);
+};
+
+}  // namespace collector
+
+#endif  // RESOURCESELECTOR_H

--- a/collector/proto/CMakeLists.txt
+++ b/collector/proto/CMakeLists.txt
@@ -15,8 +15,22 @@ set(ROX_PROTO_FILES
     internalapi/sensor/network_connection_iservice.proto
     internalapi/sensor/network_enums.proto
     internalapi/sensor/signal_iservice.proto
+    storage/container_runtime.proto
+    storage/cve.proto
+    storage/deployment.proto
+    storage/image.proto
+    storage/labels.proto
     storage/network_flow.proto
+    storage/policy.proto
     storage/process_indicator.proto
+    storage/rbac.proto
+    storage/resource_collection.proto
+    storage/role.proto
+    storage/scope.proto
+    storage/taints.proto
+    storage/traits.proto
+    storage/user.proto
+    storage/vulnerability.proto
 )
 
 add_library(rox-proto ${ROX_PROTO_FILES})

--- a/collector/test/ResourceSelectorTest.cpp
+++ b/collector/test/ResourceSelectorTest.cpp
@@ -1,0 +1,84 @@
+//
+// Created by Robby Cochran on 3/28/24.
+//
+#include <gtest/gtest.h>
+
+#include <google/protobuf/util/json_util.h>
+
+#include "storage/resource_collection.pb.h"
+
+#include "ResourceSelector.h"
+
+class NamespaceCheckerTest : public ::testing::Test {
+ protected:
+  storage::ResourceCollection CreateResourceCollectionFromJson(const std::string& jsonStr) {
+    storage::ResourceCollection resourceCollection;
+    auto status = google::protobuf::util::JsonStringToMessage(jsonStr, &resourceCollection);
+    EXPECT_TRUE(status.ok()) << "Failed to parse JSON: " << status.ToString();
+    return resourceCollection;
+  }
+};
+
+TEST_F(NamespaceCheckerTest, NamespaceIncludedWithWildcard) {
+  std::string jsonStr = R"({
+        "id": "b703d50e-b003-4a6a-bf1b-7ab36c9af184",
+        "name": "External IP reporting for Ingress",
+        "description": "Enable external ips on ingress",
+        "createdAt": "2024-03-21T16:47:08.550364622Z",
+        "lastUpdated": "2024-03-21T16:57:15.308488438Z",
+        "resourceSelectors": [
+            {
+                "rules": [
+                    {
+                        "fieldName": "Cluster",
+                        "operator": "OR",
+                        "values": [
+                            {
+                                "value": ".*",
+                                "matchType": "REGEX"
+                            }
+                        ]
+                    },
+                    {
+                        "fieldName": "Namespace",
+                        "operator": "OR",
+                        "values": [
+                            {
+                                "value": "prod-.*",
+                                "matchType": "REGEX"
+                            },
+                            {
+                                "value": "development",
+                                "matchType": "EXACT"
+                            }
+                        ]
+                    },
+                    {
+                        "fieldName": "Deployment",
+                        "operator": "OR",
+                        "values": [
+                            {
+                                "value": ".*",
+                                "matchType": "REGEX"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "embeddedCollections": [
+            {
+                "id": "afd76230-4539-498d-abf6-6208ec5c48bb"
+            },
+            {
+                "id": "49f7deb3-3ea2-4aa3-9f40-645e9b26e2e1"
+            }
+        ]
+    })";
+
+  auto resourceCollection = CreateResourceCollectionFromJson(jsonStr);
+  EXPECT_FALSE(collector::ResourceSelector::IsNamespaceSelected(resourceCollection, "default"));
+  EXPECT_TRUE(collector::ResourceSelector::IsNamespaceSelected(resourceCollection, "prod-1"));
+  EXPECT_TRUE(collector::ResourceSelector::IsNamespaceSelected(resourceCollection, "prod-2"));
+  EXPECT_TRUE(collector::ResourceSelector::IsNamespaceSelected(resourceCollection, "development"));
+}


### PR DESCRIPTION
## Description

Example for using a ResourceCollection storage object as namespace filter for runtime config. 
Updated stackrox proto to 4.4 to get latest version of the ResourceCollection proto, which also required including transitive dependencies. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
