### PR TITLE
Do not process gcloudignore files when uploading support-packages

### DIFF
--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -134,6 +134,7 @@ jobs:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
           destination: ${{ inputs.support-packages-bucket }}/${{ matrix.platform }}
+          process_gcloudignore: false
 
       - name: Push support-packages to public bucket
         uses: 'google-github-actions/upload-cloud-storage@v2'
@@ -142,6 +143,7 @@ jobs:
           path: ${{ env.SUPPORT_PACKAGE_TMP_DIR }}
           parent: false
           destination: ${{ inputs.public-support-packages-bucket }}/${{ matrix.platform }}
+          process_gcloudignore: false
 
   merge-drivers-failures:
     runs-on: ubuntu-latest
@@ -185,6 +187,7 @@ jobs:
           path: /tmp/support-packages/output/index.html
           parent: false
           destination: ${{ inputs.support-packages-index-bucket }}
+          process_gcloudignore: false
 
       - name: Push index.html to public bucket
         uses: 'google-github-actions/upload-cloud-storage@v2'
@@ -193,6 +196,7 @@ jobs:
           path: /tmp/support-packages/output/index.html
           parent: false
           destination: ${{ inputs.public-support-packages-bucket }}
+          process_gcloudignore: false
 
   copy-to-merged-bucket:
     runs-on: ubuntu-latest


### PR DESCRIPTION


## Description

This is a minor change, we are getting some error message on the upload support packages steps from the CPaaS workflows because the google-github-actions/upload-cloud-storage action expects a gcloudignore to be present by default. Since we don't expect to process this kind of file, we just set the option to false on all occurrences of the action.

Without this change the actions still worked correctly, this is merely to get rid of the annoying error messages in the CI output.

Examples of the errors can be found here: https://github.com/stackrox/collector/actions/runs/10609617180/job/29405734430

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run CPaaS steps and check the messages are gone.
