### PR TITLE
Use a different job tag for konflux tests

### DIFF
--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -69,6 +69,7 @@ jobs:
       collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
       collector-tests-tag: ${{ needs.integration-tests-containers.outputs.collector-tests-tag }}
       is-konflux: true
+      job-tag: konf
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
     secrets: inherit
 


### PR DESCRIPTION

## Description

This change prevents VMs used to test konflux images from having name collisions with the ones used by master.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough to check the names used on the VMs now have `konf` as part of their name.
