### PR TITLE
Unpin requests version

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,7 +1,5 @@
 ansible
-# TODO: unpin after https://github.com/docker/docker-py gets a release with
-# https://github.com/docker/docker-py/commit/7785ad913ddf2d86478f08278bb2c488d05a29ff
-requests==2.31.0
+requests
 google-auth
 selinux
 kubernetes


### PR DESCRIPTION
## Description

A new version of docker-py has been released containing a fix we needed so the k8s based tests can work on the latest versions of requests.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
