### PR TITLE
Switches c-ares download to github release link

### DIFF
--- a/builder/install/30-cares.sh
+++ b/builder/install/30-cares.sh
@@ -7,7 +7,7 @@ if [ -n "${WITH_RHEL_RPMS}" ]; then
     exit 0
 fi
 
-wget "https://c-ares.haxx.se/download/c-ares-${CARES_VERSION}.tar.gz"
+wget "https://github.com/c-ares/c-ares/releases/download/cares-${CARES_VERSION//./_}/c-ares-${CARES_VERSION}.tar.gz"
 tar -zxf "c-ares-${CARES_VERSION}.tar.gz"
 cd "c-ares-${CARES_VERSION}"
 cp LICENSE.md "${LICENSE_DIR}/c-ares-${CARES_VERSION}"


### PR DESCRIPTION
## Description

The previous link pointed at an non-existent location, possibly because they've moved stuff around on their website. This links directly to the github release page (which is where the website links to now)

I've built the builder locally, and successfully, a CI rebuild will prove its success. 