### PR TITLE
Use event watchers for namespace events

### DIFF
--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -17,6 +17,7 @@ on:
 env:
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
   COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/qa-multi-arch:collector-tests-${{ inputs.collector-tag }}
+  COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
 
 jobs:
   k8s-integration-tests:
@@ -50,7 +51,7 @@ jobs:
           cat << EOF > /tmp/vars.yml
           ---
           tester_image: ${{ env.COLLECTOR_TESTS_IMAGE }}
-          collector_image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+          collector_image: ${{ env.COLLECTOR_IMAGE }}
           collector_root: ${{ github.workspace }}
           EOF
 
@@ -64,6 +65,12 @@ jobs:
       - name: Pull tests image
         run: |
           docker pull ${{ env.COLLECTOR_TESTS_IMAGE }}
+
+      - name: Pull collector image
+        run: |
+          # Collector image is pulled to prevent timeout errors due
+          # to inconsistent timing
+          docker pull ${{ env.COLLECTOR_IMAGE }}
 
       - name: Run tests
         run: |

--- a/integration-tests/pkg/executor/executor_k8s.go
+++ b/integration-tests/pkg/executor/executor_k8s.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/stackrox/collector/integration-tests/pkg/common"
@@ -206,12 +207,12 @@ func (e *K8sExecutor) CreateNamespaceEventWatcher(testName, ns string) (watch.In
 		return nil, err
 	}
 
-	go func(watcher watch.Interface) {
-		logFile, err := common.PrepareLog(testName, ns+"-events.jsonl")
-		if err != nil {
-			fmt.Printf("Failed to open event file: %s\n", err)
-			return
-		}
+	logFile, err := common.PrepareLog(testName, ns+"-events.jsonl")
+	if err != nil {
+		return nil, err
+	}
+
+	go func(watcher watch.Interface, logFile *os.File) {
 		defer logFile.Close()
 
 		for event := range watcher.ResultChan() {
@@ -228,7 +229,7 @@ func (e *K8sExecutor) CreateNamespaceEventWatcher(testName, ns string) (watch.In
 				return
 			}
 		}
-	}(watcher)
+	}(watcher, logFile)
 
 	return watcher, nil
 }

--- a/integration-tests/pkg/executor/executor_k8s.go
+++ b/integration-tests/pkg/executor/executor_k8s.go
@@ -30,14 +30,12 @@ func newK8sExecutor() (*K8sExecutor, error) {
 		return nil, err
 	}
 
-	fmt.Println("Creating clientset")
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		fmt.Printf("Error: Failed to create client: %s", err)
 		return nil, err
 	}
 
-	fmt.Println("Done with executor construction")
 	k8s := &K8sExecutor{
 		clientset: clientset,
 	}
@@ -205,7 +203,6 @@ func (e *K8sExecutor) CapturePodConfiguration(testName, ns, podName string) erro
 func (e *K8sExecutor) CreateNamespaceEventWatcher(testName, ns string) (watch.Interface, error) {
 	watcher, err := e.clientset.CoreV1().Events(ns).Watch(context.Background(), metaV1.ListOptions{})
 	if err != nil {
-		fmt.Printf("Failed to start event watcher: %s\n", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

Listing namespace events is failing to get all events, limiting how useful they can be when debugging issues on the K8S based tests. This change makes it so goroutines are spawned with event watchers and events are continuously piped into output files, from the testing I've done this seems to be the most reliable method to always get useful events dumped.

There's also a minor refactor on the `k8s_namespace.go` file so that operations related to the target namespace are done closer together.

The trigger for this change was a CI run on the master branch that had no events on the output log, I managed to reproduce a similar error by attempting to run with a collector image that doesn't exist, causing it to go into pull backoff error. With this change the watchers still dump events stating the pod has gone into this state.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Tested manually with a non-existing collector image, as explained in the description section.
