### PR TITLE
Disable new line removal

### DIFF
--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -113,10 +113,6 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
     return;
   }
 
-  // remove any newlines to avoid additional empty log lines
-  // because our logging already appends a newline
-  msg.erase(std::remove(msg.begin(), msg.end(), '\n'), msg.cend());
-
   collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
 }
 


### PR DESCRIPTION
## Description

Since 52f9b30f2e falco has changed the way how verifier errors (or general libpman output) is processed, making it via a single buffer. This means that removing new lines from the log message mangles the verifier log, squashing all the lines like. Having extra empty lines is not so bad, so remove this logic.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

Log output is not tested and doesn't have to be tested, so CI is sufficient.

## Testing Performed

Manual triggering a verifier error and inspecting the output.