### PR TITLE
Add collector version to compilation step

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -1,5 +1,6 @@
 ARG BUILD_DIR=/build
 ARG CMAKE_BUILD_DIR=${BUILD_DIR}/cmake-build
+ARG COLLECTOR_TAG
 
 
 # Builder
@@ -83,6 +84,7 @@ RUN ./builder/install/install-dependencies.sh && \
            -DDISABLE_PROFILING=${DISABLE_PROFILING} \
            -DUSE_VALGRIND=${USE_VALGRIND} \
            -DADDRESS_SANITIZER=${ADDRESS_SANITIZER} \
+           -DCOLLECTOR_VERSION=${COLLECTOR_TAG} \
            -DTRACE_SINSP_EVENTS=${TRACE_SINSP_EVENTS} && \
     cmake --build ${CMAKE_BUILD_DIR} --target all -- -j "${NPROCS:-4}" && \
     ctest -V --test-dir ${CMAKE_BUILD_DIR} && \
@@ -117,8 +119,6 @@ RUN /tmp/.konflux/scripts/subscription-manager-bro.sh register /mnt && \
 FROM scratch
 
 COPY --from=rpm-implanter-app /mnt /
-
-ARG COLLECTOR_TAG
 
 WORKDIR /
 

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -1,6 +1,5 @@
 ARG BUILD_DIR=/build
 ARG CMAKE_BUILD_DIR=${BUILD_DIR}/cmake-build
-ARG COLLECTOR_TAG
 
 
 # Builder
@@ -49,6 +48,7 @@ ARG SOURCES_DIR=/staging
 
 COPY . ${SOURCES_DIR}
 
+ARG COLLECTOR_TAG
 ARG BUILD_DIR
 ARG SRC_ROOT_DIR=${BUILD_DIR}
 ARG CMAKE_BUILD_DIR
@@ -119,6 +119,8 @@ RUN /tmp/.konflux/scripts/subscription-manager-bro.sh register /mnt && \
 FROM scratch
 
 COPY --from=rpm-implanter-app /mnt /
+
+ARG COLLECTOR_TAG
 
 WORKDIR /
 


### PR DESCRIPTION

## Description

Yet another mistake from #1814. The version of collector is now hardcoded into the binary, but that needs to be set at compile time, which was not being done in konflux builds. The label with the version was being set properly, this only affects collector printing its version to the logs.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check the log for the konflux tests has the correct version of collector in them.
