### PR TITLE
Update dnf cache before installing packages

### DIFF
--- a/ansible/roles/provision-vm/tasks/redhat.yml
+++ b/ansible/roles/provision-vm/tasks/redhat.yml
@@ -23,10 +23,9 @@
   until: registration is not failed
   when: vm_arch == "ppc64le" or vm_arch == "s390x"
 
-- name: Disable troublesome repo
+- name: Update DNF cache
   ansible.builtin.shell: |
-    dnf config-manager --disable rhui-codeready-builder-for-rhel-8-x86_64-rhui-source-rpms
-  when: vm_image_family == 'rhel-8'
+    dnf makecache
 
 - name: Install needed utilities
   ansible.builtin.dnf:


### PR DESCRIPTION

## Description

Updating the dnf cache by running makecache might help reduce some timeout errors we've been having in CI.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
