### PR TITLE
ROX-25788: fix integration tests handling of connections and endpoints

### DIFF
--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -33,6 +33,14 @@
     run_args: -test.timeout 120m -test.short
   when: collector_test == "ci-integration-tests"
 
+- name: Remove old logs directory
+  file:
+    path: "{{ remote_log_mount }}"
+    state: absent
+  # don't error if the directory doesn't exist yet
+  ignore_errors: true
+  become: true
+
 - name: Make logs directory
   file:
     path: "{{ remote_log_mount }}"
@@ -72,6 +80,7 @@
     become: "{{ runtime_as_root }}"
     shell: |
       {{ runtime_command }} run -it --rm \
+        --pull always \
         -v {{ remote_log_mount }}:{{ container_logs_root }} \
         -v ~/.docker:/root/.docker \
         -v /tmp/:/tmp \

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -88,6 +88,35 @@ func TestProcfsScraper(t *testing.T) {
 	connScraperTestSuite := &suites.ProcfsScraperTestSuite{
 		TurnOffScrape:               false,
 		RoxProcessesListeningOnPort: true,
+		Expected: []types.EndpointInfo{
+			{
+				Protocol:       "L4_PROTOCOL_TCP",
+				CloseTimestamp: types.NilTimestamp,
+				Address: &types.ListenAddress{
+					AddressData: "\x00\x00\x00\x00",
+					Port:        80,
+					IpNetwork:   "\x00\x00\x00\x00 ",
+				},
+				Originator: &types.ProcessOriginator{
+					ProcessName:         "nginx",
+					ProcessExecFilePath: "/usr/sbin/nginx",
+					ProcessArgs:         "",
+				},
+			}, {
+				Protocol:       "L4_PROTOCOL_TCP",
+				CloseTimestamp: types.NilTimestamp,
+				Address: &types.ListenAddress{
+					AddressData: "\x00\x00\x00\x00",
+					Port:        80,
+					IpNetwork:   "\x00\x00\x00\x00 ",
+				},
+				Originator: &types.ProcessOriginator{
+					ProcessName:         "nginx",
+					ProcessExecFilePath: "/usr/sbin/nginx",
+					ProcessArgs:         "",
+				},
+			},
+		},
 	}
 	suite.Run(t, connScraperTestSuite)
 }
@@ -96,6 +125,7 @@ func TestProcfsScraperNoScrape(t *testing.T) {
 	connScraperTestSuite := &suites.ProcfsScraperTestSuite{
 		TurnOffScrape:               true,
 		RoxProcessesListeningOnPort: true,
+		Expected:                    []types.EndpointInfo{},
 	}
 	suite.Run(t, connScraperTestSuite)
 }
@@ -104,6 +134,17 @@ func TestProcfsScraperDisableFeatureFlag(t *testing.T) {
 	connScraperTestSuite := &suites.ProcfsScraperTestSuite{
 		TurnOffScrape:               false,
 		RoxProcessesListeningOnPort: false,
+		Expected: []types.EndpointInfo{
+			{
+				Protocol:       "L4_PROTOCOL_TCP",
+				CloseTimestamp: types.NilTimestamp,
+				Originator: &types.ProcessOriginator{
+					ProcessName:         "",
+					ProcessExecFilePath: "",
+					ProcessArgs:         "",
+				},
+			},
+		},
 	}
 	suite.Run(t, connScraperTestSuite)
 }

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -92,12 +92,12 @@ func TestProcfsScraper(t *testing.T) {
 			{
 				Protocol:       "L4_PROTOCOL_TCP",
 				CloseTimestamp: types.NilTimestamp,
-				Address: &types.ListenAddress{
+				Address: types.ListenAddress{
 					AddressData: "\x00\x00\x00\x00",
 					Port:        80,
 					IpNetwork:   "\x00\x00\x00\x00 ",
 				},
-				Originator: &types.ProcessOriginator{
+				Originator: types.ProcessOriginator{
 					ProcessName:         "nginx",
 					ProcessExecFilePath: "/usr/sbin/nginx",
 					ProcessArgs:         "",
@@ -105,12 +105,12 @@ func TestProcfsScraper(t *testing.T) {
 			}, {
 				Protocol:       "L4_PROTOCOL_TCP",
 				CloseTimestamp: types.NilTimestamp,
-				Address: &types.ListenAddress{
+				Address: types.ListenAddress{
 					AddressData: "\x00\x00\x00\x00",
 					Port:        80,
 					IpNetwork:   "\x00\x00\x00\x00 ",
 				},
-				Originator: &types.ProcessOriginator{
+				Originator: types.ProcessOriginator{
 					ProcessName:         "nginx",
 					ProcessExecFilePath: "/usr/sbin/nginx",
 					ProcessArgs:         "",
@@ -138,7 +138,13 @@ func TestProcfsScraperDisableFeatureFlag(t *testing.T) {
 			{
 				Protocol:       "L4_PROTOCOL_TCP",
 				CloseTimestamp: types.NilTimestamp,
-				Originator: &types.ProcessOriginator{
+				Address: types.ListenAddress{
+					AddressData: "\x00\x00\x00\x00",
+					Port:        80,
+					IpNetwork:   "\x00\x00\x00\x00 ",
+				},
+				// expect endpoint but no originator
+				Originator: types.ProcessOriginator{
 					ProcessName:         "",
 					ProcessExecFilePath: "",
 					ProcessArgs:         "",
@@ -183,7 +189,7 @@ func TestConnectionsAndEndpointsNormal(t *testing.T) {
 			ExpectedEndpoints: []types.EndpointInfo{
 				{
 					Protocol: "L4_PROTOCOL_TCP",
-					Address: &types.ListenAddress{
+					Address: types.ListenAddress{
 						AddressData: "\x00\x00\x00\x00",
 						Port:        40,
 						IpNetwork:   "\x00\x00\x00\x00 ",
@@ -228,7 +234,7 @@ func TestConnectionsAndEndpointsHighLowPorts(t *testing.T) {
 			ExpectedEndpoints: []types.EndpointInfo{
 				{
 					Protocol: "L4_PROTOCOL_TCP",
-					Address: &types.ListenAddress{
+					Address: types.ListenAddress{
 						AddressData: "\x00\x00\x00\x00",
 						Port:        40000,
 						IpNetwork:   "\x00\x00\x00\x00 ",
@@ -273,7 +279,7 @@ func TestConnectionsAndEndpointsServerHigh(t *testing.T) {
 			ExpectedEndpoints: []types.EndpointInfo{
 				{
 					Protocol: "L4_PROTOCOL_TCP",
-					Address: &types.ListenAddress{
+					Address: types.ListenAddress{
 						AddressData: "\x00\x00\x00\x00",
 						Port:        60999,
 						IpNetwork:   "\x00\x00\x00\x00 ",
@@ -318,7 +324,7 @@ func TestConnectionsAndEndpointsSourcePort(t *testing.T) {
 			ExpectedEndpoints: []types.EndpointInfo{
 				{
 					Protocol: "L4_PROTOCOL_TCP",
-					Address: &types.ListenAddress{
+					Address: types.ListenAddress{
 						AddressData: "\x00\x00\x00\x00",
 						Port:        10000,
 						IpNetwork:   "\x00\x00\x00\x00 ",

--- a/integration-tests/pkg/common/utils.go
+++ b/integration-tests/pkg/common/utils.go
@@ -2,10 +2,13 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"golang.org/x/sys/unix"
@@ -63,4 +66,10 @@ func PrepareLog(testName string, logName string) (*os.File, error) {
 
 	logPath := filepath.Join(logDirectory, strings.ReplaceAll(testName, "/", "_")+"-"+logName)
 	return os.Create(logPath)
+}
+
+func Sleep(duration time.Duration) {
+	_, filename, line, _ := runtime.Caller(1)
+	fmt.Printf("%s:%d sleeping for %f s\n", filename, line, duration.Seconds())
+	time.Sleep(duration)
 }

--- a/integration-tests/pkg/executor/retry.go
+++ b/integration-tests/pkg/executor/retry.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"time"
+
+	"github.com/stackrox/collector/integration-tests/pkg/common"
 )
 
 const (
@@ -24,7 +26,7 @@ func RetryWithErrorCheck(ec errorchecker, f retryable) (output string, err error
 		if ec(output, err) == nil {
 			return output, nil
 		} else if i != max_retries-1 {
-			time.Sleep(retry_wait_time)
+			common.Sleep(retry_wait_time)
 		}
 	}
 

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -18,7 +18,7 @@ import (
 func (s *MockSensor) ExpectConnections(t *testing.T, containerID string, timeout time.Duration, expected ...types.NetworkInfo) bool {
 
 	to_find := funk.Filter(expected, func(x types.NetworkInfo) bool {
-		return s.HasConnection(containerID, x)
+		return !s.HasConnection(containerID, x)
 	}).([]types.NetworkInfo)
 
 	if len(to_find) == 0 {
@@ -40,7 +40,7 @@ loop:
 			}
 
 			to_find = funk.Filter(expected, func(x types.NetworkInfo) bool {
-				return s.HasConnection(containerID, x)
+				return !s.HasConnection(containerID, x)
 			}).([]types.NetworkInfo)
 
 			if len(to_find) == 0 {
@@ -87,7 +87,7 @@ loop:
 func (s *MockSensor) ExpectEndpoints(t *testing.T, containerID string, timeout time.Duration, expected ...types.EndpointInfo) bool {
 
 	to_find := funk.Filter(expected, func(x types.EndpointInfo) bool {
-		return s.HasEndpoint(containerID, x)
+		return !s.HasEndpoint(containerID, x)
 	}).([]types.EndpointInfo)
 
 	if len(to_find) == 0 {
@@ -109,7 +109,7 @@ loop:
 			}
 
 			to_find = funk.Filter(expected, func(x types.EndpointInfo) bool {
-				return s.HasEndpoint(containerID, x)
+				return !s.HasEndpoint(containerID, x)
 			}).([]types.EndpointInfo)
 
 			if len(to_find) == 0 {

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -127,22 +127,26 @@ loop:
 // It does not consider the content of the events, just that a certain number
 // have been received
 func (s *MockSensor) ExpectEndpointsN(t *testing.T, containerID string, timeout time.Duration, n int) []types.EndpointInfo {
-	return s.waitEndpointsN(func() {
+	return s.waitEndpointsN(t, func() {
 		assert.FailNowf(t, "timed out", "found %d endpoints (expected %d)", len(s.Endpoints(containerID)), n)
 	}, containerID, timeout, n)
 }
 
 // WaitEndpointsN is a non-fatal version of ExpectEndpointsN. It waits for a given timeout
 // until n Endpoints have been receieved. On timeout it returns false.
-func (s *MockSensor) WaitEndpointsN(containerID string, timeout time.Duration, n int) bool {
-	return len(s.waitEndpointsN(func() {}, containerID, timeout, n)) == n
+func (s *MockSensor) WaitEndpointsN(t *testing.T, containerID string, timeout time.Duration, n int) bool {
+	return len(s.waitEndpointsN(t, func() {}, containerID, timeout, n)) == n
 }
 
 // waitEndpointsN is a helper function for waiting for a set number of endpoints.
 // the timeoutFn function can be used to control error behaviour on timeout.
-func (s *MockSensor) waitEndpointsN(timeoutFn func(), containerID string, timeout time.Duration, n int) []types.EndpointInfo {
-	if len(s.Endpoints(containerID)) == n {
+func (s *MockSensor) waitEndpointsN(t *testing.T, timeoutFn func(), containerID string, timeout time.Duration, n int) []types.EndpointInfo {
+	seen := len(s.Endpoints(containerID))
+
+	if seen == n {
 		return s.Endpoints(containerID)
+	} else if seen > n {
+		assert.FailNow(t, "too many endpoints", "found %d endpoints (expected %d)", seen, n)
 	}
 
 	timer := time.After(timeout)

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -208,8 +208,12 @@ func (m *MockSensor) HasEndpoint(containerID string, endpoint types.EndpointInfo
 	defer m.networkMutex.Unlock()
 
 	if endpoints, ok := m.endpoints[containerID]; ok {
-		_, exists := endpoints[endpoint]
-		return exists
+		// _, exists := endpoints[endpoint]
+		for ep, _ := range endpoints {
+			if types.CompareEndpoints(ep, endpoint) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -208,9 +208,8 @@ func (m *MockSensor) HasEndpoint(containerID string, endpoint types.EndpointInfo
 	defer m.networkMutex.Unlock()
 
 	if endpoints, ok := m.endpoints[containerID]; ok {
-		// _, exists := endpoints[endpoint]
-		for ep, _ := range endpoints {
-			if types.CompareEndpoints(ep, endpoint) {
+		for ep := range endpoints {
+			if ep.Equal(endpoint) {
 				return true
 			}
 		}
@@ -478,9 +477,9 @@ func (m *MockSensor) pushEndpoint(containerID string, endpoint *sensorAPI.Networ
 
 	ep := types.EndpointInfo{
 		Protocol:       endpoint.GetProtocol().String(),
-		Originator:     &originator,
+		Originator:     originator,
 		CloseTimestamp: endpoint.GetCloseTimestamp().String(),
-		Address:        &listen,
+		Address:        listen,
 	}
 
 	if endpoints, ok := m.endpoints[containerID]; ok {

--- a/integration-tests/pkg/types/endpoint.go
+++ b/integration-tests/pkg/types/endpoint.go
@@ -4,9 +4,9 @@ import "sort"
 
 type EndpointInfo struct {
 	Protocol       string
-	Address        *ListenAddress
+	Address        ListenAddress
 	CloseTimestamp string
-	Originator     *ProcessOriginator
+	Originator     ProcessOriginator
 }
 
 func (n *EndpointInfo) IsActive() bool {
@@ -14,57 +14,28 @@ func (n *EndpointInfo) IsActive() bool {
 	return n.CloseTimestamp == NilTimestamp
 }
 
-func SortEndpoints(endpoints []EndpointInfo) {
-	sort.Slice(endpoints, func(i, j int) bool { return CompareEndpoints(endpoints[i], endpoints[j]) })
-}
+func (n *EndpointInfo) Less(other EndpointInfo) bool {
+	addr1, addr2 := n.Address, other.Address
 
-func CompareEndpoints(endpoint1 EndpointInfo, endpoint2 EndpointInfo) bool {
-	addr1, addr2 := endpoint1.Address, endpoint2.Address
-
-	if addr1 == nil {
-		return false
-	}
-	if addr2 == nil {
-		return true
+	if !addr1.Equal(addr2) {
+		return addr1.Less(addr2)
 	}
 
-	if addr1.AddressData != addr2.AddressData {
-		return addr1.AddressData < addr2.AddressData
-	}
+	process1, process2 := n.Originator, other.Originator
 
-	if addr1.Port != addr2.Port {
-		return addr1.Port < addr2.Port
-	}
-
-	if endpoint1.Protocol != endpoint2.Protocol {
-		return endpoint1.Protocol < endpoint2.Protocol
-	}
-
-	process1, process2 := endpoint1.Originator, endpoint2.Originator
-
-	if process1 == nil {
-		return false
-	}
-
-	if process2 == nil {
-		return true
-	}
-
-	if process1.ProcessName != process2.ProcessName {
-		return process1.ProcessName < process2.ProcessName
-	}
-
-	if process1.ProcessExecFilePath != process2.ProcessExecFilePath {
-		return process1.ProcessExecFilePath < process2.ProcessExecFilePath
-	}
-
-	if process1.ProcessArgs != process2.ProcessArgs {
-		return process1.ProcessArgs < process2.ProcessArgs
-	}
-
-	if endpoint1.IsActive() == endpoint2.IsActive() {
-		return true
+	if !process1.Equal(process2) {
+		return process1.Less(process2)
 	}
 
 	return false
+}
+
+func (n *EndpointInfo) Equal(other EndpointInfo) bool {
+	return n.Address.Equal(other.Address) &&
+		n.Originator.Equal(other.Originator) &&
+		n.IsActive() == other.IsActive()
+}
+
+func SortEndpoints(endpoints []EndpointInfo) {
+	sort.Slice(endpoints, func(i, j int) bool { return endpoints[i].Less(endpoints[j]) })
 }

--- a/integration-tests/pkg/types/endpoint.go
+++ b/integration-tests/pkg/types/endpoint.go
@@ -15,10 +15,10 @@ func (n *EndpointInfo) IsActive() bool {
 }
 
 func SortEndpoints(endpoints []EndpointInfo) {
-	sort.Slice(endpoints, func(i, j int) bool { return endpointComparison(endpoints[i], endpoints[j]) })
+	sort.Slice(endpoints, func(i, j int) bool { return CompareEndpoints(endpoints[i], endpoints[j]) })
 }
 
-func endpointComparison(endpoint1 EndpointInfo, endpoint2 EndpointInfo) bool {
+func CompareEndpoints(endpoint1 EndpointInfo, endpoint2 EndpointInfo) bool {
 	addr1, addr2 := endpoint1.Address, endpoint2.Address
 
 	if addr1 == nil {
@@ -60,6 +60,10 @@ func endpointComparison(endpoint1 EndpointInfo, endpoint2 EndpointInfo) bool {
 
 	if process1.ProcessArgs != process2.ProcessArgs {
 		return process1.ProcessArgs < process2.ProcessArgs
+	}
+
+	if endpoint1.IsActive() == endpoint2.IsActive() {
+		return true
 	}
 
 	return false

--- a/integration-tests/pkg/types/listen_address.go
+++ b/integration-tests/pkg/types/listen_address.go
@@ -5,3 +5,15 @@ type ListenAddress struct {
 	Port        int
 	IpNetwork   string
 }
+
+func (l *ListenAddress) Equal(other ListenAddress) bool {
+	return l.AddressData == other.AddressData &&
+		l.Port == other.Port &&
+		l.IpNetwork == other.IpNetwork
+}
+
+func (l *ListenAddress) Less(other ListenAddress) bool {
+	return l.AddressData < other.AddressData ||
+		l.Port < other.Port ||
+		l.IpNetwork < other.IpNetwork
+}

--- a/integration-tests/pkg/types/process_originator.go
+++ b/integration-tests/pkg/types/process_originator.go
@@ -5,3 +5,15 @@ type ProcessOriginator struct {
 	ProcessExecFilePath string
 	ProcessArgs         string
 }
+
+func (p *ProcessOriginator) Less(other ProcessOriginator) bool {
+	return p.ProcessName < other.ProcessName ||
+		p.ProcessExecFilePath < other.ProcessExecFilePath ||
+		p.ProcessArgs < other.ProcessArgs
+}
+
+func (p *ProcessOriginator) Equal(other ProcessOriginator) bool {
+	return p.ProcessName == other.ProcessName &&
+		p.ProcessExecFilePath == other.ProcessExecFilePath &&
+		p.ProcessArgs == other.ProcessArgs
+}

--- a/integration-tests/suites/async_connections.go
+++ b/integration-tests/suites/async_connections.go
@@ -58,7 +58,7 @@ func (s *AsyncConnectionTestSuite) SetupSuite() {
 	s.serverIP, err = s.getIPAddress("server")
 	s.Require().NoError(err)
 
-	time.Sleep(5 * time.Second) // TODO use the endpoint declaration
+	common.Sleep(5 * time.Second) // TODO use the endpoint declaration
 
 	target := s.serverIP
 
@@ -71,7 +71,7 @@ func (s *AsyncConnectionTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.clientContainer = common.ContainerShortID(containerID)
 
-	time.Sleep(10 * time.Second) // give some time to the connection to fail
+	common.Sleep(10 * time.Second) // give some time to the connection to fail
 }
 
 func (s *AsyncConnectionTestSuite) TearDownSuite() {

--- a/integration-tests/suites/connections_and_endpoints.go
+++ b/integration-tests/suites/connections_and_endpoints.go
@@ -66,12 +66,12 @@ func (s *ConnectionsAndEndpointsTestSuite) SetupSuite() {
 	_, err = s.execContainer(serverName, []string{"/bin/sh", "-c", serverCmd})
 	s.Require().NoError(err)
 
-	time.Sleep(3 * time.Second)
+	common.Sleep(3 * time.Second)
 
 	clientCmd := strings.Replace(s.Client.Cmd, "SERVER_IP", s.Server.IP, -1)
 	_, err = s.execContainer(clientName, []string{"/bin/sh", "-c", clientCmd})
 	s.Require().NoError(err)
-	time.Sleep(6 * time.Second)
+	common.Sleep(6 * time.Second)
 }
 
 func (s *ConnectionsAndEndpointsTestSuite) TearDownSuite() {

--- a/integration-tests/suites/duplicate_endpoints.go
+++ b/integration-tests/suites/duplicate_endpoints.go
@@ -95,7 +95,7 @@ func (s *DuplicateEndpointsTestSuite) TestDuplicateEndpoints() {
 	s.Sensor().ExpectEndpointsN(s.T(), containerID, gScrapeInterval*time.Second, 2)
 
 	// (5) kill the process after a delay
-	time.Sleep(2 * time.Second)
+	common.Sleep(2 * time.Second)
 	s.killSocatProcess(81)
 
 	// (6) start an idential process
@@ -104,7 +104,7 @@ func (s *DuplicateEndpointsTestSuite) TestDuplicateEndpoints() {
 
 	// (7) wait for another scrape interval, and verify we have still only
 	// seen 2 endpoints
-	time.Sleep(gScrapeInterval * time.Second)
+	common.Sleep(gScrapeInterval * time.Second)
 	s.Assert().Len(s.Sensor().Endpoints(containerID), 2, "Got more endpoints than expected")
 
 	// additional final check to ensure there are no additional reports

--- a/integration-tests/suites/gperftools.go
+++ b/integration-tests/suites/gperftools.go
@@ -53,7 +53,7 @@ func (s *GperftoolsTestSuite) TestFetchHeapProfile() {
 	s.Assert().Equal(response.StatusCode, 200, "Failed to start heap profiling")
 
 	// Wait a bit to collect something in the heap profile
-	time.Sleep(1 * time.Second)
+	common.Sleep(1 * time.Second)
 
 	response, err = http.Post(heap_api_url, data_type, strings.NewReader("off"))
 	s.Require().NoError(err)

--- a/integration-tests/suites/listening_ports.go
+++ b/integration-tests/suites/listening_ports.go
@@ -51,7 +51,7 @@ func (s *ProcessListeningOnPortTestSuite) SetupSuite() {
 	err = s.waitForFileToBeDeleted(actionFile)
 	s.Require().NoError(err)
 
-	time.Sleep(6 * time.Second)
+	common.Sleep(6 * time.Second)
 
 	_, err = s.executor.Exec("sh", "-c", "echo close 8081 > "+actionFile)
 	err = s.waitForFileToBeDeleted(actionFile)

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -137,15 +137,21 @@ func (s *ProcessNetworkTestSuite) TestProcessLineageInfo() {
 func (s *ProcessNetworkTestSuite) TestNetworkFlows() {
 	s.Sensor().ExpectConnections(s.T(), s.serverContainer, 10*time.Second,
 		types.NetworkInfo{
-			LocalAddress:  fmt.Sprintf("%s:%d", s.clientIP, 0),
-			RemoteAddress: fmt.Sprintf(":%s", s.serverPort),
+			LocalAddress:   fmt.Sprintf(":%s", s.serverPort),
+			RemoteAddress:  s.clientIP,
+			Role:           "ROLE_SERVER",
+			SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+			CloseTimestamp: types.NilTimestamp,
 		},
 	)
 
 	s.Sensor().ExpectConnections(s.T(), s.clientContainer, 10*time.Second,
 		types.NetworkInfo{
-			LocalAddress:  "",
-			RemoteAddress: fmt.Sprintf("%s:%s", s.serverIP, s.serverPort),
+			LocalAddress:   "",
+			RemoteAddress:  fmt.Sprintf("%s:%s", s.serverIP, s.serverPort),
+			Role:           "ROLE_CLIENT",
+			SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+			CloseTimestamp: types.NilTimestamp,
 		},
 	)
 }

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -70,6 +70,11 @@ func (s *ProcfsScraperTestSuite) TestProcfsScraper() {
 		s.Sensor().ExpectEndpoints(s.T(), s.ServerContainer, 10*time.Second, types.EndpointInfo{
 			Protocol:       "L4_PROTOCOL_TCP",
 			CloseTimestamp: types.NilTimestamp,
+			Address: &types.ListenAddress{
+				AddressData: "\x00\x00\x00\x00",
+				Port:        80,
+				IpNetwork:   "\x00\x00\x00\x00 ",
+			},
 			Originator: &types.ProcessOriginator{
 				ProcessName:         processes[0].Name,
 				ProcessExecFilePath: processes[0].ExePath,
@@ -78,6 +83,11 @@ func (s *ProcfsScraperTestSuite) TestProcfsScraper() {
 		}, types.EndpointInfo{
 			Protocol:       "L4_PROTOCOL_TCP",
 			CloseTimestamp: types.NilTimestamp,
+			Address: &types.ListenAddress{
+				AddressData: "\x00\x00\x00\x00",
+				Port:        80,
+				IpNetwork:   "\x00\x00\x00\x00 ",
+			},
 			Originator: &types.ProcessOriginator{
 				ProcessName:         processes[0].Name,
 				ProcessExecFilePath: processes[0].ExePath,
@@ -86,15 +96,16 @@ func (s *ProcfsScraperTestSuite) TestProcfsScraper() {
 		})
 	} else {
 		// If scraping is off or the feature flag is disabled
-		// we expect to find the endpoint but with no originator process
-		s.Sensor().ExpectEndpoints(s.T(), s.ServerContainer, 10*time.Second, types.EndpointInfo{
-			Protocol:       "L4_PROTOCOL_TCP",
-			CloseTimestamp: types.NilTimestamp,
-			Originator: &types.ProcessOriginator{
-				ProcessName:         "",
-				ProcessExecFilePath: "",
-				ProcessArgs:         "",
-			},
-		})
+		// we expect to find no endpoints
+		s.Sensor().ExpectEndpointsN(s.T(), s.ServerContainer, 10*time.Second, 0)
+		//s.Sensor().ExpectEndpoints(s.T(), s.ServerContainer, 10*time.Second, types.EndpointInfo{
+		//	Protocol:       "L4_PROTOCOL_TCP",
+		//	CloseTimestamp: types.NilTimestamp,
+		//	Originator: &types.ProcessOriginator{
+		//		ProcessName:         "",
+		//		ProcessExecFilePath: "",
+		//		ProcessArgs:         "",
+		//	},
+		//})
 	}
 }

--- a/integration-tests/suites/procfs_scraper.go
+++ b/integration-tests/suites/procfs_scraper.go
@@ -64,5 +64,10 @@ func (s *ProcfsScraperTestSuite) TearDownSuite() {
 }
 
 func (s *ProcfsScraperTestSuite) TestProcfsScraper() {
-	s.Sensor().ExpectEndpoints(s.T(), s.ServerContainer, 10*time.Second, s.Expected...)
+	if len(s.Expected) == 0 {
+		// if we expect no endpoints, this Expect function is more precise
+		s.Sensor().ExpectEndpointsN(s.T(), s.ServerContainer, 10*time.Second, 0)
+	} else {
+		s.Sensor().ExpectEndpoints(s.T(), s.ServerContainer, 10*time.Second, s.Expected...)
+	}
 }

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
-	// "github.com/stackrox/collector/integration-tests/pkg/common"
+	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -93,8 +93,8 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	s.ClientIP, err = s.getIPAddress("nginx-curl")
 	s.Require().NoError(err)
 
-	// totalTime := (s.SleepBetweenCurlTime*s.NumIter+s.SleepBetweenIterations)*s.NumMetaIter + s.AfterglowPeriod + 10
-	// common.Sleep(time.Duration(totalTime) * time.Second)
+	totalTime := (s.SleepBetweenCurlTime*s.NumIter+s.SleepBetweenIterations)*s.NumMetaIter + s.AfterglowPeriod + 10
+	common.Sleep(time.Duration(totalTime) * time.Second)
 }
 
 func (s *RepeatedNetworkFlowTestSuite) TearDownSuite() {

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
-	//"github.com/stackrox/collector/integration-tests/pkg/common"
+	// "github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stretchr/testify/assert"
 )

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
+	//"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,8 +93,8 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 	s.ClientIP, err = s.getIPAddress("nginx-curl")
 	s.Require().NoError(err)
 
-	totalTime := (s.SleepBetweenCurlTime*s.NumIter+s.SleepBetweenIterations)*s.NumMetaIter + s.AfterglowPeriod + 10
-	time.Sleep(time.Duration(totalTime) * time.Second)
+	// totalTime := (s.SleepBetweenCurlTime*s.NumIter+s.SleepBetweenIterations)*s.NumMetaIter + s.AfterglowPeriod + 10
+	// common.Sleep(time.Duration(totalTime) * time.Second)
 }
 
 func (s *RepeatedNetworkFlowTestSuite) TearDownSuite() {

--- a/integration-tests/suites/socat.go
+++ b/integration-tests/suites/socat.go
@@ -56,7 +56,7 @@ func (s *SocatTestSuite) SetupSuite() {
 
 	s.serverContainer = common.ContainerShortID(containerID)
 
-	time.Sleep(6 * time.Second)
+	common.Sleep(6 * time.Second)
 }
 
 func (s *SocatTestSuite) TearDownSuite() {

--- a/integration-tests/suites/symlink_process.go
+++ b/integration-tests/suites/symlink_process.go
@@ -45,7 +45,7 @@ func (s *SymbolicLinkProcessTestSuite) SetupSuite() {
 	err = s.waitForFileToBeDeleted(actionFile)
 	s.Require().NoError(err)
 
-	time.Sleep(6 * time.Second)
+	common.Sleep(6 * time.Second)
 }
 
 func (s *SymbolicLinkProcessTestSuite) TearDownSuite() {


### PR DESCRIPTION
## Description

The ExpectConnections and ExpectEndpoints are incorrectly succeeding due to a logic bug in in the event filtering:

- the caller specifies a set of expected connections or endpoints
- the function attempts filter that list to get a list of entities that have not been seen
- the filter condition is backwards, instead giving a list of entities that have been seen
- At this early stage in the function, no events have been seen, but the function incorrectly believes that all events have been seen and returns success.