### PR TITLE
chore: Update product name in Konflux image labels

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -145,15 +145,15 @@ WORKDIR /
 
 LABEL \
     com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="This image supports runtime data collection in the StackRox Kubernetes Security Platform" \
+    description="This image supports runtime data collection for Red Hat Advanced Cluster Security for Kubernetes" \
     distribution-scope="public" \
-    io.k8s.description="This image supports runtime data collection in the StackRox Kubernetes Security Platform" \
+    io.k8s.description="This image supports runtime data collection for Red Hat Advanced Cluster Security for Kubernetes" \
     io.openshift.tags="rhacs,collector,stackrox" \
     maintainer="Red Hat, Inc." \
     # TODO(ROX-20236): release label is required by EC, figure what to put in the release version on rebuilds.
     release="0" \
     source-location="https://github.com/stackrox/collector" \
-    summary="Runtime data collection for the StackRox Kubernetes Security Platform" \
+    summary="Runtime data collection for Red Hat Advanced Cluster Security for Kubernetes" \
     url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
     version=${COLLECTOR_VERSION} \
     vendor="Red Hat, Inc."


### PR DESCRIPTION
## Description

This updates product name from StackRox to RHACS.
Spotted while reviewing https://gitlab.cee.redhat.com/stackrox/rhacs-midstream/-/merge_requests/2862

It may happen that we eventually will have to customize labels when we build OSS version on Konflux but we aren't there yet. For now it's important to identify containers as part of RHACS.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
  - ~~[ ] Added unit tests~~
  - ~~[ ] Added integration tests~~
  - ~~[ ] Added regression tests~~

If any of these don't apply, please comment below.

## Testing Performed

Only CI.
