### PR TITLE
Stop running konflux tests on release branches and tags

### DIFF
--- a/.github/workflows/konflux.yml
+++ b/.github/workflows/konflux.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - master
-      - release-*
-    tags:
-      - 3.*.*
   pull_request:
     types:
       - labeled


### PR DESCRIPTION
## Description

Currently, konflux is not being run on release branches and tags, so the associated tests will always fail with a timeout waiting for the images to become available.

If we start using konflux on these branches and tags, adding back the tests should be pretty straightforward.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

This is a simple change, no testing should be needed.