### PR TITLE
Run integration tests on konflux built images

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,13 @@ on:
           Optional repository to use for the collector image
         type: string
         default: "quay.io/rhacs-eng/collector"
+      is-konflux:
+        description: |
+          Marker for workflows triggered for a konflux build.
+          These builds don't support multiarch, so it should only run x86
+          tests
+        type: boolean
+        default: false
 
 jobs:
   amd64-required-integration-tests:
@@ -70,7 +77,11 @@ jobs:
 
   arm64-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+    if: |
+      !inputs.is-konflux && (
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
     strategy:
       # ensure that if one part of the matrix fails, the
       # rest will continue
@@ -92,7 +103,11 @@ jobs:
 
   s390x-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || github.event_name == 'push'
+    if: |
+      !inputs.is-konflux && (
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
     with:
       vm_type: rhel-s390x
       collector-tag: ${{ inputs.collector-tag }}
@@ -103,7 +118,11 @@ jobs:
 
   ppc64le-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') || github.event_name == 'push'
+    if: |
+      !inputs.is-konflux && (
+        github.event_name == 'push' ||
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
     with:
       vm_type: rhel-ppc64le
       collector-tag: ${{ inputs.collector-tag }}

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -17,7 +17,7 @@ on:
 env:
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
   COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/qa-multi-arch:collector-tests-${{ inputs.collector-tag }}
-  COLLECTOR_IMAGE: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
+  COLLECTOR_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
 
 jobs:
   k8s-integration-tests:

--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -1,0 +1,85 @@
+name: Run konflux tests
+
+on:
+  workflow_call:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      collector-tag: ${{ steps.generate-tag.outputs.collector-tag }}
+      collector-qa-tag: ${{ steps.generate-tag.outputs.collector-qa-tag }}
+      rebuild-qa-containers: ${{ steps.filter.outputs.container }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          submodules: true
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: shell
+
+          # Only trigger a rebuild when the QA tag has changed
+          filters: |
+            container:
+              - integration-tests/container/QA_TAG
+
+      - id: generate-tag
+        run: |
+          echo "collector-tag=$(make tag)-fast" >> "$GITHUB_OUTPUT"
+
+          COLLECTOR_QA_TAG="$(cat ${{ github.workspace }}/integration-tests/container/QA_TAG)"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${{ steps.filter.outputs.container }}" == "true" ]]; then
+            COLLECTOR_QA_TAG="${COLLECTOR_QA_TAG}-${COLLECTOR_TAG}"
+          fi
+
+          echo "collector-qa-tag=${COLLECTOR_QA_TAG}" >> "$GITHUB_OUTPUT"
+
+  wait-for-images:
+    runs-on: ubuntu-latest
+    needs:
+    - init
+    steps:
+      - uses: stackrox/actions/release/wait-for-image@v1
+        with:
+          token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          image: rhacs-eng/collector:${{ needs.init.outputs.collector-tag }}
+
+  integration-tests-containers:
+    uses: ./.github/workflows/integration-test-containers.yml
+    needs:
+    - init
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+      collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
+      rebuild-qa-containers: ${{ needs.init.outputs.rebuild-qa-containers == 'true' }}
+    secrets: inherit
+
+  run-konflux-tests:
+    uses: ./.github/workflows/integration-tests.yml
+    needs:
+    - init
+    - wait-for-images
+    - integration-tests-containers
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+      collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
+      is-konflux: true
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
+    secrets: inherit
+
+  k8s-integration-tests:
+    uses: ./.github/workflows/k8s-integration-tests.yml
+    with:
+      collector-tag: ${{ needs.init.outputs.collector-tag }}
+      collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
+    needs:
+    - init
+    - wait-for-images
+    - integration-tests-containers
+    secrets: inherit
+

--- a/.github/workflows/konflux.yml
+++ b/.github/workflows/konflux.yml
@@ -1,0 +1,31 @@
+name: Run konflux workflows
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+      - mauro/*
+    tags:
+      - 3.*.*
+      - mauro-test-*
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - reopened
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-konflux
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    uses: ./.github/workflows/konflux-tests.yml
+    if: github.event_name == 'push' ||
+        contains(github.head_ref, 'konflux') ||
+        contains(github.head_ref, 'rhtap')
+    secrets: inherit
+

--- a/.github/workflows/konflux.yml
+++ b/.github/workflows/konflux.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - master
       - release-*
-      - mauro/*
     tags:
       - 3.*.*
-      - mauro-test-*
   pull_request:
     types:
       - labeled


### PR DESCRIPTION
## Description

Since konflux seems to be coming along quite nicely and the recent changes have made it so only one image is built for it, it seems like a good moment to start properly testing the images in our CI. With this change tests will be run on the konflux built images on master, tags and PRs for branches that contain the words `konflux` or `rhtap`.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Tests are run with the `-fast` images on PRs. [CI run](https://github.com/stackrox/collector/actions/runs/9353675500)
- [x] Tests are run with the `-fast` images on branch pushes. [CI run](https://github.com/stackrox/collector/actions/runs/9353674902)
- [x] Tests are run with the `-fast` images on tag pushes. [CI run](https://github.com/stackrox/collector/actions/runs/9353754666)
