### PR TITLE
Fixes for k8s based integration tests

### DIFF
--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ansible-playbook -vv \
+          ansible-playbook -vvvv \
             -i /tmp/inventory.yml \
             -e @/tmp/vars.yml \
             ansible/k8s-integration-tests.yml

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ansible-playbook -vvvv \
+          ansible-playbook \
             -i /tmp/inventory.yml \
             -e @/tmp/vars.yml \
             ansible/k8s-integration-tests.yml

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ansible-playbook \
+          ansible-playbook -vv \
             -i /tmp/inventory.yml \
             -e @/tmp/vars.yml \
             ansible/k8s-integration-tests.yml

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -313,6 +313,7 @@ The following is a list of variables used by the playbook.
 | collector_image | The collector image to be tested. |
 | collector_root | The path to the root of the collector repo, used for dumping logs. |
 | cluster_name | When using a KinD cluster, the name to be used for the cluster where the tests will run. Default: collector-tests |
+| container_engine | Specify the container engine to be used checking for local images to upload to KinD. Default: docker |
 
 Easiest way to manage these variables is to create a yaml file that can later
 be supplied to the `ansible-playbook` command, the following should work as a

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -33,8 +33,9 @@
       changed_when: false
 
     - name: Check collector image exists locally
-      community.docker.docker_image_info:
+      containers.podman.podman_image_info:
         name: "{{ collector_image }}"
+        executable: docker
       register: collector_image_info
 
     - name: Load collector image into kind cluster
@@ -44,8 +45,9 @@
       changed_when: false
 
     - name: Check tester image exists locally
-      community.docker.docker_image_info:
+      containers.podman.podman_image_info:
         name: "{{ tester_image }}"
+        executable: docker
       register: tester_image_info
 
     - name: Load tester image into kind cluster

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -4,6 +4,7 @@
 
   vars:
     kind_name: "{{ cluster_name | default('collector-tests') }}"
+    container_engine: "{{ container_engine | default('docker') }}"
 
   tasks:
     - name: Check KinD is installed
@@ -33,10 +34,16 @@
       changed_when: false
 
     - name: Check collector image exists locally
+      community.docker.docker_image_info:
+        name: "{{ collector_image }}"
+      register: collector_image_info
+      when: container_engine == 'docker'
+
+    - name: Check collector image exists locally
       containers.podman.podman_image_info:
         name: "{{ collector_image }}"
-        executable: docker
       register: collector_image_info
+      when: container_engine == 'podman'
 
     - name: Load collector image into kind cluster
       ansible.builtin.command:
@@ -45,10 +52,16 @@
       changed_when: false
 
     - name: Check tester image exists locally
+      community.docker.docker_image_info:
+        name: "{{ tester_image }}"
+      register: tester_image_info
+      when: container_engine == 'docker'
+
+    - name: Check tester image exists locally
       containers.podman.podman_image_info:
         name: "{{ tester_image }}"
-        executable: docker
       register: tester_image_info
+      when: container_engine == 'podman'
 
     - name: Load tester image into kind cluster
       ansible.builtin.command:

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -57,6 +57,10 @@
       register: collector_image_info
       when: c_engine == 'podman'
 
+    - name: print collector image
+      debug:
+        msg: "{{ collector_image_info }}"
+
     - name: Load collector image into kind cluster
       ansible.builtin.command:
         cmd: kind --name {{ kind_name }} load docker-image {{ collector_image }}

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -7,18 +7,6 @@
     c_engine: "{{ container_engine | default('docker') }}"
 
   tasks:
-    - name: show user
-      debug:
-        msg: "{{ ansible_user_id }}"
-
-    - name: gather groups
-      shell: groups
-      register: host_groups
-
-    - name: show groups
-      debug:
-        msg: "{{ host_groups.stdout }}"
-
     - name: Check KinD is installed
       ansible.builtin.command: which kind
       register: is_kind_available

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -4,7 +4,7 @@
 
   vars:
     kind_name: "{{ cluster_name | default('collector-tests') }}"
-    container_engine: "{{ container_engine | default('docker') }}"
+    c_engine: "{{ container_engine | default('docker') }}"
 
   tasks:
     - name: Check KinD is installed
@@ -37,13 +37,13 @@
       community.docker.docker_image_info:
         name: "{{ collector_image }}"
       register: collector_image_info
-      when: container_engine == 'docker'
+      when: c_engine == 'docker'
 
     - name: Check collector image exists locally
       containers.podman.podman_image_info:
         name: "{{ collector_image }}"
       register: collector_image_info
-      when: container_engine == 'podman'
+      when: c_engine == 'podman'
 
     - name: Load collector image into kind cluster
       ansible.builtin.command:
@@ -55,13 +55,13 @@
       community.docker.docker_image_info:
         name: "{{ tester_image }}"
       register: tester_image_info
-      when: container_engine == 'docker'
+      when: c_engine == 'docker'
 
     - name: Check tester image exists locally
       containers.podman.podman_image_info:
         name: "{{ tester_image }}"
       register: tester_image_info
-      when: container_engine == 'podman'
+      when: c_engine == 'podman'
 
     - name: Load tester image into kind cluster
       ansible.builtin.command:

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -7,6 +7,10 @@
     c_engine: "{{ container_engine | default('docker') }}"
 
   tasks:
+    - name: show groups
+      debug:
+        msg: "{{ group_names }}"
+
     - name: Check KinD is installed
       ansible.builtin.command: which kind
       register: is_kind_available

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -7,9 +7,17 @@
     c_engine: "{{ container_engine | default('docker') }}"
 
   tasks:
+    - name: show user
+      debug:
+        msg: "{{ ansible_user_id }}"
+
+    - name: gather groups
+      shell: groups
+      register: host_groups
+
     - name: show groups
       debug:
-        msg: "{{ group_names }}"
+        msg: "{{ host_groups.stdout }}"
 
     - name: Check KinD is installed
       ansible.builtin.command: which kind

--- a/ansible/k8s-integration-tests.yml
+++ b/ansible/k8s-integration-tests.yml
@@ -45,45 +45,17 @@
 
       changed_when: false
 
-    - name: Check collector image exists locally
-      community.docker.docker_image_info:
-        name: "{{ collector_image }}"
-      register: collector_image_info
-      when: c_engine == 'docker'
-
-    - name: Check collector image exists locally
-      containers.podman.podman_image_info:
-        name: "{{ collector_image }}"
-      register: collector_image_info
-      when: c_engine == 'podman'
-
-    - name: print collector image
-      debug:
-        msg: "{{ collector_image_info }}"
-
     - name: Load collector image into kind cluster
-      ansible.builtin.command:
-        cmd: kind --name {{ kind_name }} load docker-image {{ collector_image }}
-      when: collector_image_info.images | length == 1
-      changed_when: false
-
-    - name: Check tester image exists locally
-      community.docker.docker_image_info:
-        name: "{{ tester_image }}"
-      register: tester_image_info
-      when: c_engine == 'docker'
-
-    - name: Check tester image exists locally
-      containers.podman.podman_image_info:
-        name: "{{ tester_image }}"
-      register: tester_image_info
-      when: c_engine == 'podman'
+      include_role:
+        name: kind-load-image
+      vars:
+        image: "{{ collector_image }}"
 
     - name: Load tester image into kind cluster
-      ansible.builtin.command:
-        cmd: kind --name {{ kind_name }} load docker-image {{ tester_image }}
-      when: tester_image_info.images | length == 1
-      changed_when: false
+      include_role:
+        name: kind-load-image
+      vars:
+        image: "{{ tester_image }}"
 
     - name: Create a namespace for collector tests
       kubernetes.core.k8s:

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,4 +1,6 @@
 ansible
+# TODO: unpin after https://github.com/docker/docker-py gets a release with
+# https://github.com/docker/docker-py/commit/7785ad913ddf2d86478f08278bb2c488d05a29ff
 requests==2.31.0
 google-auth
 selinux

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-requests
+requests==2.31.0
 google-auth
 selinux
 kubernetes

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,7 @@
 ---
 collections:
 - community.general
+- community.docker
 - containers.podman
 - ibm.cloudcollection
 - kubernetes.core

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
 - community.general
-- community.docker
+- containers.podman
 - ibm.cloudcollection
 - kubernetes.core

--- a/ansible/roles/kind-load-image/tasks/docker.yml
+++ b/ansible/roles/kind-load-image/tasks/docker.yml
@@ -3,9 +3,3 @@
   community.docker.docker_image_info:
     name: "{{ image }}"
   register: image_info
-
-- name: Load image into kind cluster
-  ansible.builtin.command:
-    cmd: kind --name {{ kind_name }} load docker-image {{ image }}
-  when: image_info.images | length == 1
-  changed_when: false

--- a/ansible/roles/kind-load-image/tasks/docker.yml
+++ b/ansible/roles/kind-load-image/tasks/docker.yml
@@ -1,0 +1,11 @@
+---
+- name: Check image exists locally
+  community.docker.docker_image_info:
+    name: "{{ image }}"
+  register: image_info
+
+- name: Load image into kind cluster
+  ansible.builtin.command:
+    cmd: kind --name {{ kind_name }} load docker-image {{ image }}
+  when: image_info.images | length == 1
+  changed_when: false

--- a/ansible/roles/kind-load-image/tasks/main.yml
+++ b/ansible/roles/kind-load-image/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Load image via docker
+  include_tasks: docker.yml
+  when: c_engine == 'docker'
+
+- name: Load image via podman
+  include_tasks: podman.yml
+  when: c_engine == 'podman'

--- a/ansible/roles/kind-load-image/tasks/main.yml
+++ b/ansible/roles/kind-load-image/tasks/main.yml
@@ -6,3 +6,9 @@
 - name: Load image via podman
   include_tasks: podman.yml
   when: c_engine == 'podman'
+
+- name: Load image into kind cluster
+  ansible.builtin.command:
+    cmd: kind --name {{ kind_name }} load docker-image {{ image }}
+  when: image_info.images | length == 1
+  changed_when: false

--- a/ansible/roles/kind-load-image/tasks/podman.yml
+++ b/ansible/roles/kind-load-image/tasks/podman.yml
@@ -3,9 +3,3 @@
   containers.podman.podman_image_info:
     name: "{{ image }}"
   register: image_info
-
-- name: Load image into kind cluster
-  ansible.builtin.command:
-    cmd: kind --name {{ kind_name }} load docker-image {{ image }}
-  when: image_info.images | length == 1
-  changed_when: false

--- a/ansible/roles/kind-load-image/tasks/podman.yml
+++ b/ansible/roles/kind-load-image/tasks/podman.yml
@@ -1,0 +1,11 @@
+---
+- name: Check image exists locally
+  containers.podman.podman_image_info:
+    name: "{{ image }}"
+  register: image_info
+
+- name: Load image into kind cluster
+  ansible.builtin.command:
+    cmd: kind --name {{ kind_name }} load docker-image {{ image }}
+  when: image_info.images | length == 1
+  changed_when: false


### PR DESCRIPTION
## Description

This change was triggered by an issue on CI where the k8s based integration tests were failing to upload the collector image to the kind cluster. The culprit for this error was a breaking change on the python requests package, see:
- https://github.com/docker/docker-py/issues/3256
- https://github.com/docker/docker-py/pull/3257

For the time being and until a new release of the docker Python SDK is uploaded, pinning requests to version 2.31.0 seems to fix the issue.

While trying to debug the issue locally with podman v5 it was found out the community.docker module is incompatible. In order to work around this, a new role was added so people can chose to upload images from docker or podman via the `container_engine` variable. Ideally we would have a way to decide which to use automatically, but GHA has both docker and podman installed by default and messing about with versions seems a bit overkill, at least for the moment.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
