### PR TITLE
Run all amd64 integration tests on PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ on:
         default: false
 
 jobs:
-  amd64-required-integration-tests:
+  amd64-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     strategy:
       # ensure that if one part of the matrix fails, the
@@ -48,24 +48,6 @@ jobs:
         vm_type:
           - rhcos
           - ubuntu-os
-    with:
-      vm_type: ${{ matrix.vm_type }}
-      collector-tag: ${{ inputs.collector-tag }}
-      collector-qa-tag: ${{ inputs.collector-qa-tag }}
-      collector-tests-tag: ${{ inputs.collector-tests-tag }}
-      job-tag: ${{ inputs.job-tag }}
-      collector-repo: ${{ inputs.collector-repo }}
-    secrets: inherit
-
-  amd64-all-integration-tests:
-    uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: contains(github.event.pull_request.labels.*.name, 'all-integration-tests') || github.event_name != 'pull_request'
-    strategy:
-      # ensure that if one part of the matrix fails, the
-      # rest will continue
-      fail-fast: false
-      matrix:
-        vm_type:
           - cos
           - flatcar
           - fedora-coreos
@@ -145,8 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
     needs:
-      - amd64-required-integration-tests
-      - amd64-all-integration-tests
+      - amd64-integration-tests
       - arm64-integration-tests
       - s390x-integration-tests
       - ppc64le-integration-tests


### PR DESCRIPTION
## Description

We split the set of integration tests run on PRs due to some of them taking a long time and some flakiness. Since we did this split, the flakiness has gone down as well as the time taken to run the tests, so we might as well always run the full set.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough