### PR TITLE
Reenable cos-dev tests

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -90,8 +90,7 @@ virtual_machines:
     families:
       - cos-stable
       - cos-beta
-      # ROX-24938: disabled until the verifier issue is fixed.
-      # - cos-dev
+      - cos-dev
 
   sles:
     project: suse-cloud


### PR DESCRIPTION
## Description

Now that the verifier issue that was present on newer cos kernels has been resolved by #1812, we should be able to add back the dev version of this distro to our integration tests.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
