### PR TITLE
Collect K8S events and pod configuration on K8S based tests

### DIFF
--- a/integration-tests/pkg/collector/collector.go
+++ b/integration-tests/pkg/collector/collector.go
@@ -1,11 +1,6 @@
 package collector
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stackrox/collector/integration-tests/pkg/executor"
 )
 
@@ -31,15 +26,4 @@ func New(e executor.Executor, name string) Manager {
 		return newK8sManager(*k8sExec, name)
 	}
 	return newDockerManager(e, name)
-}
-
-func prepareLog(m Manager) (*os.File, error) {
-	logDirectory := filepath.Join(".", "container-logs", config.VMInfo().Config, config.CollectionMethod())
-	err := os.MkdirAll(logDirectory, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-
-	logPath := filepath.Join(logDirectory, strings.ReplaceAll(m.TestName(), "/", "_")+"-collector.log")
-	return os.Create(logPath)
 }

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -190,7 +190,7 @@ func (c *DockerCollectorManager) captureLogs(containerName string) (string, erro
 		return "", err
 	}
 
-	logFile, err := prepareLog(c)
+	logFile, err := common.PrepareLog(c.testName, "collector.log")
 	if err != nil {
 		return "", err
 	}

--- a/integration-tests/pkg/common/utils.go
+++ b/integration-tests/pkg/common/utils.go
@@ -2,9 +2,12 @@ package common
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"golang.org/x/sys/unix"
 	"k8s.io/utils/strings/slices"
 )
@@ -48,4 +51,16 @@ func ArchSupported(supported ...string) (bool, string) {
 	// Exclude null bytes from comparison
 	arch := string(bytes.Trim(u.Machine[:], "\x00"))
 	return slices.Contains(supported, arch), arch
+}
+
+// Creates a new file to dump logs into
+func PrepareLog(testName string, logName string) (*os.File, error) {
+	logDirectory := filepath.Join(".", "container-logs", config.VMInfo().Config, config.CollectionMethod())
+	err := os.MkdirAll(logDirectory, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	logPath := filepath.Join(logDirectory, strings.ReplaceAll(testName, "/", "_")+"-"+logName)
+	return os.Create(logPath)
 }

--- a/integration-tests/suites/k8s_namespace.go
+++ b/integration-tests/suites/k8s_namespace.go
@@ -51,6 +51,12 @@ func (k *K8sNamespaceTestSuite) SetupSuite() {
 			k.sensor.Stop()
 		}
 
+		// Dump logs for the target namespace
+		e, ok := k.Executor().(*executor.K8sExecutor)
+		k.Require().True(ok)
+		err = e.CaptureNamespaceEvents(k.collector.TestName(), NAMESPACE)
+		k.Require().NoError(err)
+
 		nginxPodFilter := executor.ContainerFilter{
 			Name:      "nginx",
 			Namespace: NAMESPACE,
@@ -58,6 +64,8 @@ func (k *K8sNamespaceTestSuite) SetupSuite() {
 		exists, _ = k.Executor().ContainerExists(nginxPodFilter)
 
 		if exists {
+			err = e.CapturePodConfiguration(k.collector.TestName(), NAMESPACE, "nginx")
+			k.Require().NoError(err)
 			k.Executor().RemoveContainer(nginxPodFilter)
 		}
 


### PR DESCRIPTION
## Description

#1606 added some basic K8S based tests. Because the amount of changes needed for those to work were significant, I decided to postpone adding anything that was not absolutely necessary for the tests to work. Now that those have been merged to master, it's a great time to improve them a bit and make them easier to work with.

This PR makes it so alongside the collector logs for the tests, the events for the involved namespaces and the pod configuration used by pods are also dumped in order to provide more details when a deeper issue arises and no logs are available. The one "downside" to the approach is the dumped events and configuration are in JSON format, since that seemed like the easiest to get working, using `jq` and/or `grep` should make it relatively easy to get any required information, a couple example queries for `jq` have been added to the tests docs as examples.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Ran the tests manually and checked the new logs are created.
