### PR TITLE
Remove support packages from driver workflow notification

### DIFF
--- a/.github/workflows/main-drivers.yml
+++ b/.github/workflows/main-drivers.yml
@@ -73,7 +73,6 @@ jobs:
     - init
     - build-drivers
     - upload-drivers
-    - build-support-packages
     steps:
       - name: Slack notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Description

Support package workflow handles its own notifications, so remove it from the main driver workflow to avoid double notifications.
