### PR TITLE
Remove offline-mode from CPaaS workflow

### DIFF
--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -139,7 +139,6 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}-cpaas
       collector-qa-tag: ${{ needs.init.outputs.collector-qa-tag }}
       collector-tests-tag: ${{ needs.build-test-containers.outputs.collector-tests-tag }}
-      offline-mode: true
       job-tag: cpaas
       collector-repo: quay.io/stackrox-io/collector
     needs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,3 @@ jobs:
           GOBIN="${HOME}/bin/" go install github.com/rhysd/actionlint/cmd/actionlint@latest
 
       - uses: pre-commit/action@v3.0.0
-        with:
-          # ensure we're only linting the diff between the PR and the base ref
-          extra_args: --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref HEAD


### PR DESCRIPTION
## Description

PR https://github.com/stackrox/collector/pull/1783 removed offline-mode from the integration tests, breaking the
CPaaS workflow. This commit fixes the workflow.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run with `run-cpaas-steps` label.
