### PR TITLE
Build 2.9.1 drivers

### DIFF
--- a/RELEASED_VERSIONS
+++ b/RELEASED_VERSIONS
@@ -40,3 +40,4 @@
 3.18.1 4.4.1  # Rox release 4.4.1 by rhacs-bot at Mon Apr 22 22:31:40 UTC 2024
 3.17.0 4.3.7  # Rox release 4.3.7 by roxbot at Mon May 13 12:44:58 UTC 2024
 3.18.2 4.4.2  # Rox release 4.4.2 by rhacs-bot at Tue May 21 09:17:33 UTC 2024
+3.18.3 4.4.3  # Mock release


### PR DESCRIPTION
## Description

This change mocks a release for the 2.9.1 drivers and reenables driver builds on the release branch. This is done to fix a failure to build support-packages in the master branch. The fix is just a workaround, but because driver deprecation and removal is coming soon, I think this should be good enough.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
