### PR TITLE
Check for existence of MODULE_VERSION file

### DIFF
--- a/.github/actions/support-package-metadata/create-metadata-dir.sh
+++ b/.github/actions/support-package-metadata/create-metadata-dir.sh
@@ -6,7 +6,10 @@ for version_dir in /tmp/support-packages/metadata/collector-versions/*; do
     version="$(basename "$version_dir")"
     git checkout "${version}"
 
-    cp "${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION" "${version_dir}/MODULE_VERSION"
+    module_version_file="${GITHUB_WORKSPACE}/kernel-modules/MODULE_VERSION"
+    if [[ -f "${module_version_file}" ]]; then
+        cp "${module_version_file}" "${version_dir}/MODULE_VERSION"
+    fi
 done
 
 git checkout "${BRANCH_NAME}"

--- a/kernel-modules/support-packages/03-group-by-module-version.sh
+++ b/kernel-modules/support-packages/03-group-by-module-version.sh
@@ -18,6 +18,7 @@ MD_DIR="$1"
 
 for version_dir in "${MD_DIR}/collector-versions"/*; do
     [[ -d "$version_dir" ]] || continue
+    [[ -f "${version_dir}/MODULE_VERSION" ]] || continue
 
     module_version="$(< "${version_dir}/MODULE_VERSION")"
 


### PR DESCRIPTION
## Description

#1773 removed the `MODULE_VERSION` file, so when syncing support packages from downstream, we should skip versions that don't have this file.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run with `run-cpaas-steps` label.
