### PR TITLE
Fixes test image tag default

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -19,7 +19,7 @@ on:
     outputs:
       collector-tests-tag:
         description: The tag used for the integration test image
-        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'master' }}
+        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'collector-tests-master' }}
 
 jobs:
   should-build-test-image:


### PR DESCRIPTION
When the image isn't rebuilt, the default tag is chosen, but one instance of the default tag was incorrect, causing failing tests.