### PR TITLE
Skip EL 8 and 9 kernel modules for 3.74

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -92,3 +92,4 @@
 # Since kmods are not supported anyway, block these combination
 ~.*\.el8_9\..* * mod
 ~.*\.el9_4\..* ~2\.[3-9]\..* *
+~.*\.el[89].* 2.3.0 mod


### PR DESCRIPTION
## Description

Kernel modules for newer EL 8 and 9 kernels for 3.74 are failing with the following error message:
```
============================================================================
Failed to build mod probe
Module version: 2.3.0
Kernel version: 4.18.0-553.el8_10.x86_64

/kobuild-tmp/versions-src/2.3.0/main.c: In function 'scap_init':
/kobuild-tmp/versions-src/2.3.0/main.c:3245:23: error: assignment to 'char * (*)(const struct device *, umode_t *)' {aka 'char * (*)(const struct device *, short unsigned int *)'} from incompatible pointer type 'char * (*)(struct device *, umode_t *)' {aka 'char * (*)(struct device *, short unsigned int *)'} [-Werror=incompatible-pointer-types]
  g_ppm_class->devnode = ppm_devnode;
                       ^
In file included from /kobuild-tmp/versions-src/2.3.0/ppm_fillers.c:100:
/kobuild-tmp/versions-src/2.3.0/kernel_hacks.h:33: warning: "copy_from_kernel_nofault" redefined
 #define copy_from_kernel_nofault probe_kernel_read
 
In file included from ./include/linux/crypto.h:26,
                 from ./include/crypto/hash.h:16,
                 from ./include/linux/uio.h:16,
                 from ./include/linux/socket.h:8,
                 from ./include/linux/compat.h:15,
                 from /kobuild-tmp/versions-src/2.3.0/ppm_fillers.c:12:
./include/linux/uaccess.h:396: note: this is the location of the previous definition
 #define copy_from_kernel_nofault(a,b,c) probe_kernel_read(a,b,c)
 
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:317: /kobuild-tmp/versions-src/2.3.0/main.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:1619: _module_/kobuild-tmp/versions-src/2.3.0] Error 2
make: *** [Makefile:16: all] Error 2
strip: 'collector.ko': No such file
modinfo: ERROR: Module alias collector.ko not found.
Corrupted probe, KO_VERSION=, BUNDLE_UNAME=4.18.0-553.el8_10.x86_64


============================================================================
```

Since we only need to build drivers for EL7, we can just block these.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run with `build-legacy-probes`.