### PR TITLE
Prevent waiting infinitely for processes

### DIFF
--- a/integration-tests/pkg/mock_sensor/expect_proc.go
+++ b/integration-tests/pkg/mock_sensor/expect_proc.go
@@ -125,13 +125,14 @@ func (s *MockSensor) waitProcessesN(
 	}
 
 	tick := time.Tick(tickSeconds)
+	timer := time.After(timeout)
 
 loop:
 	for {
 		select {
 		case <-tick:
 			tickFn()
-		case <-time.After(timeout):
+		case <-timer:
 			timeoutFn()
 			return make([]types.ProcessInfo, 0)
 		case proc := <-s.LiveProcesses():


### PR DESCRIPTION


## Description

Calling time.After in a for-select loop causes a new channel to be spawned with a new timeout, so using it alongside a ticker causes the timeout to never occur. Assigning the channel to a separate variable and using that on the loop should take care of the issue. See [this SO answer](https://stackoverflow.com/a/66003389) for more details.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Fix is simple enough that shouldn't need testing outside CI.
