### PR TITLE
Update Falco bumping instructions

### DIFF
--- a/docs/falco-update.md
+++ b/docs/falco-update.md
@@ -14,24 +14,39 @@ order to retain versions of released code and avoid maintenance hell.
 The process, at a high level is:
 
 - Update the `upstream-main` branch to the tip of master
-- Create a new module version branch from the previous version
-- Rebase the new module version branch to a newer tag on `upstream-main`
+- Pick the new upstream tag we will be based on
+- Create a new branch from the previous version
+- Rebase the new branch to the newer tag on `upstream-main`
     - This is likely to require conflict resolution and testing
-- Push the new module version branch to origin
+- Push the new branch to origin
 
 Or, described in Git commands:
 
 First you must identify the latest version branch in the repository:
 
-```
-$ git branch -a | grep 'module-version-'
+```sh
+$ git branch -a | grep '.*-stackrox$'
 # e.g.
-module-version-2.9
-module-version-2.10
+0.17.1-stackrox
+0.17.2-stackrox
 ```
 
-With a latest version in hand, you can proceed with the update:
+... As well as the upstream tag that will be used for the new version:
 
+```sh
+$ git tag -l
+# e.g.
+0.17.0
+0.17.0-rc1
+0.17.0-rc2
+0.17.1
+0.17.2
+0.17.3
+0.17.3-rc1
+0.17.3-rc2
+```
+
+With the versions in hand, you can proceed with the update:
 ```sh
 $ git remote add falco git@github.com:falcosecurity/libs
 $ git fetch falco
@@ -44,12 +59,12 @@ $ git push origin upstream-main
 $ git push --tags origin upstream-main
 
 # Now update the most recent branch
-$ git switch module-version-2.9
+$ git switch 0.17.2-stackrox
 
 # Perform the update, fixing any conflicts
-$ git switch -c module-version-2.10
-$ git rebase <tag> # NOT upstream-main, we should only update to stable tags
-$ git push -u origin module-version-2.10
+$ git switch -c 0.17.3-stackrox
+$ git rebase 0.17.3
+$ git push -u origin 0.17.3-stackrox
 ```
 
 In order to review an updated Falco branch, any PRs should target the original


### PR DESCRIPTION
## Description

With the removal of the MODULE_VERSION file in #1773 our handling of the falco libs fork is somewhat outdated, since now there is no module version to use as a guideline. Instead, I'm proposing that we start using the upstream version we are based on as part of our branching strategy.

With this new approach, branches with our changes will be of the form M.m.p-stackrox, with M.m.p being the version numbers for the upstream libs tag the branch is based on.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

This is a documentation only PR, no testing is necessary.
