### PR TITLE
ROX-23499: Force EBPF when Power + OCP4.12

### DIFF
--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -109,8 +109,8 @@ class PowerHeuristic : public Heuristic {
       return;
     }
 
-    if (host.IsOCP4_12() || host.IsRHEL86()) {
-      CLOG(INFO) << "CORE_BPF is not available on OCP 4.12, switching to EBPF collection method.";
+    if (host.IsRHEL86()) {
+      CLOG(INFO) << "CORE_BPF is not available, switching to EBPF collection method.";
       hconfig->SetCollectionMethod(CollectionMethod::EBPF);
     }
   }

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -110,7 +110,7 @@ class PowerHeuristic : public Heuristic {
     }
 
     if (host.IsRHEL86()) {
-      CLOG(INFO) << "CORE_BPF is not available, switching to EBPF collection method.";
+      CLOG(INFO) << "RHEL 8.6 on ppc64le does not support CORE_BPF, switching to eBPF collection method.";
       hconfig->SetCollectionMethod(CollectionMethod::EBPF);
     }
   }

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -100,11 +100,28 @@ class ARM64Heuristic : public Heuristic {
   }
 };
 
+class PowerHeuristic : public Heuristic {
+ public:
+  void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
+    auto k = host.GetKernelVersion();
+
+    if (k.machine != "ppc64le") {
+      return;
+    }
+
+    if (host.IsOCP4_12() || host.IsRHEL86()) {
+      CLOG(INFO) << "CORE_BPF is not available on OCP 4.12, switching to EBPF collection method.";
+      hconfig->SetCollectionMethod(CollectionMethod::EBPF);
+    }
+  }
+};
+
 const std::unique_ptr<Heuristic> g_host_heuristics[] = {
     std::unique_ptr<Heuristic>(new CollectionHeuristic),
     std::unique_ptr<Heuristic>(new DockerDesktopHeuristic),
     std::unique_ptr<Heuristic>(new S390XHeuristic),
     std::unique_ptr<Heuristic>(new ARM64Heuristic),
+    std::unique_ptr<Heuristic>(new PowerHeuristic),
 };
 
 }  // namespace

--- a/collector/lib/HostInfo.cpp
+++ b/collector/lib/HostInfo.cpp
@@ -159,13 +159,6 @@ std::string& HostInfo::GetOSID() {
   return os_id_;
 }
 
-std::string& HostInfo::GetVersionID() {
-  if (version_id_.empty()) {
-    version_id_ = GetOSReleaseValue("VERSION_ID");
-  }
-  return version_id_;
-}
-
 std::string HostInfo::GetOSReleaseValue(const char* name) {
   std::ifstream release_file(GetHostPath("/etc/os-release"));
   if (!release_file.is_open()) {
@@ -185,12 +178,9 @@ bool HostInfo::IsRHEL76() {
 }
 
 bool HostInfo::IsRHEL86() {
-  return GetOSID() == "rhel" && GetVersionID() == "8.6";
-}
-
-bool HostInfo::IsOCP4_12() {
   auto kernel = GetKernelVersion();
-  return GetOSID() == "rhcos" && GetVersionID() == "4.12";
+  return (GetOSID() == "rhel" || GetOSID() == "rhcos") &&
+         (kernel.release.find(".el8_6.") != std::string::npos);
 }
 
 bool HostInfo::HasEBPFSupport() {

--- a/collector/lib/HostInfo.cpp
+++ b/collector/lib/HostInfo.cpp
@@ -159,6 +159,13 @@ std::string& HostInfo::GetOSID() {
   return os_id_;
 }
 
+std::string& HostInfo::GetVersionID() {
+  if (version_id_.empty()) {
+    version_id_ = GetOSReleaseValue("VERSION_ID");
+  }
+  return version_id_;
+}
+
 std::string HostInfo::GetOSReleaseValue(const char* name) {
   std::ifstream release_file(GetHostPath("/etc/os-release"));
   if (!release_file.is_open()) {
@@ -175,6 +182,15 @@ std::string HostInfo::GetOSReleaseValue(const char* name) {
 bool HostInfo::IsRHEL76() {
   auto kernel = GetKernelVersion();
   return collector::isRHEL76(kernel, GetOSID());
+}
+
+bool HostInfo::IsRHEL86() {
+  return GetOSID() == "rhel" && GetVersionID() == "8.6";
+}
+
+bool HostInfo::IsOCP4_12() {
+  auto kernel = GetKernelVersion();
+  return GetOSID() == "rhcos" && GetVersionID() == "4.12";
 }
 
 bool HostInfo::HasEBPFSupport() {

--- a/collector/lib/HostInfo.cpp
+++ b/collector/lib/HostInfo.cpp
@@ -179,8 +179,10 @@ bool HostInfo::IsRHEL76() {
 
 bool HostInfo::IsRHEL86() {
   auto kernel = GetKernelVersion();
-  return (GetOSID() == "rhel" || GetOSID() == "rhcos") &&
-         (kernel.release.find(".el8_6.") != std::string::npos);
+  if (GetOSID() == "rhel" || GetOSID() == "rhcos") {
+    return kernel.release.find(".el8_6.") != std::string::npos;
+  }
+  return false;
 }
 
 bool HostInfo::HasEBPFSupport() {

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -185,6 +185,9 @@ class HostInfo {
   // Get the OS ID of the host
   virtual std::string& GetOSID();
 
+  // Get the VERSION_ID of the host
+  virtual std::string& GetVersionID();
+
   // Whether we're running on a COS host
   virtual bool IsCOS() {
     return GetOSID() == "cos" && !GetBuildID().empty();
@@ -226,6 +229,12 @@ class HostInfo {
   // this check to build IDs between MIN_RHEL_BUILD_ID and MAX_RHEL_BUILD_ID
   bool IsRHEL76();
 
+  // Whether we are running on RHEL 8.6
+  bool IsRHEL86();
+
+  // Whether we are running on OCP 4.12
+  bool IsOCP4_12();
+
   // Whether this host has eBPF support, based on the kernel version.
   // Only exception is RHEL 7.6, which does support eBPF but runs kernel 3.10 (which ordinarily does
   // not support eBPF)
@@ -265,6 +274,8 @@ class HostInfo {
   std::string build_id_;
   // the OS ID (from os-release file)
   std::string os_id_;
+  // the VERSION_ID of the host (from os-release file)
+  std::string version_id_;
   // the system SecureBoot status
   SecureBootStatus secure_boot_status_;
 };

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -185,9 +185,6 @@ class HostInfo {
   // Get the OS ID of the host
   virtual std::string& GetOSID();
 
-  // Get the VERSION_ID of the host
-  virtual std::string& GetVersionID();
-
   // Whether we're running on a COS host
   virtual bool IsCOS() {
     return GetOSID() == "cos" && !GetBuildID().empty();
@@ -232,9 +229,6 @@ class HostInfo {
   // Whether we are running on RHEL 8.6
   bool IsRHEL86();
 
-  // Whether we are running on OCP 4.12
-  bool IsOCP4_12();
-
   // Whether this host has eBPF support, based on the kernel version.
   // Only exception is RHEL 7.6, which does support eBPF but runs kernel 3.10 (which ordinarily does
   // not support eBPF)
@@ -274,8 +268,6 @@ class HostInfo {
   std::string build_id_;
   // the OS ID (from os-release file)
   std::string os_id_;
-  // the VERSION_ID of the host (from os-release file)
-  std::string version_id_;
   // the system SecureBoot status
   SecureBootStatus secure_boot_status_;
 };


### PR DESCRIPTION
## Description

The modern probe fails to load on RHEL 8.6 + Power.
Temporarily fallback on ebpf in this particular case while we troubleshoot this issue.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Tested on Power + OCP 4.12