### PR TITLE
ROX-22474: push Konflux images to quay.io/rhacs-eng

### DIFF
--- a/.tekton/collector-pull-request.yaml
+++ b/.tekton/collector-pull-request.yaml
@@ -292,7 +292,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)-latest
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT

--- a/.tekton/collector-pull-request.yaml
+++ b/.tekton/collector-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: '13w'
   - name: output-image-repo
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/collector
+    value: quay.io/rhacs-eng/collector
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/collector-push.yaml
+++ b/.tekton/collector-push.yaml
@@ -292,7 +292,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)-latest
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT

--- a/.tekton/collector-push.yaml
+++ b/.tekton/collector-push.yaml
@@ -27,7 +27,7 @@ spec:
     # TODO(ROX-20230): make release images not expire.
     value: '13w'
   - name: output-image-repo
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/collector
+    value: quay.io/rhacs-eng/collector
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/collector-slim-pull-request.yaml
+++ b/.tekton/collector-slim-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: '13w'
   - name: output-image-repo
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/collector-slim
+    value: quay.io/rhacs-eng/collector-slim
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/collector-slim-pull-request.yaml
+++ b/.tekton/collector-slim-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: '13w'
   - name: output-image-repo
-    value: quay.io/rhacs-eng/collector-slim
+    value: quay.io/rhacs-eng/collector
   - name: path-context
     value: .
   - name: revision
@@ -288,7 +288,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)-slim
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT

--- a/.tekton/collector-slim-push.yaml
+++ b/.tekton/collector-slim-push.yaml
@@ -27,7 +27,7 @@ spec:
     # TODO(ROX-20230): make release images not expire.
     value: '13w'
   - name: output-image-repo
-    value: quay.io/rhacs-eng/collector-slim
+    value: quay.io/rhacs-eng/collector
   - name: path-context
     value: .
   - name: revision
@@ -288,7 +288,7 @@ spec:
     - name: build-container
       params:
       - name: IMAGE
-        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)
+        value: $(params.output-image-repo):$(tasks.determine-image-tag.results.image-tag)-slim
       - name: DOCKERFILE
         value: $(params.dockerfile)
       - name: CONTEXT

--- a/.tekton/collector-slim-push.yaml
+++ b/.tekton/collector-slim-push.yaml
@@ -27,7 +27,7 @@ spec:
     # TODO(ROX-20230): make release images not expire.
     value: '13w'
   - name: output-image-repo
-    value: quay.io/redhat-user-workloads/rh-acs-tenant/acs/collector-slim
+    value: quay.io/rhacs-eng/collector-slim
   - name: path-context
     value: .
   - name: revision


### PR DESCRIPTION
## Description

Switch to push images to `quay.io/rhacs-eng`.
Creates images like:

- `quay.io/rhacs-eng/collector:3.18.x-231-g2c316751d5-fast-latest`
- `quay.io/rhacs-eng/collector:3.18.x-231-g2c316751d5-fast-slim`

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Konflux passing with correct image names is sufficient.