### PR TITLE
Pin ansible version to allow RHEL 8 tests to work

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,4 +1,6 @@
-ansible
+# TODO: unpin if RHEL 8 VMs on GCP update their python interpreter to 3.7+
+# https://github.com/ansible/ansible/blob/v2.17.0/changelogs/CHANGELOG-v2.17.rst#removed-features-previously-deprecated
+ansible<10
 # TODO: unpin after https://github.com/docker/docker-py gets a release with
 # https://github.com/docker/docker-py/commit/7785ad913ddf2d86478f08278bb2c488d05a29ff
 requests==2.31.0


### PR DESCRIPTION
## Description

Ansible 10 has removed support for python 3.6 on remote systems, which also happens to be the version shipped with RHEL 8.  In order to get our tests up and running again, we can politely ask pip to install a version less than 10 for ansible.

References:
- ansible-core removes support for Python 3.6 on remote systems: https://github.com/ansible/ansible/blob/v2.17.0/changelogs/CHANGELOG-v2.17.rst#removed-features-previously-deprecated
- Failing tests on RHEL 8: https://github.com/stackrox/collector/actions/runs/9369754292/job/25829475272

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Validate the RHEL 8 tests now work correctly.
