### PR TITLE
Add systemtap to Konflux

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -32,7 +32,9 @@ RUN /tmp/.konflux/scripts/subscription-manager-bro.sh register /mnt && \
         elfutils-libelf-devel \
         tbb-devel \
         jq-devel \
-        c-ares-devel && \
+        c-ares-devel \
+        # for USDT support
+        systemtap-sdt-devel && \
     /tmp/.konflux/scripts/subscription-manager-bro.sh cleanup && \
     dnf -y --installroot=/mnt clean all
 


### PR DESCRIPTION
## Description

USDT support requires systemtap, but Konflux setup doesn't use the builder image. Add the dependency directly.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.