### PR TITLE
Provide environment variable alternatives to CLI arguments

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -38,7 +38,4 @@ HEALTHCHECK	\
 	# the command uses /ready API
 	CMD /usr/local/bin/status-check.sh
 
-ENTRYPOINT collector \
-    --collector-config=$COLLECTOR_CONFIG \
-    --collection-method=$COLLECTION_METHOD \
-    --grpc-server=$GRPC_SERVER
+ENTRYPOINT collector

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -153,10 +153,7 @@ RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && \
 
 EXPOSE 8080 9090
 
-ENTRYPOINT collector \
-    --collector-config=$COLLECTOR_CONFIG \
-    --collection-method=$COLLECTION_METHOD \
-    --grpc-server=$GRPC_SERVER
+ENTRYPOINT collector
 
 LABEL \
     com.redhat.component="rhacs-collector-container" \

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string>
 
+#include "GRPC.h"
 #include "Logging.h"
 #include "optionparser.h"
 
@@ -174,49 +175,17 @@ CollectorArgs::checkCollectorConfig(const option::Option& option, bool msg) {
 option::ArgStatus
 CollectorArgs::checkGRPCServer(const option::Option& option, bool msg) {
   using namespace option;
-  using std::string;
+  const auto& [status, m] = CheckGrpcServer(option.arg);
 
-  if (option.arg == NULL || ::strlen(option.arg) == 0) {
-    if (msg) {
-      this->message = "Missing grpc list. Cannot configure GRPC client. Reverting to stdout.";
-    }
-    return ARG_OK;
+  if (status == ARG_OK) {
+    grpcServer = option.arg;
   }
 
-  if (::strlen(option.arg) > 255) {
-    if (msg) {
-      this->message = "GRPC Server addr too long (> 255)";
-    }
-    return ARG_ILLEGAL;
+  if (msg) {
+    this->message = m;
   }
 
-  string arg(option.arg);
-  string::size_type j = arg.find(':');
-  if (j == string::npos) {
-    if (msg) {
-      this->message = "Malformed grpc server addr";
-    }
-    return ARG_ILLEGAL;
-  }
-
-  string host = arg.substr(0, j);
-  if (host.empty()) {
-    if (msg) {
-      this->message = "Missing grpc host";
-    }
-    return ARG_ILLEGAL;
-  }
-
-  string port = arg.substr(j + 1, arg.length());
-  if (port.empty()) {
-    if (msg) {
-      this->message = "Missing grpc port";
-    }
-    return ARG_ILLEGAL;
-  }
-
-  grpcServer = arg;
-  return ARG_OK;
+  return status;
 }
 
 const Json::Value&

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -41,8 +41,8 @@ static const option::Descriptor usage[] =
          "USAGE: collector [options]\n\n"
          "Options:"},
         {HELP, 0, "", "help", option::Arg::None, "  --help                \tPrint usage and exit."},
-        {COLLECTOR_CONFIG, 0, "", "collector-config", checkCollectorConfig, "  --collector-config    \tREQUIRED: Collector config as a JSON string. Please refer to documentation on the valid JSON format."},
-        {COLLECTION_METHOD, 0, "", "collection-method", checkCollectionMethod, "  --collection-method   \tCollection method (kernel_module, ebpf or core_bpf)."},
+        {COLLECTOR_CONFIG, 0, "", "collector-config", checkCollectorConfig, "  --collector-config    \tCollector config as a JSON string. Please refer to documentation on the valid JSON format."},
+        {COLLECTION_METHOD, 0, "", "collection-method", checkCollectionMethod, "  --collection-method   \tCollection method (ebpf or core_bpf)."},
         {GRPC_SERVER, 0, "", "grpc-server", checkGRPCServer, "  --grpc-server         \tGRPC server endpoint string in the form HOST1:PORT1."},
         {UNKNOWN, 0, "", "", option::Arg::None,
          "\nExamples:\n"
@@ -87,7 +87,7 @@ bool CollectorArgs::parse(int argc, char** argv, int& exitCode) {
     return false;
   }
 
-  if (options[HELP] || argc == 0) {
+  if (options[HELP]) {
     stringstream out;
     option::printUsage(out, usage);
     message = out.str();
@@ -143,7 +143,7 @@ CollectorArgs::checkCollectorConfig(const option::Option& option, bool msg) {
     if (msg) {
       this->message = "Missing collector config";
     }
-    return ARG_ILLEGAL;
+    return ARG_IGNORE;
   }
 
   string arg(option.arg);

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -61,18 +61,18 @@ BoolEnvVar use_podman_ce("ROX_COLLECTOR_CE_USE_PODMAN", false);
 BoolEnvVar enable_introspection("ROX_COLLECTOR_INTROSPECTION_ENABLE", false);
 
 // Collector arguments alternatives
-OptionalStringEnvVar log_level("ROX_COLLECTOR_LOG_LEVEL");
-OptionalIntEnvVar scrape_interval("ROX_COLLECTOR_SCRAPE_INTERVAL");
-OptionalBoolEnvVar scrape_off("ROX_COLLECTOR_SCRAPE_DISABLED");
-OptionalStringEnvVar grpc_server("GRPC_SERVER");
-OptionalStringEnvVar collector_config("COLLECTOR_CONFIG");
-OptionalStringEnvVar collection_method("COLLECTION_METHOD");
+StringEnvVar log_level("ROX_COLLECTOR_LOG_LEVEL");
+IntEnvVar scrape_interval("ROX_COLLECTOR_SCRAPE_INTERVAL");
+BoolEnvVar scrape_off("ROX_COLLECTOR_SCRAPE_DISABLED");
+StringEnvVar grpc_server("GRPC_SERVER");
+StringEnvVar collector_config("COLLECTOR_CONFIG");
+StringEnvVar collection_method("COLLECTION_METHOD");
 
 // TLS Configuration
-OptionalPathEnvVar tls_certs_path("ROX_COLLECTOR_TLS_CERTS");
-OptionalPathEnvVar tls_ca_path("ROX_COLLECTOR_TLS_CA");
-OptionalPathEnvVar tls_client_cert_path("ROX_COLLECTOR_TLS_CLIENT_CERT");
-OptionalPathEnvVar tls_client_key_path("ROX_COLLECTOR_TLS_CLIENT_KEY");
+PathEnvVar tls_certs_path("ROX_COLLECTOR_TLS_CERTS");
+PathEnvVar tls_ca_path("ROX_COLLECTOR_TLS_CA");
+PathEnvVar tls_client_cert_path("ROX_COLLECTOR_TLS_CLIENT_CERT");
+PathEnvVar tls_client_key_path("ROX_COLLECTOR_TLS_CLIENT_KEY");
 
 }  // namespace
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -64,7 +64,7 @@ BoolEnvVar enable_introspection("ROX_COLLECTOR_INTROSPECTION_ENABLE", false);
 OptionalStringEnvVar log_level("ROX_COLLECTOR_LOG_LEVEL");
 OptionalIntEnvVar scrape_interval("ROX_COLLECTOR_SCRAPE_INTERVAL");
 OptionalBoolEnvVar scrape_off("ROX_COLLECTOR_SCRAPE_DISABLED");
-OptionalStringEnvVar grpc_server("ROX_COLLECTOR_GRPC_SERVER");
+OptionalStringEnvVar grpc_server("GRPC_SERVER");
 
 // TLS Configuration
 OptionalPathEnvVar tls_certs_path("ROX_COLLECTOR_TLS_CERTS");

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -12,6 +12,8 @@
 #include "HostConfig.h"
 #include "NetworkConnection.h"
 #include "TlsConfig.h"
+#include "json/value.h"
+#include "optionparser.h"
 
 namespace collector {
 
@@ -88,6 +90,8 @@ class CollectorConfig {
   unsigned int GetSinspBufferSize() const;
   unsigned int GetSinspTotalBufferSize() const { return sinsp_total_buffer_size_; }
   unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
+
+  static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -11,6 +11,7 @@
 #include "CollectionMethod.h"
 #include "HostConfig.h"
 #include "NetworkConnection.h"
+#include "TlsConfig.h"
 
 namespace collector {
 
@@ -68,7 +69,7 @@ class CollectorConfig {
   const std::vector<IPNet>& NonAggregatedNetworks() const { return non_aggregated_networks_; }
   bool EnableAfterglow() const { return enable_afterglow_; }
   bool IsCoreDumpEnabled() const;
-  Json::Value TLSConfiguration() const { return tls_config_; }
+  const std::optional<TlsConfig>& TLSConfiguration() const { return tls_config_; }
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
@@ -82,6 +83,7 @@ class CollectorConfig {
   const std::vector<double>& GetConnectionStatsQuantiles() const { return connection_stats_quantiles_; }
   double GetConnectionStatsError() const { return connection_stats_error_; }
   unsigned int GetConnectionStatsWindow() const { return connection_stats_window_; }
+  const std::optional<std::string>& GetGrpcServer() const { return grpc_server_; }
   unsigned int GetSinspCpuPerBuffer() const { return sinsp_cpu_per_buffer_; }
   unsigned int GetSinspBufferSize() const;
   unsigned int GetSinspTotalBufferSize() const { return sinsp_total_buffer_size_; }
@@ -120,6 +122,9 @@ class CollectorConfig {
   double connection_stats_error_;
   unsigned int connection_stats_window_;
 
+  // URL to the GRPC server
+  std::optional<std::string> grpc_server_;
+
   // One ring buffer will be initialized for this many CPUs
   unsigned int sinsp_cpu_per_buffer_ = 0;
   // Size of one ring buffer, in bytes.
@@ -135,7 +140,7 @@ class CollectorConfig {
   // is 2^17 (131072) and twice as large.
   unsigned int sinsp_thread_cache_size_ = 32768;
 
-  Json::Value tls_config_;
+  std::optional<TlsConfig> tls_config_;
 
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();

--- a/collector/lib/GRPC.cpp
+++ b/collector/lib/GRPC.cpp
@@ -6,6 +6,8 @@
 
 #include <grpcpp/create_channel.h>
 
+#include "optionparser.h"
+
 namespace collector {
 
 namespace {
@@ -19,13 +21,12 @@ std::string ReadFileContents(const std::string& filename) {
 
 }  // namespace
 
-std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromFiles(
-    const std::string& ca_cert_path, const std::string& client_cert_path, const std::string& client_key_path) {
+std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromConfig(const TlsConfig& config) {
   grpc::SslCredentialsOptions sslOptions;
 
-  sslOptions.pem_root_certs = ReadFileContents(ca_cert_path);
-  sslOptions.pem_private_key = ReadFileContents(client_key_path);
-  sslOptions.pem_cert_chain = ReadFileContents(client_cert_path);
+  sslOptions.pem_root_certs = ReadFileContents(config.GetCa());
+  sslOptions.pem_private_key = ReadFileContents(config.GetClientKey());
+  sslOptions.pem_cert_chain = ReadFileContents(config.GetClientCert());
 
   return grpc::SslCredentials(sslOptions);
 }
@@ -43,6 +44,43 @@ std::shared_ptr<grpc::Channel> CreateChannel(const std::string& server_address, 
     chan_args.SetSslTargetNameOverride(hostname_override);
   }
   return grpc::CreateCustomChannel(server_address, creds, chan_args);
+}
+
+std::pair<option::ArgStatus, std::string> CheckGrpcServer(std::string_view server) {
+  using namespace option;
+
+  if (server.empty()) {
+    return std::make_pair(ARG_IGNORE, "Missing grpc list. Cannot configure GRPC client. Reverting to stdout.");
+  }
+
+  if (server.size() > 255) {
+    return std::make_pair(ARG_ILLEGAL, "GRPC Server addr too long (> 255)");
+  }
+
+  auto marker = server.find(':');
+  if (marker == std::string_view::npos) {
+    return std::make_pair(ARG_ILLEGAL, "Malformed grpc server addr");
+  }
+
+  auto host = server.substr(0, marker);
+  if (host.empty()) {
+    return std::make_pair(ARG_ILLEGAL, "Missing grpc host");
+  }
+
+  auto port = server.substr(marker + 1);
+  if (port.empty()) {
+    return std::make_pair(ARG_ILLEGAL, "Missing grpc port");
+  }
+
+  return std::make_pair(ARG_OK, "");
+}
+
+std::pair<option::ArgStatus, std::string> CheckGrpcServer(const char* server) {
+  if (server == nullptr) {
+    return std::make_pair(option::ARG_IGNORE, "Missing grpc list. Cannot configure GRPC client. Reverting to stdout.");
+  }
+
+  return CheckGrpcServer(std::string_view(server));
 }
 
 }  // namespace collector

--- a/collector/lib/GRPC.h
+++ b/collector/lib/GRPC.h
@@ -1,15 +1,23 @@
 #ifndef COLLECTOR_GRPC_H
 #define COLLECTOR_GRPC_H
 
+#include <optional>
+#include <string_view>
+
 #include <grpcpp/channel.h>
 #include <grpcpp/security/credentials.h>
 
+#include "TlsConfig.h"
+#include "optionparser.h"
+
 namespace collector {
 
-std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromFiles(
-    const std::string& ca_cert_path, const std::string& client_cert_path, const std::string& client_key_path);
+std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromConfig(const TlsConfig& config);
 
 std::shared_ptr<grpc::Channel> CreateChannel(const std::string& server_address, const std::string& hostname_override, const std::shared_ptr<grpc::ChannelCredentials>& creds);
+
+std::pair<option::ArgStatus, std::string> CheckGrpcServer(std::string_view server);
+std::pair<option::ArgStatus, std::string> CheckGrpcServer(const char* server);
 
 }  // namespace collector
 

--- a/collector/lib/TlsConfig.h
+++ b/collector/lib/TlsConfig.h
@@ -1,0 +1,25 @@
+#ifndef _TLS_H_
+#define _TLS_H_
+
+#include <filesystem>
+#include <utility>
+
+class TlsConfig {
+ public:
+  TlsConfig(std::filesystem::path ca, std::filesystem::path clientCert, std::filesystem::path clientKey) : ca_(std::move(ca)), clientCert_(std::move(clientCert)), clientKey_(std::move(clientKey)) {}
+
+  const std::filesystem::path& GetCa() const { return ca_; }
+  const std::filesystem::path& GetClientCert() const { return clientCert_; }
+  const std::filesystem::path& GetClientKey() const { return clientKey_; }
+
+  bool IsValid() const {
+    return !ca_.empty() && !clientCert_.empty() && !clientKey_.empty();
+  }
+
+ private:
+  std::filesystem::path ca_;
+  std::filesystem::path clientCert_;
+  std::filesystem::path clientKey_;
+};
+
+#endif  // _TLS_H_

--- a/collector/test/CollectorArgs_test.cpp
+++ b/collector/test/CollectorArgs_test.cpp
@@ -14,9 +14,9 @@ TEST(CollectorArgs, NoArgs) {
 
   CollectorArgs* args = CollectorArgs::getInstance();
   int exitCode;
-  EXPECT_EQ(false, args->parse(argc, argv, exitCode));
+  EXPECT_EQ(true, args->parse(argc, argv, exitCode));
   EXPECT_EQ(0, exitCode);
-  EXPECT_THAT(args->Message(), StartsWith("USAGE: collector"));
+  EXPECT_TRUE(args->Message().empty());
 }
 
 TEST(CollectorArgs, ProgramNameOnly) {
@@ -30,9 +30,9 @@ TEST(CollectorArgs, ProgramNameOnly) {
 
   CollectorArgs* args = CollectorArgs::getInstance();
   int exitCode;
-  EXPECT_EQ(false, args->parse(argc, (char**)argv, exitCode));
+  EXPECT_EQ(true, args->parse(argc, (char**)argv, exitCode));
   EXPECT_EQ(0, exitCode);
-  EXPECT_THAT(args->Message(), StartsWith("USAGE: collector"));
+  EXPECT_TRUE(args->Message().empty());
 }
 
 TEST(CollectorArgs, HelpFlag) {

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -49,6 +49,7 @@ func newDockerManager(e executor.Executor, name string) *DockerCollectorManager 
 		bootstrapOnly: false,
 		env:           env,
 		mounts:        mounts,
+		config:        map[string]any{},
 		testName:      name,
 	}
 }

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -28,19 +28,12 @@ type DockerCollectorManager struct {
 func newDockerManager(e executor.Executor, name string) *DockerCollectorManager {
 	collectorOptions := config.CollectorInfo()
 
-	collectionMethod := config.CollectionMethod()
-
-	collectorConfig := map[string]any{
-		"logLevel":       collectorOptions.LogLevel,
-		"turnOffScrape":  true,
-		"scrapeInterval": 2,
-	}
-
 	env := map[string]string{
-		"GRPC_SERVER":             "localhost:9999",
-		"COLLECTION_METHOD":       collectionMethod,
-		"COLLECTOR_PRE_ARGUMENTS": collectorOptions.PreArguments,
-		"ENABLE_CORE_DUMP":        "true",
+		"GRPC_SERVER":                   "localhost:9999",
+		"ENABLE_CORE_DUMP":              "true",
+		"ROX_COLLECTOR_LOG_LEVEL":       collectorOptions.LogLevel,
+		"ROX_COLLECTOR_SCRAPE_DISABLED": "true",
+		"ROX_COLLECTOR_SCRAPE_INTERVAL": "2",
 	}
 
 	mounts := map[string]string{
@@ -56,7 +49,6 @@ func newDockerManager(e executor.Executor, name string) *DockerCollectorManager 
 		bootstrapOnly: false,
 		env:           env,
 		mounts:        mounts,
-		config:        collectorConfig,
 		testName:      name,
 	}
 }


### PR DESCRIPTION
## Description

This change makes it so environment variables can be used to configure all arguments that can be provided via CLI parameters. This should in turn make configuring collector in k8s easier and simplify the command
to be used in our dockerfiles.

In order to prevent as many breaking changes as possible, CLI arguments will take precedence over environment variables. For TLS certificates a variable was added for specifying a directory holding the ca.pem,
cert.pem and key.pem files, and three other variables were added to be able to override the location of each of the files or explicitly setting all three if needed.

New environment variables added:
- ROX_COLLECTOR_LOG_LEVEL: Sets the log level to be used.
- ROX_COLLECTOR_SCRAPE_INTERVAL: Set the scrapping interval in seconds.
- ROX_COLLECTOR_SCRAPE_DISABLED: Completely disable scrapping.
- ROX_COLLECTOR_TLS_CERTS: Path to a directory holding TLS certificates.
- ROX_COLLECTOR_TLS_CA: Path to the CA certificate to be used in TLS.
- ROX_COLLECTOR_TLS_CLIENT_CERT: Path to the client certificate to be used in TLS.
- ROX_COLLECTOR_TLS_CLIENT_KEY: Path to the client key to be used in TLS.

Existing dockerfile environment variables that used to be passed through CLI args that should still be compatible:
- COLLECTOR_CONFIG
- COLLECTION_METHOD
- GRPC_SERVER

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
