### PR TITLE
Unblock drivers for RHEL 9.4+ on 2.9.1

### DIFF
--- a/kernel-modules/BLOCKLIST
+++ b/kernel-modules/BLOCKLIST
@@ -92,7 +92,8 @@
 # https://github.com/falcosecurity/libs/issues/918
 # Since kmods are not supported anyway, block these combination
 ~.*\.el8_9\..* * mod
-~.*\.el9_4\..* ~2\.[3-9]\..* *
+~.*\.el9_4\..* ~2\.[3-8]\..* *
+~.*\.el9_4\..* 2.9.0 *
 ~.*\.el[89].* 2.3.0 mod
 # Block unsupported fedora kernels
 ~.*\.fc3[4-8].* 2.9.1 *


### PR DESCRIPTION
## Description

eBPF drivers for RHEL 9.4 should be supported starting with version 2.9.1

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run with `build-legacy-probes` label.