### PR TITLE
ROX-20230: bump image expiration on Konflux to 1 year

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -25,8 +25,8 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after
-    # TODO(ROX-20230): make release images not expire.
-    value: '13w'
+    # TODO(ROX-24530): return expiration for non-released images to 13w
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/collector
   - name: path-context


### PR DESCRIPTION
## Description

Per title. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Image builds
- [x] Image has annotation with expiration set to 52w in Quay.io