### PR TITLE
Don't build support packages for 2.10.0 and newer

### DIFF
--- a/.github/workflows/main-drivers.yml
+++ b/.github/workflows/main-drivers.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
   pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - reopened
 
 jobs:
   init:

--- a/.github/workflows/main-drivers.yml
+++ b/.github/workflows/main-drivers.yml
@@ -58,7 +58,8 @@ jobs:
       public-support-packages-bucket: ${{ needs.init.outputs.public-support-packages-bucket }}
     if: |
       always() &&
-      (github.event_name == 'push' && github.ref_name == 'master')
+      ((github.event_name == 'push' && github.ref_name == 'master') ||
+      contains(github.event.pull_request.labels.*.name, 'test-support-packages'))
     needs:
     - init
     - build-drivers

--- a/.github/workflows/support-packages.yml
+++ b/.github/workflows/support-packages.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Create support-packages
         run: |
           ${{ github.workspace }}/kernel-modules/support-packages/04-create-support-packages.sh \
-            ${{ github.workspace }}/collector/LICENSE-kernel-modules.txt \
+            ${{ github.workspace }}/collector/kernel-modules/LICENSE \
             gs://${{ inputs.upstream-drivers-bucket }} \
             /tmp/support-packages/metadata \
             /tmp/support-packages/output \

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -42,7 +42,7 @@ mkdir -p "${OUT_DIR}" || die "Failed to create output directory '${OUT_DIR}'"
 for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     mod_ver="$(basename "$mod_ver_dir")"
 
-    if dont_build_support_package "$mod_ver"; then
+    if skip_version "$mod_ver"; then
         continue
     fi
 

--- a/kernel-modules/support-packages/04-create-support-packages.sh
+++ b/kernel-modules/support-packages/04-create-support-packages.sh
@@ -42,6 +42,10 @@ mkdir -p "${OUT_DIR}" || die "Failed to create output directory '${OUT_DIR}'"
 for mod_ver_dir in "${MD_DIR}/module-versions"/*; do
     mod_ver="$(basename "$mod_ver_dir")"
 
+    if dont_build_support_package "$mod_ver"; then
+        continue
+    fi
+
     package_root="$(mktemp -d)"
     probe_dir="${package_root}/kernel-modules/${mod_ver}"
     mkdir -p "$probe_dir"

--- a/kernel-modules/support-packages/utils.sh
+++ b/kernel-modules/support-packages/utils.sh
@@ -33,6 +33,10 @@ use_downstream_only() {
     _check_min_version "$1" "2.9.0"
 }
 
+dont_build_support_package() {
+    _check_min_version "$1" "2.10.0"
+}
+
 bucket_has_drivers() {
     count=$(gsutil ls "$1" | wc -l)
 

--- a/kernel-modules/support-packages/utils.sh
+++ b/kernel-modules/support-packages/utils.sh
@@ -33,7 +33,7 @@ use_downstream_only() {
     _check_min_version "$1" "2.9.0"
 }
 
-dont_build_support_package() {
+skip_version() {
     _check_min_version "$1" "2.10.0"
 }
 


### PR DESCRIPTION
## Description

Following eBPF turn off, this will prevent support package creation for newer module versions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
