### PR TITLE
Limit total ring buffer size

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -386,27 +386,30 @@ unsigned int CollectorConfig::GetSinspCpuPerBuffer() const {
 
   if (sinsp_buffer_size_ == 0) {
     CLOG(WARNING) << "Trying to calculate cpu-per-buffer without"
-                     "initialized buffer size. Return raw value.";
+                     "initialized buffer size. Return unmodified "
+                  << sinsp_cpu_per_buffer_ << " CPUs per buffer.";
     return sinsp_cpu_per_buffer_;
   }
 
   if (host_config_.GetNumPossibleCPUs() == 0) {
     CLOG(WARNING) << "Trying to calculate cpu-per-buffer without"
-                     "number of possible CPUs. Return raw value.";
+                     "number of possible CPUs. Return unmodified "
+                  << sinsp_cpu_per_buffer_ << " CPUs per buffer.";
     return sinsp_cpu_per_buffer_;
   }
 
   // Round to the larger value, since one buffer will be allocated even if the
   // last group of CPUs is less than sinsp_cpu_per_buffer_
-  n_buffers = std::ceil((host_config_.GetNumPossibleCPUs() / sinsp_cpu_per_buffer_));
-  max_n_buffers = std::ceil(sinsp_total_buffer_size_ / sinsp_buffer_size_);
+  n_buffers = std::ceil(((float)host_config_.GetNumPossibleCPUs() / (float)sinsp_cpu_per_buffer_));
+  max_n_buffers = std::ceil((float)sinsp_total_buffer_size_ / (float)sinsp_buffer_size_);
 
   // Baseline case, nothing to adjust
-  if (n_buffers <= max_n_buffers)
+  if (n_buffers <= max_n_buffers) {
     return sinsp_cpu_per_buffer_;
+  }
 
   // Otherwise reduce sinsp_cpu_per_buffer_ to fit into the total limit
-  return host_config_.GetNumPossibleCPUs() / max_n_buffers;
+  return std::ceil((float)host_config_.GetNumPossibleCPUs() / (float)max_n_buffers);
 }
 
 void CollectorConfig::SetSinspBufferSize(unsigned int buffer_size) {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -79,7 +79,8 @@ class CollectorConfig {
   double GetConnectionStatsError() const { return connection_stats_error_; }
   unsigned int GetConnectionStatsWindow() const { return connection_stats_window_; }
   unsigned int GetSinspBufferSize() const { return sinsp_buffer_size_; }
-  unsigned int GetSinspCpuPerBuffer() const { return sinsp_cpu_per_buffer_; }
+  unsigned int GetSinspCpuPerBuffer() const;
+  unsigned int GetSinspTotalBufferSize() const { return sinsp_total_buffer_size_; }
   unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
@@ -112,9 +113,12 @@ class CollectorConfig {
   unsigned int connection_stats_window_;
 
   // One ring buffer will be initialized for this many CPUs
-  unsigned int sinsp_cpu_per_buffer_;
-  // Size of one ring buffer, in bytes
-  unsigned int sinsp_buffer_size_;
+  unsigned int sinsp_cpu_per_buffer_ = 0;
+  // Size of one ring buffer, in bytes. The default value 512Mi is based on the
+  // default memory limit set of the Collector DaemonSet, which is 1Gi.
+  unsigned int sinsp_buffer_size_ = 512 * 1024 * 1024;
+  // Allowed size of all ring buffers, in bytes
+  unsigned int sinsp_total_buffer_size_ = 0;
 
   // Max size of the thread cache. This parameter essentially translated into
   // the upper boundary for memory consumption. Note that Falco puts it's own
@@ -127,6 +131,12 @@ class CollectorConfig {
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
+
+  // Protected, used for testing purposes
+  void SetSinspBufferSize(unsigned int buffer_size);
+  void SetSinspTotalBufferSize(unsigned int total_buffer_size);
+  void SetSinspCpuPerBuffer(unsigned int buffer_size);
+  void SetHostConfig(HostConfig* config);
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/collector/lib/HostConfig.h
+++ b/collector/lib/HostConfig.h
@@ -22,8 +22,12 @@ class HostConfig {
     collection_method_ = method;
   }
 
+  unsigned int GetNumPossibleCPUs() const { return num_possible_cpus_; }
+  void SetNumPossibleCPUs(unsigned int value) { num_possible_cpus_ = value; }
+
  private:
   std::optional<collector::CollectionMethod> collection_method_;
+  unsigned int num_possible_cpus_;
 };
 
 #endif  // COLLECTOR_HOSTCONFIG_H

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -116,12 +116,21 @@ class PowerHeuristic : public Heuristic {
   }
 };
 
+class CPUHeuristic : public Heuristic {
+ public:
+  // Enrich HostConfig with the number of possible CPU cores.
+  void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
+    hconfig->SetNumPossibleCPUs(host.NumPossibleCPU());
+  }
+};
+
 const std::unique_ptr<Heuristic> g_host_heuristics[] = {
     std::unique_ptr<Heuristic>(new CollectionHeuristic),
     std::unique_ptr<Heuristic>(new DockerDesktopHeuristic),
     std::unique_ptr<Heuristic>(new S390XHeuristic),
     std::unique_ptr<Heuristic>(new ARM64Heuristic),
     std::unique_ptr<Heuristic>(new PowerHeuristic),
+    std::unique_ptr<Heuristic>(new CPUHeuristic),
 };
 
 }  // namespace

--- a/collector/lib/HostInfo.cpp
+++ b/collector/lib/HostInfo.cpp
@@ -415,4 +415,15 @@ std::string HostInfo::GetMinikubeVersion() {
   return match.str();
 }
 
+int HostInfo::NumPossibleCPU() {
+  int n_possible_cpus = libbpf_num_possible_cpus();
+  if (n_possible_cpus < 0) {
+    CLOG(WARNING) << "Cannot get number of possible CPUs: "
+                  << StrError(n_possible_cpus);
+    return 0;
+  }
+
+  return n_possible_cpus;
+}
+
 }  // namespace collector

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -243,6 +243,16 @@ class HostInfo {
   // Check for BPF tracepoint program type support
   bool HasBPFTracingSupport();
 
+  // Return number of possible CPU cores. It relies on
+  // libbpf_num_possible_cpus, and "possible" means the same as in
+  // "/sys/devices/system/cpu/possible":
+  //
+  // 	possible: cpus that have been allocated resources and can be brought
+  // 	online if they are present.
+  //
+  // In case of failure, logs the error and returns 0.
+  int NumPossibleCPU();
+
   // The system was booted in UEFI mode.
   virtual bool IsUEFI();
 

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -1,0 +1,69 @@
+#include "CollectorArgs.h"
+#include "CollectorConfig.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
+
+namespace collector {
+
+class MockCollectorConfig : public CollectorConfig {
+ public:
+  MockCollectorConfig() = default;
+
+  void MockSetSinspBufferSize(unsigned int value) {
+    SetSinspBufferSize(value);
+  }
+
+  void MockSetSinspTotalBufferSize(unsigned int value) {
+    SetSinspTotalBufferSize(value);
+  }
+
+  void MockSetHostConfig(HostConfig* config) {
+    SetHostConfig(config);
+  }
+
+  void MockSetSinspCpuPerBuffer(unsigned int value) {
+    SetSinspCpuPerBuffer(value);
+  }
+};
+
+TEST(CollectorConfigTest, TestSinspCpuPerBufferRaw) {
+  using namespace collector;
+
+  MockCollectorConfig config;
+  HostConfig hconfig;
+  hconfig.SetNumPossibleCPUs(0);
+  config.MockSetSinspBufferSize(0);
+  config.MockSetSinspCpuPerBuffer(1);
+  config.MockSetHostConfig(&hconfig);
+
+  // Buffer size is not initialized
+  EXPECT_EQ(1, config.GetSinspCpuPerBuffer());
+
+  // Number of CPUs is not initialized
+  config.MockSetSinspBufferSize(1024);
+  EXPECT_EQ(1, config.GetSinspCpuPerBuffer());
+}
+
+TEST(CollectorConfigTest, TestSinspCpuPerBufferAdjusted) {
+  using namespace collector;
+
+  MockCollectorConfig config;
+  HostConfig hconfig;
+  config.MockSetSinspTotalBufferSize(512 * 1024 * 1024);
+  config.MockSetSinspBufferSize(8 * 1024 * 1024);
+  config.MockSetSinspCpuPerBuffer(1);
+
+  // Low number of CPUs, raw value
+  hconfig.SetNumPossibleCPUs(16);
+  config.MockSetHostConfig(&hconfig);
+  EXPECT_EQ(1, config.GetSinspCpuPerBuffer());
+
+  // High number of CPUs, adjusted value
+  hconfig.SetNumPossibleCPUs(150);
+  config.MockSetHostConfig(&hconfig);
+  EXPECT_EQ(2, config.GetSinspCpuPerBuffer());
+}
+
+}  // namespace collector

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -63,7 +63,7 @@ TEST(CollectorConfigTest, TestSinspCpuPerBufferAdjusted) {
   // High number of CPUs, adjusted value
   hconfig.SetNumPossibleCPUs(150);
   config.MockSetHostConfig(&hconfig);
-  EXPECT_EQ(2, config.GetSinspCpuPerBuffer());
+  EXPECT_EQ(3, config.GetSinspCpuPerBuffer());
 }
 
 }  // namespace collector

--- a/docs/references.md
+++ b/docs/references.md
@@ -63,6 +63,12 @@ are there. This parameter affects CO-RE BPF only.
 * `ROX_COLLECTOR_SINSP_BUFFER_SIZE`: Specifies the size of a sinsp buffer in
 bytes. The default value is 16 MB.
 
+* `ROX_COLLECTOR_SINSP_TOTAL_BUFFER_SIZE`: Specifies the allowed total size of
+all sinsp buffer in bytes. If the actual value will be larger than that due to
+number of available CPUs, `ROX_COLLECTOR_SINSP_CPU_PER_BUFFER` will be adjusted
+to match the limit. The default value is 512 MB and based on the default memory
+limit specified for Collector DaemonSet in ACS.
+
 * `ROX_COLLECTOR_SINSP_THREAD_CACHE_SIZE`: Puts upper limit on how many
 thread info objects are going to be kept in memory. Since for process-based
 workloads it's the main part of memory consumption, this value effectively


### PR DESCRIPTION
## Description

Allow to specify the upper limit for all ring buffers together, to avoid issues when a node has lots of CPUs, and for every single one buffer will be allocated, eventually running out of memory. The limit could be specified via ROX_COLLECTOR_SINSP_TOTAL_BUFFER_SIZE, but the default value of 512Mi should be good enough for the basic case, where the Collector DaemonSet memory limit is 1Gi.

If at the configuration phase Collector figures out that it can't match specified limit, sinsp_cpu_per_buffer_ will be adjusted to fit under the allowed threshold.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing.