### PR TITLE
Bump golang version used for integration tests

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -39,6 +39,8 @@ jobs:
               - integration-tests/pkg/**
               - integration-tests/suites/**
               - integration-tests/*.go
+              - integration-tests/go.mod
+              - integration-tests/go.sum
               - integration-tests/images.yml
               - integration-tests/Dockerfile
               - .github/workflows/integration-test-containers.yml

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,6 +1,6 @@
 ARG TEST_ROOT="/tests"
 
-FROM golang:1.19 as builder
+FROM golang:1.21 as builder
 
 ARG TEST_ROOT
 

--- a/integration-tests/pkg/types/network.go
+++ b/integration-tests/pkg/types/network.go
@@ -1,7 +1,7 @@
 package types
 
 const (
-	NilTimestamp = "(timestamp: nil Timestamp)"
+	NilTimestamp = "<nil>"
 )
 
 type NetworkInfo struct {

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -65,8 +65,6 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 		s.Require().NoError(err)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	// invokes default nginx
 	containerID, err := s.launchContainer("nginx", image_store.ImageByKey("nginx"))
 	s.Require().NoError(err)
@@ -82,7 +80,6 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 
 	s.ServerPort, err = s.getPort("nginx")
 	s.Require().NoError(err)
-	time.Sleep(30 * time.Second)
 
 	serverAddress := fmt.Sprintf("%s:%s", s.ServerIP, s.ServerPort)
 


### PR DESCRIPTION
## Description

#1755 bumped the go version required for the integration tests, a similar bump is needed to the base version used for the container.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Ensure the integration tests container is built correctly.
