### PR TITLE
Add RHEL 9.4 block for legacy module versions

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -91,3 +91,4 @@
 # https://github.com/falcosecurity/libs/issues/918
 # Since kmods are not supported anyway, block these combination
 ~.*\.el8_9\..* * mod
+~.*\.el9_4\..* ~2\.[3-9]\..* *


### PR DESCRIPTION
## Description

Should fix the drivers failures on master.
