### PR TITLE
Control normalization in network introspection API

### DIFF
--- a/collector/lib/NetworkStatusInspector.h
+++ b/collector/lib/NetworkStatusInspector.h
@@ -2,8 +2,6 @@
 #define COLLECTOR_NETWORKSTATUSINSPECTOR_H
 
 #include <memory>
-#include <optional>
-#include <unordered_map>
 
 #include <json/writer.h>
 
@@ -29,6 +27,9 @@ class NetworkStatusInspector : public IntrospectionEndpoint {
   Json::FastWriter writer_;
 
   static const std::string kQueryParam_container;  // = "container"
+  static const std::string kQueryParam_normalize;  // = "normalize"
+
+  bool shouldNormalize(const QueryParams& queryParams) const;
 
   bool handleGetEndpoints(struct mg_connection* conn, const QueryParams& queryParams);
   bool handleGetConnections(struct mg_connection* conn, const QueryParams& queryParams);

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -580,10 +580,14 @@ Afterglow is not applied to the data returned by this API.
 It is possible to filter the items returned per container_id by providing
 a query parameter: `container=<container_id>`
 
-Example of connection query, limited to container with identifier `c6f030bc4b42`:
+By default, connections and endpoints are normalized in the result. It is
+possible to disable normalization with a query parameter: `normalize=false`
+
+Example of connection query, limited to container with identifier `c6f030bc4b42`
+and without normalization :
 
 ```
-$ curl "http://<collector>:8080/state/network/connection?container=c6f030bc4b42"
+$ curl "http://<collector>:8080/state/network/connection?container=c6f030bc4b42&normalize=false"
 {
   "c6f030bc4b42" :
   [


### PR DESCRIPTION
## Description

With normalization always enabled, the introspection API cannot be used to retrieve all IP addresses. So we add a parameter to disable it.

Link to the updated documentation: https://github.com/stackrox/collector/blob/ovalenti/conn_introspection_no_normalize/docs/troubleshooting.md#network-endpoint

## Checklist
- [x] Investigated and inspected CI test results
- [x] Tested the behavior manually at least once (deployed the image built from CI and query the endpoint with `normalize=false`
- [x] Updated documentation accordingly