### PR TITLE
chore: Add `^release-` branches for on-push Konflux builds

### DIFF
--- a/.github/workflows/konflux.yml
+++ b/.github/workflows/konflux.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - release-*
   pull_request:
     types:
       - labeled

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("rhtap") || source_branch.contains("appstudio") || source_branch.contains("konflux")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("rhtap") || source_branch.contains("appstudio") || source_branch.contains("konflux")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && (target_branch == "master" || target_branch.startsWith("release-"))) || (event == "pull_request" && (source_branch.contains("rhtap") || source_branch.contains("appstudio") || source_branch.contains("konflux")))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("^(master|release-.*)$")) || (event == "pull_request" && source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs


### PR DESCRIPTION
## Description

This should enable Konflux builds from release branches for the case when [COLLECTOR_VERSION](https://github.com/stackrox/stackrox/blob/master/COLLECTOR_VERSION) points to a tag/commit that was on a release branch, not on `master`.

Prerequisite for ROX-24468

Available CEL functions are here <https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions>.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
No contributions.

## Testing Performed

None, only CI.