### PR TITLE
Narrow down disabling of RHUI repo to the one family that is failing

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -61,7 +61,10 @@ virtual_machines:
     families:
       - rhel-8-4-sap-ha
       - rhel-8-6-sap-ha
-    container_engine: podman
+    # RHEL SAP 8.4 seems to have an older version of podman that
+    # fails with our integration tests, so we stick with docker
+    # for now.
+    container_engine: docker
 
   rhcos:
     project: rhcos-cloud

--- a/ansible/roles/provision-vm/tasks/redhat.yml
+++ b/ansible/roles/provision-vm/tasks/redhat.yml
@@ -26,7 +26,7 @@
 - name: Disable troublesome repo
   ansible.builtin.shell: |
     dnf config-manager --disable rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms
-  when: vm_config.find('-8') != -1 and vm_arch == 'amd64'
+  when: vm_image_family == 'rhel-8'
 
 - name: Install needed utilities
   ansible.builtin.dnf:


### PR DESCRIPTION
## Description

After disabling of the troublesome repo, some other RHEL based tests have been failing because the repo is not actually available in them. This attempts to narrow down the `dnf config-manager --disable` command to the one GCP family that was showing the issue.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run all integration tests for all archs and ensure no failures happen (cos-dev is currently failing due to a verifier error that is unrelated to this PR).