### PR TITLE
Remove WARNING health status for ppc64le VMs

### DIFF
--- a/ansible/roles/create-vm/tasks/create-ppc64le-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-ppc64le-vm.yml
@@ -104,7 +104,6 @@
     pi_proc_type: "{{ proc_type }}"
     pi_image_id: "{{ image_dict[vm_image] }}"
     pi_volume_ids: []
-    pi_health_status: "WARNING"
     pi_network:
       - network_id: "{{ pi_network_id }}"
     pi_key_pair_name: "{{ pi_ssh_key.pi_key_name }}"


### PR DESCRIPTION
## Description

WARNING health status was added in an attempt to speed up ppc64le provisioning by shortcutting the creation process, allowing us to try to communicate with the VM before IBM cloud says it's in a stable condition.

This worked in testing on the original PR, but has been failing on master. This PR undoes the change in order to maintain some CI stability. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
