### PR TITLE
Instruct Collector to not aggregate some subnets

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -27,7 +27,7 @@ BoolEnvVar network_drop_ignored("ROX_NETWORK_DROP_IGNORED", true);
 StringListEnvVar ignored_networks("ROX_IGNORE_NETWORKS", std::vector<std::string>({"169.254.0.0/16", "fe80::/10"}));
 
 // Connection endpoints matching a network prefix listed here will never be aggregated.
-StringListEnvVar detailed_networks("ROX_DETAIL_NETWORKS", std::vector<std::string>());
+StringListEnvVar non_aggregated_networks("ROX_NON_AGGREGATED_NETWORKS", std::vector<std::string>());
 
 // If true, set curl to be verbose, adding further logging that might be useful for debugging.
 BoolEnvVar set_curl_verbose("ROX_COLLECTOR_SET_CURL_VERBOSE", false);
@@ -188,8 +188,8 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
                   }
                 });
 
-  std::for_each(detailed_networks.value().begin(), detailed_networks.value().end(),
-                [&detailed_networks = this->detailed_networks_](const std::string& str) {
+  std::for_each(non_aggregated_networks.value().begin(), non_aggregated_networks.value().end(),
+                [&non_aggregated_networks = this->non_aggregated_networks_](const std::string& str) {
                   if (str.empty())
                     return;
 
@@ -197,9 +197,9 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
 
                   if (net) {
                     CLOG(INFO) << "Detail network : " << *net;
-                    detailed_networks.emplace_back(std::move(*net));
+                    non_aggregated_networks.emplace_back(std::move(*net));
                   } else {
-                    CLOG(ERROR) << "Invalid network in ROX_DETAIL_NETWORKS : " << str;
+                    CLOG(ERROR) << "Invalid network in ROX_NON_AGGREGATED_NETWORKS : " << str;
                   }
                 });
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -196,7 +196,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
                   std::optional<IPNet> net = IPNet::parse(str);
 
                   if (net) {
-                    CLOG(INFO) << "Private network : " << *net;
+                    CLOG(INFO) << "Detail network : " << *net;
                     detailed_networks.emplace_back(std::move(*net));
                   } else {
                     CLOG(ERROR) << "Invalid network in ROX_DETAIL_NETWORKS : " << str;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -173,35 +173,33 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     ignored_l4proto_port_pairs_ = kIgnoredL4ProtoPortPairs;
   }
 
-  std::for_each(ignored_networks.value().begin(), ignored_networks.value().end(),
-                [&ignored_networks = this->ignored_networks_](const std::string& str) {
-                  if (str.empty())
-                    return;
+  for (const std::string &str : ignored_networks.value()) {
+    if (str.empty())
+      continue;
 
-                  std::optional<IPNet> net = IPNet::parse(str);
+    std::optional<IPNet> net = IPNet::parse(str);
 
-                  if (net) {
-                    CLOG(INFO) << "Ignore network : " << *net;
-                    ignored_networks.emplace_back(std::move(*net));
-                  } else {
-                    CLOG(ERROR) << "Invalid network in ROX_IGNORE_NETWORKS : " << str;
-                  }
-                });
+    if (net) {
+      CLOG(INFO) << "Ignore network : " << *net;
+      ignored_networks_.emplace_back(std::move(*net));
+    } else {
+      CLOG(ERROR) << "Invalid network in ROX_IGNORE_NETWORKS : " << str;
+    }
+  }
 
-  std::for_each(non_aggregated_networks.value().begin(), non_aggregated_networks.value().end(),
-                [&non_aggregated_networks = this->non_aggregated_networks_](const std::string& str) {
-                  if (str.empty())
-                    return;
+  for (const std::string &str : non_aggregated_networks.value()) {
+    if (str.empty())
+      continue;
 
-                  std::optional<IPNet> net = IPNet::parse(str);
+    std::optional<IPNet> net = IPNet::parse(str);
 
-                  if (net) {
-                    CLOG(INFO) << "Detail network : " << *net;
-                    non_aggregated_networks.emplace_back(std::move(*net));
-                  } else {
-                    CLOG(ERROR) << "Invalid network in ROX_NON_AGGREGATED_NETWORKS : " << str;
-                  }
-                });
+    if (net) {
+      CLOG(INFO) << "Detail network : " << *net;
+      non_aggregated_networks_.emplace_back(std::move(*net));
+    } else {
+      CLOG(ERROR) << "Invalid network in ROX_NON_AGGREGATED_NETWORKS : " << str;
+    }
+  }
 
   if (set_curl_verbose) {
     curl_verbose_ = true;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -173,7 +173,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     ignored_l4proto_port_pairs_ = kIgnoredL4ProtoPortPairs;
   }
 
-  for (const std::string &str : ignored_networks.value()) {
+  for (const std::string& str : ignored_networks.value()) {
     if (str.empty())
       continue;
 
@@ -187,7 +187,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     }
   }
 
-  for (const std::string &str : non_aggregated_networks.value()) {
+  for (const std::string& str : non_aggregated_networks.value()) {
     if (str.empty())
       continue;
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -194,7 +194,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     std::optional<IPNet> net = IPNet::parse(str);
 
     if (net) {
-      CLOG(INFO) << "Detail network : " << *net;
+      CLOG(INFO) << "Non-aggregated network : " << *net;
       non_aggregated_networks_.emplace_back(std::move(*net));
     } else {
       CLOG(ERROR) << "Invalid network in ROX_NON_AGGREGATED_NETWORKS : " << str;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -65,7 +65,7 @@ class CollectorConfig {
   bool DisableNetworkFlows() const { return disable_network_flows_; }
   const UnorderedSet<L4ProtoPortPair>& IgnoredL4ProtoPortPairs() const { return ignored_l4proto_port_pairs_; }
   const std::vector<IPNet>& IgnoredNetworks() const { return ignored_networks_; }
-  const std::vector<IPNet>& DetailedNetworks() const { return detailed_networks_; }
+  const std::vector<IPNet>& NonAggregatedNetworks() const { return non_aggregated_networks_; }
   bool CurlVerbose() const { return curl_verbose_; }
   bool EnableAfterglow() const { return enable_afterglow_; }
   bool IsCoreDumpEnabled() const;
@@ -101,7 +101,7 @@ class CollectorConfig {
   bool scrape_listen_endpoints_ = false;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
   std::vector<IPNet> ignored_networks_;
-  std::vector<IPNet> detailed_networks_;
+  std::vector<IPNet> non_aggregated_networks_;
   bool curl_verbose_ = false;
 
   HostConfig host_config_;

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -65,6 +65,7 @@ class CollectorConfig {
   bool DisableNetworkFlows() const { return disable_network_flows_; }
   const UnorderedSet<L4ProtoPortPair>& IgnoredL4ProtoPortPairs() const { return ignored_l4proto_port_pairs_; }
   const std::vector<IPNet>& IgnoredNetworks() const { return ignored_networks_; }
+  const std::vector<IPNet>& DetailedNetworks() const { return detailed_networks_; }
   bool CurlVerbose() const { return curl_verbose_; }
   bool EnableAfterglow() const { return enable_afterglow_; }
   bool IsCoreDumpEnabled() const;
@@ -100,6 +101,7 @@ class CollectorConfig {
   bool scrape_listen_endpoints_ = false;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
   std::vector<IPNet> ignored_networks_;
+  std::vector<IPNet> detailed_networks_;
   bool curl_verbose_ = false;
 
   HostConfig host_config_;

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -86,7 +86,7 @@ void CollectorService::RunForever() {
     UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
     conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
     conn_tracker->UpdateIgnoredNetworks(config_.IgnoredNetworks());
-    conn_tracker->UpdateDetailedNetworks(config_.DetailedNetworks());
+    conn_tracker->UpdateNonAggregatedNetworks(config_.NonAggregatedNetworks());
     conn_tracker->EnableExternalIPs(config_.EnableExternalIPs());
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -86,6 +86,7 @@ void CollectorService::RunForever() {
     UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs(config_.IgnoredL4ProtoPortPairs());
     conn_tracker->UpdateIgnoredL4ProtoPortPairs(std::move(ignored_l4proto_port_pairs));
     conn_tracker->UpdateIgnoredNetworks(config_.IgnoredNetworks());
+    conn_tracker->UpdateDetailedNetworks(config_.DetailedNetworks());
     conn_tracker->EnableExternalIPs(config_.EnableExternalIPs());
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -77,7 +77,7 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
   }
 
   // We want to keep private addresses and explicitely requested ones.
-  bool keep_addr = !address.IsPublic() || !detailed_networks_.Find(address).IsNull();
+  bool keep_addr = !address.IsPublic() || !non_aggregated_networks_.Find(address).IsNull();
   const bool* known_private_networks_exists = Lookup(known_private_networks_exists_, address.family());
   if (keep_addr && (known_private_networks_exists && !*known_private_networks_exists)) {
     return IPNet(address, 0, true);
@@ -331,9 +331,9 @@ void ConnectionTracker::UpdateIgnoredNetworks(const std::vector<IPNet>& network_
   }
 }
 
-void ConnectionTracker::UpdateDetailedNetworks(const std::vector<IPNet>& network_list) {
+void ConnectionTracker::UpdateNonAggregatedNetworks(const std::vector<IPNet>& network_list) {
   WITH_LOCK(mutex_) {
-    detailed_networks_ = NRadixTree(network_list);
+    non_aggregated_networks_ = NRadixTree(network_list);
   }
 }
 

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -76,14 +76,15 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return {};
   }
 
-  bool private_addr = !address.IsPublic();
+  // We want to keep private addresses and explicitely requested ones.
+  bool keep_addr = !address.IsPublic() || !detailed_networks_.Find(address).IsNull();
   const bool* known_private_networks_exists = Lookup(known_private_networks_exists_, address.family());
-  if (private_addr && (known_private_networks_exists && !*known_private_networks_exists)) {
+  if (keep_addr && (known_private_networks_exists && !*known_private_networks_exists)) {
     return IPNet(address, 0, true);
   }
 
   const auto& network = known_ip_networks_.Find(address);
-  if (private_addr || Contains(known_public_ips_, address)) {
+  if (keep_addr || Contains(known_public_ips_, address)) {
     return IPNet(address, network.bits(), true);
   }
 
@@ -327,6 +328,12 @@ void ConnectionTracker::UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPa
 void ConnectionTracker::UpdateIgnoredNetworks(const std::vector<IPNet>& network_list) {
   WITH_LOCK(mutex_) {
     ignored_networks_ = NRadixTree(network_list);
+  }
+}
+
+void ConnectionTracker::UpdateDetailedNetworks(const std::vector<IPNet>& network_list) {
+  WITH_LOCK(mutex_) {
+    detailed_networks_ = NRadixTree(network_list);
   }
 }
 

--- a/collector/lib/ConnTracker.cpp
+++ b/collector/lib/ConnTracker.cpp
@@ -76,8 +76,12 @@ IPNet ConnectionTracker::NormalizeAddressNoLock(const Address& address) const {
     return {};
   }
 
+  bool private_addr = !address.IsPublic();
+  bool do_not_aggregate_addr = !non_aggregated_networks_.Find(address).IsNull();
+
   // We want to keep private addresses and explicitely requested ones.
-  bool keep_addr = !address.IsPublic() || !non_aggregated_networks_.Find(address).IsNull();
+  bool keep_addr = private_addr || do_not_aggregate_addr;
+
   const bool* known_private_networks_exists = Lookup(known_private_networks_exists_, address.family());
   if (keep_addr && (known_private_networks_exists && !*known_private_networks_exists)) {
     return IPNet(address, 0, true);

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -130,6 +130,7 @@ class ConnectionTracker {
   void EnableExternalIPs(bool enable) { enable_external_ips_ = enable; }
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
   void UpdateIgnoredNetworks(const std::vector<IPNet>& network_list);
+  void UpdateDetailedNetworks(const std::vector<IPNet>& network_list);
 
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
   // than the stored one.
@@ -200,6 +201,7 @@ class ConnectionTracker {
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
   NRadixTree ignored_networks_;
+  NRadixTree detailed_networks_;
 
   Stats inserted_connections_counters_ = {};
 };

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -130,7 +130,7 @@ class ConnectionTracker {
   void EnableExternalIPs(bool enable) { enable_external_ips_ = enable; }
   void UpdateIgnoredL4ProtoPortPairs(UnorderedSet<L4ProtoPortPair>&& ignored_l4proto_port_pairs);
   void UpdateIgnoredNetworks(const std::vector<IPNet>& network_list);
-  void UpdateDetailedNetworks(const std::vector<IPNet>& network_list);
+  void UpdateNonAggregatedNetworks(const std::vector<IPNet>& network_list);
 
   // Emplace a connection into the state ConnMap, or update its timestamp if the supplied timestamp is more recent
   // than the stored one.
@@ -201,7 +201,7 @@ class ConnectionTracker {
   UnorderedMap<Address::Family, bool> known_private_networks_exists_;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;
   NRadixTree ignored_networks_;
-  NRadixTree detailed_networks_;
+  NRadixTree non_aggregated_networks_;
 
   Stats inserted_connections_counters_ = {};
 };

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -171,6 +171,30 @@ TEST(ConnTrackerTest, TestUpdateIgnoredNetworks) {
   EXPECT_TRUE(tracker.FetchConnState().empty());
 }
 
+TEST(ConnTrackerTest, TestUpdateDetailedNetworks) {
+  Endpoint a(Address(192, 168, 1, 10), 9999);
+  Endpoint b(Address(245, 1, 1, 1), 80);
+
+  Connection conn1("xyz", a, b, L4Proto::TCP, false);
+
+  int64_t time_micros = 1000;
+
+  Connection conn_aggregated("xyz", Endpoint(IPNet(Address(), 0, true), 0), Endpoint(IPNet(Address(255, 255, 255, 255), 0), 80), L4Proto::TCP, false);
+  Connection conn_detailed("xyz", Endpoint(IPNet(Address(), 0, true), 0), Endpoint(IPNet(Address(245, 1, 1, 1), 0, true), 80), L4Proto::TCP, false);
+
+  ConnectionTracker tracker;
+
+  tracker.Update({conn1}, {}, time_micros);
+
+  auto state = tracker.FetchConnState(true);
+  EXPECT_THAT(state, UnorderedElementsAre(std::make_pair(conn_aggregated, ConnStatus(time_micros, true))));
+
+  tracker.UpdateDetailedNetworks({IPNet(Address(240, 0, 0, 0), 4)});
+
+  state = tracker.FetchConnState(true);
+  EXPECT_THAT(state, UnorderedElementsAre(std::make_pair(conn_detailed, ConnStatus(time_micros, true))));
+}
+
 TEST(ConnTrackerTest, TestUpdateNormalized) {
   Endpoint a(Address(192, 168, 0, 1), 80);
   Endpoint b(Address(192, 168, 1, 10), 9999);

--- a/collector/test/ConnTrackerTest.cpp
+++ b/collector/test/ConnTrackerTest.cpp
@@ -171,7 +171,7 @@ TEST(ConnTrackerTest, TestUpdateIgnoredNetworks) {
   EXPECT_TRUE(tracker.FetchConnState().empty());
 }
 
-TEST(ConnTrackerTest, TestUpdateDetailedNetworks) {
+TEST(ConnTrackerTest, TestUpdateNonAggregatedNetworks) {
   Endpoint a(Address(192, 168, 1, 10), 9999);
   Endpoint b(Address(245, 1, 1, 1), 80);
 
@@ -189,7 +189,7 @@ TEST(ConnTrackerTest, TestUpdateDetailedNetworks) {
   auto state = tracker.FetchConnState(true);
   EXPECT_THAT(state, UnorderedElementsAre(std::make_pair(conn_aggregated, ConnStatus(time_micros, true))));
 
-  tracker.UpdateDetailedNetworks({IPNet(Address(240, 0, 0, 0), 4)});
+  tracker.UpdateNonAggregatedNetworks({IPNet(Address(240, 0, 0, 0), 4)});
 
   state = tracker.FetchConnState(true);
   EXPECT_THAT(state, UnorderedElementsAre(std::make_pair(conn_detailed, ConnStatus(time_micros, true))));

--- a/docs/references.md
+++ b/docs/references.md
@@ -21,6 +21,12 @@ port pairs (at the moment only `udp/9`). The default is true.
 Any connection with a remote peer matching this list will not be reported.
 The default is `169.254.0.0/16,fe80::/10`
 
+* `ROX_NON_AGGREGATED_NETWORKS`: A coma-separated list of network prefixes
+indicating endpoints which should never be considered for aggregation.
+This option can be useful when the CIDR blocks used for services or PODs are
+not standard private subnets, as it will prevent Collector from handling them
+as public IPs.
+
 * `ROX_NETWORK_GRAPH_PORTS`: Controls whether to retrieve TCP listening
 sockets, while reading connection information from procfs. The default is true.
 


### PR DESCRIPTION
## Description

This adds an environment variable providing Collector with a list of subnets to never aggregate (`ROX_NON_AGGREGATED_NETWORKS`).

As a side effect, this can be used to expand the list of standard private network prefixes with new ones.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing

- deployed a K8S cluster with 34.228.224.0/24 as the service CIDR
- install ACS 4.4
- the network graph shows no connection to `central-db`
- update the collector image to the one produced by this PR. Set `ROX_NON_AGGREGATED_NETWORKS=34.228.224.0/24`
- the network graph then shows `central` connecting to `central-db`