### PR TITLE
Small fix to libbpf log downgrading

### DIFF
--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -103,14 +103,14 @@ bool ParseLogLevelName(std::string name, LogLevel* level) {
 void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
   auto collector_severity = (LogLevel)severity;
 
-  if (!collector::logging::CheckLogLevel(collector_severity)) {
-    return;
-  }
-
-  if (msg.rfind("libbpf:", 0) == 0 && collector_severity == LogLevel::DEBUG) {
+  if (collector_severity == LogLevel::DEBUG && msg.rfind("libbpf:", 0) == 0) {
     // downgrade libbpf debug logs to TRACE to avoid thousands of lines
     // of verbose relocation logging
     collector_severity = LogLevel::TRACE;
+  }
+
+  if (!collector::logging::CheckLogLevel(collector_severity)) {
+    return;
   }
 
   // remove any newlines to avoid additional empty log lines


### PR DESCRIPTION
## Description

The check for log level needs to happen after we've downgraded them to trace. In order to prevent looking for the `libbpf:` prefix on every log line issued by Falco, we first check if we are running in debug mode, limiting the impact to systems that are actively being debugged.

This bug was introduced by a change I suggested in https://github.com/stackrox/collector/pull/1738#discussion_r1679500633

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check the integration test logs don't have the libbpf lines in them.
