### PR TITLE
Rename runtime filters to config

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -48,7 +48,7 @@ BoolEnvVar enable_connection_stats("ROX_COLLECTOR_ENABLE_CONNECTION_STATS", true
 
 BoolEnvVar enable_detailed_metrics("ROX_COLLECTOR_ENABLE_DETAILED_METRICS", true);
 
-BoolEnvVar enable_runtime_filters("ROX_COLLECTOR_RUNTIME_FILTERS_ENABLED", false);
+BoolEnvVar enable_runtime_config("ROX_COLLECTOR_RUNTIME_CONFIG_ENABLED", false);
 
 BoolEnvVar use_docker_ce("ROX_COLLECTOR_CE_USE_DOCKER", false);
 BoolEnvVar use_podman_ce("ROX_COLLECTOR_CE_USE_PODMAN", false);
@@ -80,7 +80,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
   enable_external_ips_ = enable_external_ips.value();
   enable_connection_stats_ = enable_connection_stats.value();
   enable_detailed_metrics_ = enable_detailed_metrics.value();
-  enable_runtime_filters_ = enable_runtime_filters.value();
+  enable_runtime_config_ = enable_runtime_config.value();
   use_docker_ce_ = use_docker_ce.value();
   use_podman_ce_ = use_podman_ce.value();
   enable_introspection_ = enable_introspection.value();

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -75,7 +75,7 @@ class CollectorConfig {
   bool EnableExternalIPs() const { return enable_external_ips_; }
   bool EnableConnectionStats() const { return enable_connection_stats_; }
   bool EnableDetailedMetrics() const { return enable_detailed_metrics_; }
-  bool EnableRuntimeFilters() const { return enable_runtime_filters_; }
+  bool EnableRuntimeConfig() const { return enable_runtime_config_; }
   bool UseDockerCe() const { return use_docker_ce_; }
   bool UsePodmanCe() const { return use_podman_ce_; }
   bool IsIntrospectionEnabled() const { return enable_introspection_; }
@@ -112,7 +112,7 @@ class CollectorConfig {
   bool enable_external_ips_;
   bool enable_connection_stats_;
   bool enable_detailed_metrics_;
-  bool enable_runtime_filters_;
+  bool enable_runtime_config_;
   bool use_docker_ce_;
   bool use_podman_ce_;
   bool enable_introspection_;

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -97,7 +97,7 @@ bool Service::InitKernel(const CollectorConfig& config, const DriverCandidate& c
 
     container_metadata_inspector_.reset(new ContainerMetadata(inspector_.get()));
 
-    if (config.EnableRuntimeFilters()) {
+    if (config.EnableRuntimeConfig()) {
       uint64_t mask = 1 << CT_CRI |
                       1 << CT_CRIO |
                       1 << CT_CONTAINERD;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -511,7 +511,7 @@ $ curl collector:8080/state/containers/01e8c0454972
 In order for the metadata to be collected, the collector daemonset needs to be
 edited for it to have access to the corresponding CRI socket on the system.
 Since metadata collection is locked behind a feature flag, the
-`ROX_COLLECTOR_RUNTIME_FILTERS_ENABLED` needs to be set to `true` as well.
+`ROX_COLLECTOR_RUNTIME_CONFIG_ENABLED` needs to be set to `true` as well.
 
 ```yaml
 spec:
@@ -520,7 +520,7 @@ spec:
       containers:
         ...
         env:
-        - name: ROX_COLLECTOR_RUNTIME_FILTERS_ENABLED
+        - name: ROX_COLLECTOR_RUNTIME_CONFIG_ENABLED
           value: "true"
         ...
         volumeMounts:
@@ -585,7 +585,7 @@ Example of connection query, limited to container with identifier `c6f030bc4b42`
 ```
 $ curl "http://<collector>:8080/state/network/connection?container=c6f030bc4b42"
 {
-  "c6f030bc4b42" : 
+  "c6f030bc4b42" :
   [
     {
       "active" : true,

--- a/integration-tests/suites/k8s_namespace.go
+++ b/integration-tests/suites/k8s_namespace.go
@@ -55,8 +55,8 @@ func (k *K8sNamespaceTestSuite) SetupSuite() {
 
 	err := k.Collector().Setup(&collector.StartupOptions{
 		Env: map[string]string{
-			"ROX_COLLECTOR_RUNTIME_FILTERS_ENABLED": "true",
-			"ROX_COLLECTOR_INTROSPECTION_ENABLE":    "true",
+			"ROX_COLLECTOR_RUNTIME_CONFIG_ENABLED": "true",
+			"ROX_COLLECTOR_INTROSPECTION_ENABLE":   "true",
 		},
 	})
 	k.Require().NoError(err)


### PR DESCRIPTION

## Description

Since the initial implementation, we've expanded the reach for the runtime filters and it has been renamed to runtime configuration, so we should rename some part of our code to match this.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should suffice.
