### PR TITLE
Enable stats v2

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -313,7 +313,7 @@ void CollectorConfig::HandleSinspEnvVars() {
   if ((envvar = std::getenv("ROX_COLLECTOR_SINSP_TOTAL_BUFFER_SIZE")) != NULL) {
     try {
       sinsp_total_buffer_size_ = std::stoll(envvar);
-      CLOG(INFO) << "Sinsp total buffer size: " << sinsp_buffer_size_;
+      CLOG(INFO) << "Sinsp total buffer size: " << sinsp_total_buffer_size_;
     } catch (...) {
       CLOG(ERROR) << "Invalid total buffer size value: '" << envvar << "'";
     }

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -112,6 +112,8 @@ void CollectorStatsExporter::run() {
 
   auto& kernel = collectorEventCounters.Add({{"type", "kernel"}});
   auto& drops = collectorEventCounters.Add({{"type", "drops"}});
+  auto& threadCacheDrops = collectorEventCounters.Add({{"type", "threadCacheDrops"}});
+  auto& ringbufferDrops = collectorEventCounters.Add({{"type", "ringbufferDrops"}});
   auto& preemptions = collectorEventCounters.Add({{"type", "preemptions"}});
   auto& grpcSendFailures = collectorEventCounters.Add({{"type", "grpcSendFailures"}});
   auto& threadTableSize = collectorEventCounters.Add({{"type", "threadCacheSize"}});
@@ -223,6 +225,8 @@ void CollectorStatsExporter::run() {
 
     kernel.Set(stats.nEvents);
     drops.Set(stats.nDrops);
+    threadCacheDrops.Set(stats.nDropsThreadCache);
+    ringbufferDrops.Set(stats.nDropsBuffer);
     preemptions.Set(stats.nPreemptions);
     threadTableSize.Set(stats.nThreadCacheSize);
 

--- a/collector/lib/GetStatus.cpp
+++ b/collector/lib/GetStatus.cpp
@@ -15,11 +15,16 @@ bool GetStatus::handleGet(CivetServer* server, struct mg_connection* conn) {
   bool ready = system_inspector_->GetStats(&stats);
 
   if (ready) {
+    Json::Value drops = Json::Value(Json::objectValue);
+    drops["total"] = Json::UInt64(stats.nDrops);
+    drops["ringbuffer"] = Json::UInt64(stats.nDropsBuffer);
+    drops["threadcache"] = Json::UInt64(stats.nDropsThreadCache);
+
     status["status"] = "ok";
     status["collector"] = Json::Value(Json::objectValue);
     status["collector"]["node"] = node_name_;
     status["collector"]["events"] = Json::UInt64(stats.nEvents);
-    status["collector"]["drops"] = Json::UInt64(stats.nDrops);
+    status["collector"]["drops"] = drops;
     status["collector"]["preemptions"] = Json::UInt64(stats.nPreemptions);
 
     mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n");

--- a/collector/lib/system-inspector/SystemInspector.h
+++ b/collector/lib/system-inspector/SystemInspector.h
@@ -17,19 +17,17 @@ struct Stats {
   using uint64_t = std::uint64_t;
 
   // stats gathered in kernel space
-  volatile uint64_t nEvents = 0;            // the number of kernel events
-  volatile uint64_t nDrops = 0;             // the number of drops
-  volatile uint64_t nDropsBuffer = 0;       // the number of drops due to full
-                                            // ringbuf
-  volatile uint64_t nDropsThreadCache = 0;  // the number of drops due to full
-                                            // thread cache
-  volatile uint64_t nPreemptions = 0;       // the number of preemptions
+  volatile uint64_t nEvents = 0;       // the number of kernel events
+  volatile uint64_t nDrops = 0;        // the number of drops
+  volatile uint64_t nDropsBuffer = 0;  // the number of drops due to full ringbuf
+  volatile uint64_t nPreemptions = 0;  // the number of preemptions
 
   // stats gathered in user space
   volatile uint64_t nFilteredEvents[PPM_EVENT_MAX] = {0};   // events post filtering
   volatile uint64_t nUserspaceEvents[PPM_EVENT_MAX] = {0};  // events processed by userspace
   volatile uint64_t nGRPCSendFailures = 0;                  // number of signals that were not sent on GRPC
   volatile uint64_t nThreadCacheSize = 0;                   // number of thread-info entries stored in the cache
+  volatile uint64_t nDropsThreadCache = 0;                  // the number of drops due to full thread cache
 
   // process related metrics
   volatile uint64_t nProcessSent = 0;                       // number of process signals sent

--- a/collector/lib/system-inspector/SystemInspector.h
+++ b/collector/lib/system-inspector/SystemInspector.h
@@ -17,9 +17,13 @@ struct Stats {
   using uint64_t = std::uint64_t;
 
   // stats gathered in kernel space
-  volatile uint64_t nEvents = 0;       // the number of kernel events
-  volatile uint64_t nDrops = 0;        // the number of drops
-  volatile uint64_t nPreemptions = 0;  // the number of preemptions
+  volatile uint64_t nEvents = 0;            // the number of kernel events
+  volatile uint64_t nDrops = 0;             // the number of drops
+  volatile uint64_t nDropsBuffer = 0;       // the number of drops due to full
+                                            // ringbuf
+  volatile uint64_t nDropsThreadCache = 0;  // the number of drops due to full
+                                            // thread cache
+  volatile uint64_t nPreemptions = 0;       // the number of preemptions
 
   // stats gathered in user space
   volatile uint64_t nFilteredEvents[PPM_EVENT_MAX] = {0};   // events post filtering

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -290,6 +290,8 @@ Units: occurence
 |----------------------------------------|-----------------------------------------------------------------------------------------------------|
 | kernel                                 | number of received kernel events (by the probe)                                                     |
 | drops                                  | number of dropped kernel events                                                                     |
+| threadCacheDrops                       | number of dropped kernel events due to threadcache being full                                       |
+| ringbufferDrops                        | number of dropped kernel events due to ringbuffer being full                                        |
 | preemptions                            | Number of preemptions (?)                                                                           |
 | userspace[syscall]                     | Number of this kind of event                                                                        |
 | grpcSendFailures                       | (not used?)                                                                                         |


### PR DESCRIPTION
## Description

Use Falco's stats v2 to zoom into the events drop metrics and split it into drops due to full buffers vs due to full thread cache.

There was some concern enabling the stats v2 portion of Falco would cause some unwanted procfs scraping from the following functions:
- https://github.com/stackrox/falcosecurity-libs/blob/a283653ee897a17c77d781931170962494188bc3/userspace/libsinsp/metrics_collector.cpp#L241
- https://github.com/stackrox/falcosecurity-libs/blob/a283653ee897a17c77d781931170962494188bc3/userspace/libsinsp/metrics_collector.cpp#L349
- https://github.com/stackrox/falcosecurity-libs/blob/a283653ee897a17c77d781931170962494188bc3/userspace/libsinsp/metrics_collector.cpp#L449

However, after inspecting the code and testing with GDB, it became clear those functions are only called from the [`snapshot`](https://github.com/stackrox/falcosecurity-libs/blob/a283653ee897a17c77d781931170962494188bc3/userspace/libsinsp/metrics_collector.cpp#L483) function, so no additional procfs scrapping is added in the way we are using it.

Part of ROX-24691.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Since this is a change to metrics, automated testing is not strictly required. As such, changes were tested manually by:
- Running the new image as part of a stackrox deployment.
- Edit the collector daemonset to include the `ROX_COLLECTOR_SINSP_THREAD_CACHE_SIZE` and the `ROX_COLLECTOR_SINSP_BUFFER_SIZE`, setting them to low values one at a time.
- Run berserker in a container to add some strain to the system.
- Check the new metrics are working as expected by using curl to query the `:8080/ready` or `:9090/metrics` endpoints.
