### PR TITLE
Bump layers used on the full image to 7

### DIFF
--- a/.github/workflows/collector-full.yml
+++ b/.github/workflows/collector-full.yml
@@ -26,7 +26,7 @@ on:
           GCP bucket to pull drivers from.
       max-layer-depth:
         type: string
-        default: "6"
+        default: "7"
         description: |
           Max layer the drivers will be split into
 


### PR DESCRIPTION
## Description

This is needed because the number of probes have exceeded the configured size. The master branch has an improved partitioning script that auto-adjusts this value, but I don't think it's worth the hassle to backport it.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI with `build-full-images` label should be enough.
