### PR TITLE
Disabling the COS dev tests until we can look into the verifier error

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -87,7 +87,8 @@ virtual_machines:
     families:
       - cos-stable
       - cos-beta
-      - cos-dev
+      # ROX-24938: disabled until the verifier issue is fixed.
+      # - cos-dev
 
   sles:
     project: suse-cloud


### PR DESCRIPTION
## Description

As explained in ROX-24938, collector has been unable to run on cos-dev VMs due to a verifier error for the last couple of days. Until we can look into the issue, we should disable the integration test from running so we can keep our CI green and happy.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run with the all integration tests label, cos-dev should not be created.