### PR TITLE
build: Adjust timeout waiting for Konflux images

### DIFF
--- a/.github/workflows/konflux-tests.yml
+++ b/.github/workflows/konflux-tests.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
           image: rhacs-eng/collector:${{ needs.init.outputs.collector-tag }}
-          limit: 5400 # 1h30m
+          limit: 9000 # 2h30m
 
   integration-tests-containers:
     uses: ./.github/workflows/integration-test-containers.yml

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -78,8 +78,9 @@ spec:
         requests:
           cpu: 1
 
-  # The pipeline regularly takes >1h to finish.
   timeouts:
+    # The pipeline regularly takes >1h to finish.
+    # When changing the value here, make sure to adjust wait-for-images time limit in .github/workflows/konflux-tests.yml
     pipeline: 2h00m0s
 
   pipelineRef:


### PR DESCRIPTION
## Description

I noticed that GHA builds were failing on me https://github.com/stackrox/collector/actions/runs/10375095581/job/28724093219

This should fix it.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change to automated tests.

## Testing Performed

GHA should pass.