### PR TITLE
ROX-25715: Add Slack notifications for Konflux builds

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -81,7 +81,9 @@ spec:
   timeouts:
     # The pipeline regularly takes >1h to finish.
     # When changing the value here, make sure to adjust wait-for-images time limit in .github/workflows/konflux-tests.yml
-    pipeline: 2h00m0s
+    tasks: 2h
+    finally: 10m
+    pipeline: 2h10m
 
   pipelineRef:
     name: collector-component-pipeline

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -6,6 +6,27 @@ metadata:
 spec:
 
   finally:
+  - name: slack-notification
+    params:
+    - name: message
+      value: ':x: `{{event_type}}` pipeline for <https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/$(context.pipelineRun.name)|$(context.pipelineRun.name)> (`$(params.output-image-repo)`, revision <$(params.git-url)/commit/$(params.revision)|$(params.revision)>) has failed.'
+    - name: key-name
+      value: 'acs-konflux-notifications'
+    when:
+    # Run when any task has Failed
+    - input: $(tasks.status)
+      operator: in
+      values: ["Failed"]
+    taskRef:
+      params:
+      - name: name
+        value: slack-webhook-notification
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:0dfdfd87a8716ff9c20ae3325eff9a5d52ee9c708959c1e93eaedc852621a4d5
+      - name: kind
+        value: task
+      resolver: bundles
+
   - name: show-sbom
     params:
     - name: IMAGE_URL


### PR DESCRIPTION
## Description

Add Slack notifications in case Konflux build times out or tasks fail.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.



## Testing Performed

Existing Konflux pipelines need to pass.