### PR TITLE
Reload docker service

### DIFF
--- a/ansible/roles/provision-vm/tasks/docker.yml
+++ b/ansible/roles/provision-vm/tasks/docker.yml
@@ -1,10 +1,10 @@
 ---
 
-- name: Start docker service
-  service:
-    name: "docker"
-    enabled: true
+- name: Reload service
+  systemd:
     state: started
+    daemon_reload: true
+    name: docker
 
 - name: Add user to docker group
   user:


### PR DESCRIPTION
## Description

Make sure that the docker service was reloaded before doing anything else. This should address spurious "Could not find the requested service docker: host" error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

## Testing Performed

CI is sufficient.