### PR TITLE
Fix Konflux build after collector scripts removal

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -146,10 +146,6 @@ ENV COLLECTOR_HOST_ROOT=/host
 
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/collector /usr/local/bin/
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
-COPY --from=builder ${BUILD_DIR}/collector/container/scripts /
-
-RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/usrlocallib.conf && \
-    ldconfig
 
 EXPOSE 8080 9090
 


### PR DESCRIPTION
## Description

PR #1814 removed the scripts used by collector to run, making it possible for it to be run directly. The Konflux build is still attempting to copy the scripts directory into the image even though it doesn't exist anymore, so we should remove that line from the dockerfile.

As an additional cleanup, since we have been linking falco statically for some time now, there's no need to call ldconfig anymore.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Run Konflux tests.
