### PR TITLE
Fix mixed up total/single buffer size

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -392,7 +392,7 @@ unsigned int CollectorConfig::GetSinspCpuPerBuffer() const {
   }
 
   if (sinsp_cpu_per_buffer_ == 0) {
-    CLOG(WARNING) << "Trying to calculate cpu-per-buffer without"
+    CLOG(WARNING) << "Trying to calculate cpu-per-buffer without "
                      "requested cpu-per-buffer. Return unmodified "
                   << sinsp_cpu_per_buffer_ << " CPUs per buffer.";
     return sinsp_cpu_per_buffer_;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -391,6 +391,13 @@ unsigned int CollectorConfig::GetSinspCpuPerBuffer() const {
     return sinsp_cpu_per_buffer_;
   }
 
+  if (sinsp_cpu_per_buffer_ == 0) {
+    CLOG(WARNING) << "Trying to calculate cpu-per-buffer without"
+                     "requested cpu-per-buffer. Return unmodified "
+                  << sinsp_cpu_per_buffer_ << " CPUs per buffer.";
+    return sinsp_cpu_per_buffer_;
+  }
+
   if (host_config_.GetNumPossibleCPUs() == 0) {
     CLOG(WARNING) << "Trying to calculate cpu-per-buffer without"
                      "number of possible CPUs. Return unmodified "

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -114,11 +114,12 @@ class CollectorConfig {
 
   // One ring buffer will be initialized for this many CPUs
   unsigned int sinsp_cpu_per_buffer_ = 0;
-  // Size of one ring buffer, in bytes. The default value 512Mi is based on the
-  // default memory limit set of the Collector DaemonSet, which is 1Gi.
-  unsigned int sinsp_buffer_size_ = 512 * 1024 * 1024;
-  // Allowed size of all ring buffers, in bytes
-  unsigned int sinsp_total_buffer_size_ = 0;
+  // Size of one ring buffer, in bytes.
+  unsigned int sinsp_buffer_size_ = 0;
+  // Allowed size of all ring buffers, in bytes. The default value 512Mi is
+  // based on the default memory limit set of the Collector DaemonSet, which is
+  // 1Gi.
+  unsigned int sinsp_total_buffer_size_ = 512 * 1024 * 1024;
 
   // Max size of the thread cache. This parameter essentially translated into
   // the upper boundary for memory consumption. Note that Falco puts it's own


### PR DESCRIPTION
## Description

Fix mixed up initial values. Add one more sanity check to not go into calculations of no cpu-per-buffer is even requested.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing.