### PR TITLE
Removes eBPF logging references and eBPF switching host heuristics

### DIFF
--- a/collector/container/scripts/bootstrap.sh
+++ b/collector/container/scripts/bootstrap.sh
@@ -40,15 +40,6 @@ function test {
     return $status
 }
 
-function remove_module() {
-    local module_name="$1"
-    if lsmod | grep -q "$module_name"; then
-        log "Collector kernel module has already been loaded."
-        log "Removing so that collector can insert it at startup."
-        test rmmod "$module_name"
-    fi
-}
-
 exit_with_error() {
     log ""
     log "Please provide this complete error message to StackRox support."
@@ -93,12 +84,6 @@ function main() {
     PID=$!
     wait $PID
     status=$?
-
-    # Always try to remove the module after collector exits.
-    # If collector is using eBPF then nothing is unloaded, and if it is
-    # the host state is cleaned up and allows collector to reload the module
-    # upon next start up.
-    remove_module "collector"
 
     exit $status
 }

--- a/collector/lib/HostHeuristics.cpp
+++ b/collector/lib/HostHeuristics.cpp
@@ -6,6 +6,8 @@ namespace collector {
 
 namespace {
 
+static const char* g_switch_collection_hint = "HINT: You may alternatively want to disable collection with collector.collectionMethod=NO_COLLECTION";
+
 class Heuristic {
  public:
   // Process the given HostInfo and CollectorConfig to adjust HostConfig as necessary.
@@ -31,13 +33,12 @@ class CollectionHeuristic : public Heuristic {
         CLOG(FATAL) << "Missing BTF symbols, core_bpf is not available. "
                     << "They can be provided by the kernel when configured with DEBUG_INFO_BTF, "
                     << "or as file. "
-                    << "HINT: You may alternatively want to use eBPF based collection "
-                    << "with collector.collectionMethod=EBPF.";
+                    << g_switch_collection_hint;
       }
 
       if (!host.HasBPFRingBufferSupport()) {
         CLOG(FATAL) << "Missing RingBuffer support, core_bpf is not available. "
-                    << "HINT: Change collection method to eBPF with collector.collectionMethod=EBPF.";
+                    << g_switch_collection_hint;
       }
 
       if (!host.HasBPFTracingSupport()) {
@@ -69,37 +70,6 @@ class DockerDesktopHeuristic : public Heuristic {
   }
 };
 
-class S390XHeuristic : public Heuristic {
- public:
-  // S390X does not support eBPF ealier than rhel8.5 so we switch to use corebpf instead
-  void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
-    auto k = host.GetKernelVersion();
-    std::string os_id = host.GetOSID();
-
-    if (k.machine != "s390x" || config.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
-      return;
-    }
-
-    // example release version: 4.18.0-305.88.1.el8_4.s390x
-    if (k.release.find(".el8_4.") != std::string::npos) {
-      CLOG(WARNING) << "RHEL 8.4 on s390x does not support eBPF, switching to CO.RE eBPF module based collection.";
-      hconfig->SetCollectionMethod(CollectionMethod::CORE_BPF);
-    }
-  }
-};
-
-class ARM64Heuristic : public Heuristic {
- public:
-  void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
-    auto kernel = host.GetKernelVersion();
-
-    if (kernel.machine == "aarch64" && config.GetCollectionMethod() == CollectionMethod::EBPF) {
-      CLOG(WARNING) << "eBPF collection method is not supported on ARM, switching to CO-RE BPF collection method.";
-      hconfig->SetCollectionMethod(CollectionMethod::CORE_BPF);
-    }
-  }
-};
-
 class PowerHeuristic : public Heuristic {
  public:
   void Process(HostInfo& host, const CollectorConfig& config, HostConfig* hconfig) const {
@@ -126,8 +96,6 @@ class CPUHeuristic : public Heuristic {
 const std::unique_ptr<Heuristic> g_host_heuristics[] = {
     std::unique_ptr<Heuristic>(new CollectionHeuristic),
     std::unique_ptr<Heuristic>(new DockerDesktopHeuristic),
-    std::unique_ptr<Heuristic>(new S390XHeuristic),
-    std::unique_ptr<Heuristic>(new ARM64Heuristic),
     std::unique_ptr<Heuristic>(new PowerHeuristic),
     std::unique_ptr<Heuristic>(new CPUHeuristic),
 };

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -251,7 +251,7 @@ class HostInfo {
   // 	online if they are present.
   //
   // In case of failure, logs the error and returns 0.
-  int NumPossibleCPU();
+  virtual int NumPossibleCPU();
 
   // The system was booted in UEFI mode.
   virtual bool IsUEFI();

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -58,33 +58,6 @@ class IKernelDriver {
   }
 };
 
-class KernelDriverEBPF : public IKernelDriver {
- public:
-  KernelDriverEBPF() = default;
-
-  bool Setup(const CollectorConfig& config, sinsp& inspector) override {
-    FDHandle fd = FDHandle(open(system_inspector::Service::kProbePath, O_RDONLY));
-    if (!fd.valid()) {
-      CLOG(ERROR) << "Cannot open eBPF probe at " << system_inspector::Service::kProbePath;
-      return false;
-    }
-
-    /* Get only necessary tracepoints. */
-    std::unordered_set<ppm_sc_code> ppm_sc = GetSyscallList(config);
-
-    try {
-      inspector.open_bpf(system_inspector::Service::kProbePath,
-                         config.GetSinspBufferSize(),
-                         ppm_sc);
-    } catch (const sinsp_exception& ex) {
-      CLOG(WARNING) << ex.what();
-      return false;
-    }
-
-    return true;
-  }
-};
-
 class KernelDriverCOREEBPF : public IKernelDriver {
  public:
   KernelDriverCOREEBPF() = default;

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -131,14 +131,8 @@ bool Service::InitKernel(const CollectorConfig& config, const DriverCandidate& c
                                                      EventExtractor::FilterList()));
   }
 
-  std::unique_ptr<IKernelDriver> driver;
-  if (candidate.GetCollectionMethod() == CollectionMethod::EBPF) {
-    driver = std::make_unique<KernelDriverEBPF>(KernelDriverEBPF());
-  } else if (candidate.GetCollectionMethod() == CollectionMethod::CORE_BPF) {
-    driver = std::make_unique<KernelDriverCOREEBPF>(KernelDriverCOREEBPF());
-  }
-
-  if (!driver->Setup(config, *inspector_)) {
+  KernelDriverCOREEBPF driver;
+  if (!driver.Setup(config, *inspector_)) {
     CLOG(ERROR) << "Failed to setup " << candidate.GetName();
     return false;
   }

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -51,7 +51,7 @@ class MockHostInfoHeuristics : public HostInfo {
 class MockCollectorConfig : public CollectorConfig {
  public:
   MockCollectorConfig()
-      : CollectorConfig() {};
+      : CollectorConfig(){};
 
   void SetCollectionMethod(CollectionMethod cm) {
     if (host_config_.HasCollectionMethod()) {

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -31,14 +31,9 @@ using namespace testing;
 
 namespace collector {
 
-class MockS390xHeuristics : public S390XHeuristic {
+class MockCPUHeuristic : public CPUHeuristic {
  public:
-  MockS390xHeuristics() = default;
-};
-
-class MockARM64Heuristics : public ARM64Heuristic {
- public:
-  MockARM64Heuristics() = default;
+  MockCPUHeuristic() = default;
 };
 
 class MockHostInfoHeuristics : public HostInfo {
@@ -50,12 +45,13 @@ class MockHostInfoHeuristics : public HostInfo {
   MOCK_METHOD0(GetKernelVersion, KernelVersion());
   MOCK_METHOD0(IsGarden, bool());
   MOCK_METHOD0(GetDistro, std::string&());
+  MOCK_METHOD0(NumPossibleCPU, int());
 };
 
 class MockCollectorConfig : public CollectorConfig {
  public:
   MockCollectorConfig()
-      : CollectorConfig(){};
+      : CollectorConfig() {};
 
   void SetCollectionMethod(CollectionMethod cm) {
     if (host_config_.HasCollectionMethod()) {
@@ -65,36 +61,17 @@ class MockCollectorConfig : public CollectorConfig {
   }
 };
 
-TEST(HostHeuristicsTest, TestS390XRHEL84) {
-  MockS390xHeuristics s390xHeuristics;
+TEST(HostHeuristicsTest, TestCPUHeuristic) {
+  MockCPUHeuristic cpuHeuristic;
   MockHostInfoHeuristics host;
-  KernelVersion version = KernelVersion("4.18.0-305.88.1.el8_4.s390x", "", "s390x");
   MockCollectorConfig config;
   HostConfig hconfig;
 
-  config.SetCollectionMethod(CollectionMethod::EBPF);
-  hconfig.SetCollectionMethod(CollectionMethod::EBPF);
-  EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
+  EXPECT_CALL(host, NumPossibleCPU()).WillOnce(Return(10));
 
-  s390xHeuristics.Process(host, config, &hconfig);
+  cpuHeuristic.Process(host, config, &hconfig);
 
-  EXPECT_EQ(hconfig.GetCollectionMethod(), CollectionMethod::CORE_BPF);
-}
-
-TEST(HostHeuristicsTest, TestARM64Heuristic) {
-  MockARM64Heuristics heuristic;
-  MockHostInfoHeuristics host;
-  KernelVersion version = KernelVersion("6.5.5-200.fc38.aarch64", "", "aarch64");
-  MockCollectorConfig config;
-  HostConfig hconfig;
-
-  config.SetCollectionMethod(CollectionMethod::EBPF);
-  hconfig.SetCollectionMethod(CollectionMethod::EBPF);
-  EXPECT_CALL(host, GetKernelVersion()).WillOnce(Return(version));
-
-  heuristic.Process(host, config, &hconfig);
-
-  EXPECT_EQ(hconfig.GetCollectionMethod(), CollectionMethod::CORE_BPF);
+  EXPECT_EQ(hconfig.GetNumPossibleCPUs(), 10);
 }
 
 }  // namespace collector


### PR DESCRIPTION
## Description

Now we live in a post-eBPF world, the log messages in the heuristics can be confusing. They have been reworded to suggest that NO_COLLECTION can be used, since we do not have another collection method to switch to if any of these checks fail.

Also includes some minor cleanup in the unit tests and bootstrap shell script (which contained references to kernel modules... remember them?)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
