### PR TITLE
Limit inclusion forwarding of the falco headers

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include <libsinsp/sinsp.h>
+
 #include "CollectorArgs.h"
 #include "EnvVar.h"
 #include "HostHeuristics.h"

--- a/collector/lib/ContainerMetadata.cpp
+++ b/collector/lib/ContainerMetadata.cpp
@@ -1,0 +1,38 @@
+#include "ContainerMetadata.h"
+
+#include <libsinsp/sinsp.h>
+
+#include "system-inspector/EventExtractor.h"
+
+namespace collector {
+
+ContainerMetadata::ContainerMetadata(sinsp* inspector) : event_extractor_(std::make_unique<system_inspector::EventExtractor>()), inspector_(inspector) {
+  event_extractor_->Init(inspector);
+}
+
+std::string ContainerMetadata::GetNamespace(sinsp_evt* event) {
+  const char* ns = event_extractor_->get_k8s_namespace(event);
+  return ns != nullptr ? ns : "";
+}
+
+std::string ContainerMetadata::GetNamespace(const std::string& container_id) {
+  return GetContainerLabel(container_id, "io.kubernetes.pod.namespace");
+}
+
+std::string ContainerMetadata::GetContainerLabel(const std::string& container_id, const std::string& label) {
+  auto containers = inspector_->m_container_manager.get_containers();
+  const auto& container = containers->find(container_id);
+  if (container == containers->end()) {
+    return "";
+  }
+
+  const auto& labels = container->second->m_labels;
+  const auto& label_it = labels.find(label);
+  if (label_it == labels.end()) {
+    return "";
+  }
+
+  return label_it->second;
+}
+
+}  // namespace collector

--- a/collector/lib/ContainerMetadata.h
+++ b/collector/lib/ContainerMetadata.h
@@ -1,43 +1,32 @@
 #ifndef _CONTAINER_METADATA_H_
 #define _CONTAINER_METADATA_H_
 
-#include "system-inspector/EventExtractor.h"
+#include <memory>
+#include <string>
+
+// forward declarations
+class sinsp;
+class sinsp_evt;
+namespace collector {
+namespace system_inspector {
+class EventExtractor;
+}
+}  // namespace collector
 
 namespace collector {
 
 class ContainerMetadata {
  public:
-  ContainerMetadata(sinsp* inspector) : inspector_(inspector) {
-    event_extractor_.Init(inspector);
-  }
+  ContainerMetadata(sinsp* inspector);
 
-  inline std::string GetNamespace(sinsp_evt* event) {
-    const char* ns = event_extractor_.get_k8s_namespace(event);
-    return ns != nullptr ? ns : "";
-  }
+  std::string GetNamespace(sinsp_evt* event);
 
-  inline std::string GetNamespace(const std::string& container_id) {
-    return GetContainerLabel(container_id, "io.kubernetes.pod.namespace");
-  }
+  std::string GetNamespace(const std::string& container_id);
 
-  inline std::string GetContainerLabel(const std::string& container_id, const std::string& label) {
-    auto containers = inspector_->m_container_manager.get_containers();
-    const auto& container = containers->find(container_id);
-    if (container == containers->end()) {
-      return "";
-    }
-
-    const auto& labels = container->second->m_labels;
-    const auto& label_it = labels.find(label);
-    if (label_it == labels.end()) {
-      return "";
-    }
-
-    return label_it->second;
-  }
+  std::string GetContainerLabel(const std::string& container_id, const std::string& label);
 
  private:
-  system_inspector::EventExtractor event_extractor_;
+  std::unique_ptr<system_inspector::EventExtractor> event_extractor_;
   sinsp* inspector_;
 };
 

--- a/collector/lib/NetworkSignalHandler.h
+++ b/collector/lib/NetworkSignalHandler.h
@@ -1,21 +1,27 @@
 #ifndef COLLECTOR_NETWORKSIGNALHANDLER_H
 #define COLLECTOR_NETWORKSIGNALHANDLER_H
 
+#include <memory>
 #include <optional>
 
 #include "ConnTracker.h"
 #include "SignalHandler.h"
-#include "system-inspector/EventExtractor.h"
 #include "system-inspector/SystemInspector.h"
+
+// forward declarations
+class sinsp;
+class sinsp_evt;
+namespace collector {
+namespace system_inspector {
+class EventExtractor;
+}
+}  // namespace collector
 
 namespace collector {
 
 class NetworkSignalHandler final : public SignalHandler {
  public:
-  explicit NetworkSignalHandler(sinsp* inspector, std::shared_ptr<ConnectionTracker> conn_tracker, system_inspector::Stats* stats)
-      : conn_tracker_(std::move(conn_tracker)), stats_(stats), collect_connection_status_(true) {
-    event_extractor_.Init(inspector);
-  }
+  explicit NetworkSignalHandler(sinsp* inspector, std::shared_ptr<ConnectionTracker> conn_tracker, system_inspector::Stats* stats);
 
   std::string GetName() override { return "NetworkSignalHandler"; }
   Result HandleSignal(sinsp_evt* evt) override;
@@ -27,7 +33,7 @@ class NetworkSignalHandler final : public SignalHandler {
  private:
   std::optional<Connection> GetConnection(sinsp_evt* evt);
 
-  system_inspector::EventExtractor event_extractor_;
+  std::unique_ptr<system_inspector::EventExtractor> event_extractor_;
   std::shared_ptr<ConnectionTracker> conn_tracker_;
   system_inspector::Stats* stats_;
 

--- a/collector/lib/Process.cpp
+++ b/collector/lib/Process.cpp
@@ -2,6 +2,8 @@
 
 #include <chrono>
 
+#include <libsinsp/sinsp.h>
+
 #include "CollectorStats.h"
 #include "system-inspector/Service.h"
 

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -1,6 +1,8 @@
 #ifndef _PROCESS_SIGNAL_FORMATTER_H_
 #define _PROCESS_SIGNAL_FORMATTER_H_
 
+#include <memory>
+
 #include "api/v1/signal.pb.h"
 #include "internalapi/sensor/signal_iservice.pb.h"
 #include "storage/process_indicator.pb.h"
@@ -9,15 +11,22 @@
 #include "ContainerMetadata.h"
 #include "EventNames.h"
 #include "ProtoSignalFormatter.h"
-#include "system-inspector/EventExtractor.h"
+
+// forward definitions
+class sinsp;
+class sinsp_threadinfo;
+namespace collector {
+namespace system_inspector {
+class EventExtractor;
+}
+}  // namespace collector
 
 namespace collector {
 
 class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamMessage> {
  public:
-  ProcessSignalFormatter(sinsp* inspector) : event_names_(EventNames::GetInstance()), container_metadata_(inspector) {
-    event_extractor_.Init(inspector);
-  }
+  ProcessSignalFormatter(sinsp* inspector);
+  ~ProcessSignalFormatter();
 
   using Signal = v1::Signal;
   using ProcessSignal = storage::ProcessSignal;
@@ -41,7 +50,7 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
   void CountLineage(const std::vector<LineageInfo>& lineage);
 
   const EventNames& event_names_;
-  system_inspector::EventExtractor event_extractor_;
+  std::unique_ptr<system_inspector::EventExtractor> event_extractor_;
   ContainerMetadata container_metadata_;
 };
 

--- a/collector/lib/ProcessSignalHandler.cpp
+++ b/collector/lib/ProcessSignalHandler.cpp
@@ -4,9 +4,12 @@
 
 #include <sys/sdt.h>
 
+#include <libsinsp/sinsp.h>
+
 #include "storage/process_indicator.pb.h"
 
 #include "RateLimit.h"
+#include "system-inspector/EventExtractor.h"
 
 namespace collector {
 

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -3,14 +3,17 @@
 
 #include <memory>
 
-#include "libsinsp/sinsp.h"
-
 #include <grpcpp/channel.h>
 
 #include "ProcessSignalFormatter.h"
 #include "RateLimit.h"
 #include "SignalHandler.h"
 #include "system-inspector/Service.h"
+
+// forward declarations
+class sinsp;
+class sinsp_evt;
+class sinsp_threadinfo;
 
 namespace collector {
 

--- a/collector/lib/ProtoSignalFormatter.h
+++ b/collector/lib/ProtoSignalFormatter.h
@@ -3,11 +3,12 @@
 
 #include <utility>
 
-#include "libsinsp/sinsp.h"
-
 #include <google/protobuf/message.h>
 
 #include "ProtoAllocator.h"
+
+// forward declarations
+class sinsp_evt;
 
 namespace collector {
 

--- a/collector/lib/SelfCheckHandler.cpp
+++ b/collector/lib/SelfCheckHandler.cpp
@@ -5,8 +5,32 @@
 
 #include "Logging.h"
 #include "SelfChecks.h"
+#include "system-inspector/EventExtractor.h"
 
 namespace collector {
+
+SelfCheckHandler::SelfCheckHandler(
+    sinsp* inspector,
+    std::chrono::seconds timeout) : inspector_(inspector), event_extractor_(std::make_unique<system_inspector::EventExtractor>()), timeout_(timeout) {
+  event_extractor_->Init(inspector);
+  start_ = std::chrono::steady_clock::now();
+}
+
+bool SelfCheckHandler::isSelfCheckEvent(sinsp_evt* evt) {
+  const std::string* name = event_extractor_->get_comm(evt);
+  const std::string* exe = event_extractor_->get_exe(evt);
+
+  if (name == nullptr || exe == nullptr) {
+    return false;
+  }
+
+  return name->compare(self_checks::kSelfChecksName) == 0 && exe->compare(self_checks::kSelfChecksExePath) == 0;
+}
+
+bool SelfCheckHandler::hasTimedOut() {
+  auto now = std::chrono::steady_clock::now();
+  return now > (start_ + timeout_);
+}
 
 SignalHandler::Result SelfCheckProcessHandler::HandleSignal(sinsp_evt* evt) {
   if (hasTimedOut()) {
@@ -32,8 +56,8 @@ SignalHandler::Result SelfCheckNetworkHandler::HandleSignal(sinsp_evt* evt) {
     return IGNORED;
   }
 
-  const uint16_t* server_port = event_extractor_.get_server_port(evt);
-  const uint16_t* client_port = event_extractor_.get_client_port(evt);
+  const uint16_t* server_port = event_extractor_->get_server_port(evt);
+  const uint16_t* client_port = event_extractor_->get_client_port(evt);
 
   if (server_port == nullptr || client_port == nullptr) {
     return IGNORED;

--- a/collector/lib/SignalHandler.h
+++ b/collector/lib/SignalHandler.h
@@ -4,7 +4,9 @@
 #include <string>
 #include <vector>
 
-#include "libsinsp/sinsp.h"
+// forward declarations
+class sinsp_evt;
+class sinsp_threadinfo;
 
 namespace collector {
 

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -18,6 +18,8 @@ extern "C" {
 #include <fstream>
 #include <regex>
 
+#include <libsinsp/sinsp.h>
+
 #include "HostInfo.h"
 #include "Logging.h"
 #include "Utility.h"

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -14,7 +14,8 @@
 #include <string_view>
 #include <utility>
 
-#include "libsinsp/sinsp.h"
+// forward declarations
+class sinsp_threadinfo;
 
 namespace collector {
 

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -7,6 +7,7 @@
 
 #include "libsinsp/container_engine/sinsp_container_type.h"
 #include "libsinsp/parsers.h"
+#include "libsinsp/sinsp.h"
 
 #include <google/protobuf/util/time_util.h>
 
@@ -15,6 +16,7 @@
 #include "CollectorStats.h"
 #include "ContainerEngine.h"
 #include "ContainerMetadata.h"
+#include "EventExtractor.h"
 #include "EventNames.h"
 #include "HostInfo.h"
 #include "KernelDriver.h"
@@ -33,6 +35,9 @@ constexpr char Service::kModulePath[];
 constexpr char Service::kModuleName[];
 constexpr char Service::kProbePath[];
 constexpr char Service::kProbeName[];
+
+Service::Service() {}
+Service::~Service() {}
 
 void Service::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTracker> conn_tracker) {
   // The self-check handlers should only operate during start up,
@@ -398,6 +403,10 @@ void Service::ServePendingProcessRequests() {
 
     pending_process_requests_.pop_front();
   }
+}
+
+bool Service::SignalHandlerEntry::ShouldHandle(sinsp_evt* evt) const {
+  return event_filter[evt->get_type()];
 }
 
 }  // namespace collector::system_inspector

--- a/collector/test/SystemInspectorServiceTest.cpp
+++ b/collector/test/SystemInspectorServiceTest.cpp
@@ -1,3 +1,5 @@
+#include <libsinsp/sinsp.h>
+
 #include "gtest/gtest.h"
 #include "system-inspector/Service.h"
 


### PR DESCRIPTION
## Description

This is to avoid unexpected conflicts when updating falco, and because we plan to decouple Collector from the probe implementation (makes it explicit which parts make direct use of types).

# Isolation strategy

- Everywhere possible, the `sinsp.h` includes have been moved from the header side to the implementation (.cpp)
- Only EventExtractor was kept with this include in its own header, as its interface is rooted in falco types.
- Users of EventExtractor then forward declare it and include the EventExtractor header from their implementation.

## Checklist
- [x] Investigated and inspected CI test results
