### PR TITLE
Shorten ubuntu arm name so GCP doesn't complain of VM name too long

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         vm_type:
           - rhel-arm64
-          - ubuntu-os-arm64
+          - ubuntu-arm
           - sles-arm64
           - fcarm
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -115,7 +115,7 @@ virtual_machines:
       - ubuntu-2004-lts
       - ubuntu-2204-lts
 
-  ubuntu-os-arm64:
+  ubuntu-arm:
     project: ubuntu-os-cloud
     arch: arm64
     machine_type: t2a-standard-2

--- a/ansible/roles/provision-vm/tasks/main.yml
+++ b/ansible/roles/provision-vm/tasks/main.yml
@@ -14,7 +14,7 @@
 - set_fact:
     is_rhel: "{{ vm_config.find('rhel') != -1 }}"
     is_coreos: "{{ vm_config.find('coreos') != -1 }}"
-    is_ubuntu: "{{ vm_config.find('ubuntu-os') != -1 }}"
+    is_ubuntu: "{{ vm_config.find('ubuntu') != -1 }}"
     is_flatcar: "{{ vm_config.find('flatcar') != -1 }}"
 
 # Wait for SSH to be available on the remote host


### PR DESCRIPTION
## Description

The latest nightly failed because GHA workflow number added a digit and pushed the VM name over the limit of characters allowed by GCP. Simple fix is to just use a shorter name for the family like we already do for Fedora CoreOS on Arm.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
Run CI with the `run-multiarch-builds` and check all tests create VMs and run as expected.