### PR TITLE
Downgrade libbpf DEBUG logs to TRACE

### DIFF
--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -103,6 +103,10 @@ bool ParseLogLevelName(std::string name, LogLevel* level) {
 void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
   auto collector_severity = (LogLevel)severity;
 
+  if (!collector::logging::CheckLogLevel(collector_severity)) {
+    return;
+  }
+
   if (msg.rfind("libbpf:", 0) == 0 && collector_severity == LogLevel::DEBUG) {
     // downgrade libbpf debug logs to TRACE to avoid thousands of lines
     // of verbose relocation logging
@@ -113,9 +117,7 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
   // because our logging already appends a newline
   msg.erase(std::remove(msg.begin(), msg.end(), '\n'), msg.cend());
 
-  if (collector::logging::CheckLogLevel(collector_severity)) {
-    collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
-  }
+  collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
 }
 
 const char* GetGlobalLogPrefix() {

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -109,7 +109,7 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
     collector_severity = LogLevel::TRACE;
   }
 
-  if (collector::Logging::CheckLogLevel(collector_severity)) {
+  if (collector::logging::CheckLogLevel(collector_severity)) {
     collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
   }
 }

--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -109,6 +109,10 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
     collector_severity = LogLevel::TRACE;
   }
 
+  // remove any newlines to avoid additional empty log lines
+  // because our logging already appends a newline
+  msg.erase(std::remove(msg.begin(), msg.end(), '\n'), msg.cend());
+
   if (collector::logging::CheckLogLevel(collector_severity)) {
     collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
   }


### PR DESCRIPTION
## Description

The logs coming from libbpf are marked by Falco as DEBUG logs, but they are extremely verbose (>35000 lines) and contain little information useful to general debugging of Collector. This PR downgrades those logs to TRACE, so they are still available for debugging of CORE_BPF loading, but not always written to our usual test logs or under typical testing load.
