### PR TITLE
Inherit secrets for driver build failure check

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -50,6 +50,7 @@ jobs:
   check-drivers-failures:
     uses: ./.github/workflows/check-drivers-failures.yml
     needs: sync-drivers-and-support-packages
+    secrets: inherit
     with:
       logs-artifact:
         drivers-build-failures


### PR DESCRIPTION
## Description

The check-drivers-build-failures notification was failing because it didn't have secrets for the slack webhook. This PR simply passes those through to the workflow. 
