### PR TITLE
Add username to dev VMs to make it easier to differentiate them

### DIFF
--- a/ansible/dev/group_vars/all.yml
+++ b/ansible/dev/group_vars/all.yml
@@ -4,7 +4,7 @@
 gcp_project: "acs-team-sandbox"
 gcp_auth_kind: "application"
 gcp_service_account_file: null
-gcp_instance_prefix: dev
+gcp_instance_prefix: "{{ lookup('env', 'USER') }}-dev"
 gcp_available_zones:
   - us-central1-a
   - us-central1-b

--- a/ansible/dev/inventory_gcp.yml
+++ b/ansible/dev/inventory_gcp.yml
@@ -4,7 +4,7 @@ plugin: gcp_compute
 projects:
   - acs-team-sandbox
 filters:
-  - name = dev-*
+  - name eq "^.*-dev-.*$"
 keyed_groups:
   # This will group the VMs by their labels, which means that on
   # creation, we can use a unique identifier to group VMs


### PR DESCRIPTION
## Description

To make GCP VMs easier to differentiate, this PR prefixes the (local) username to the VM name upon creation. 

Tested locally.

Regarding VM name length limits, this won't affect CI VMs at all, and will break locally a fair while before it breaks for VMs (though with the recent changes to the naming convention, we have a significant buffer zone before limits become a problem again)
