### PR TITLE
Enable multi-arch testing for konflux images

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,7 +85,7 @@ jobs:
   arm64-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      !inputs.is-konflux && (
+      (
         github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
       )
@@ -112,7 +112,7 @@ jobs:
   s390x-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      !inputs.is-konflux && (
+      (
         github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
       )
@@ -128,7 +128,7 @@ jobs:
   ppc64le-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      !inputs.is-konflux && (
+      (
         github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
       )


### PR DESCRIPTION
## Description

Simply removes guards from tests, to allow running konflux images on multi-arch VMs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
