### PR TITLE
Local dev fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ falcosecurity-libs/cmake-build-rhel
 kernel-modules/kobuild-tmp
 utilities/PerformanceTesting/TestResults
 cmake-build/
+cmake-build-*/
 
 # Mac OS hidden file
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ image: collector unittest
 
 image-dev: collector unittest container-dockerfile-dev
 	make -C collector txt-files
-	docker build --build-arg collector_version="$(COLLECTOR_TAG)" \
+	docker buildx build --load --platform ${PLATFORM} \
+		--build-arg COLLECTOR_VERSION="$(COLLECTOR_TAG)" \
 		--build-arg BUILD_TYPE=devel \
 		-f collector/container/Dockerfile.dev \
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \
@@ -99,8 +100,9 @@ teardown-builder:
 
 .PHONY: clean
 clean:
-	rm -rf cmake-build/
+	rm -rf cmake-build*
 	make -C collector clean
+	make -C integration-tests docker-clean
 
 .PHONY: shfmt-check
 shfmt-check:

--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -17,8 +17,8 @@ PLATFORM ?= "linux/$(HOST_ARCH)"
 
 USE_VALGRIND ?= false
 ADDRESS_SANITIZER ?= false
-CMAKE_BUILD_TYPE ?= release
-CMAKE_BASE_DIR = cmake-build-$(CMAKE_BUILD_TYPE)-$(HOST_ARCH)
+CMAKE_BUILD_TYPE ?= Release
+CMAKE_BASE_DIR = cmake-build-$(shell echo $(CMAKE_BUILD_TYPE) | tr A-Z a-z)-$(HOST_ARCH)
 TRACE_SINSP_EVENTS ?= false
 DISABLE_PROFILING ?= false
 BPF_DEBUG_MODE ?= false

--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -1,25 +1,27 @@
-
 ifeq ($(COLLECTOR_BUILDER_TAG),)
 COLLECTOR_BUILDER_TAG=master
 endif
 
 ifeq ($(COLLECTOR_TAG),)
-ifeq ($(CIRCLE_TAG),)
 COLLECTOR_TAG=$(shell git describe --tags --abbrev=10 --dirty)
-else
-COLLECTOR_TAG := $(CIRCLE_TAG)
 endif
+
+DOCKER_CLI := $(shell command -v docker 2>/dev/null)
+
+ifeq ($(DOCKER_CLI),)
+$(error "docker is required for building")
 endif
+
+HOST_ARCH := $(shell docker system info --format '{{.Architecture}}')
+PLATFORM ?= "linux/$(HOST_ARCH)"
 
 USE_VALGRIND ?= false
 ADDRESS_SANITIZER ?= false
-CMAKE_BUILD_TYPE ?= Release
-PLATFORM ?= linux/amd64
+CMAKE_BUILD_TYPE ?= release
+CMAKE_BASE_DIR = cmake-build-$(CMAKE_BUILD_TYPE)-$(HOST_ARCH)
 TRACE_SINSP_EVENTS ?= false
 DISABLE_PROFILING ?= false
 BPF_DEBUG_MODE ?= false
 
 COLLECTOR_BUILD_CONTEXT = collector/
-COLLECTOR_BUILDER_NAME ?= collector_builder
-
-export COLLECTOR_PRE_ARGUMENTS
+COLLECTOR_BUILDER_NAME ?= collector_builder_$(HOST_ARCH)

--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -35,7 +35,7 @@ if (NOT COLLECTOR_VERSION)
 	set(COLLECTOR_VERSION "0.0.0")
 endif()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Version.h.in ${CMAKE_CURRENT_BINARY_DIR}/Version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lib/CollectorVersion.h.in ${CMAKE_CURRENT_BINARY_DIR}/CollectorVersion.h)
 
 set(FALCO_DIR ${PROJECT_SOURCE_DIR}/../falcosecurity-libs)
 

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -9,11 +9,11 @@ COLLECTOR_BIN_DIR = $(CMAKE_DIR)/collector
 LIBSINSP_BIN_DIR = $(CMAKE_DIR)/collector/EXCLUDE_FROM_DEFAULT_BUILD/libsinsp
 SRC_MOUNT_DIR = /tmp/collector
 
-HDRS := $(wildcard lib/*.h) $(shell find falcosecurity-libs/userspace -name '*.h')
+HDRS := $(wildcard lib/*.h) $(shell find $(BASE_PATH)/falcosecurity-libs/userspace -name '*.h')
 
 SRCS := $(wildcard lib/*.cpp) collector.cpp
 
-COLLECTOR_BUILD_DEPS := $(HDRS) $(SRCS) $(shell find falcosecurity-libs -name '*.h' -o -name '*.cpp' -o -name '*.c')
+COLLECTOR_BUILD_DEPS := $(HDRS) $(SRCS) $(shell find $(BASE_PATH)/falcosecurity-libs -name '*.h' -o -name '*.cpp' -o -name '*.c')
 
 .SUFFIXES:
 
@@ -65,17 +65,8 @@ txt-files:
 
 .PHONY: clean
 clean:
-	docker rm -fv build_collector || true
-	docker rm -fv container-stats benchmark collector grpc-server || true
-	rm -rf falcosecurity-libs/cmake-build
-	rm -rf falcosecurity-libs/falcosecurity-libs-build
+	rm -rf container/LICENSE-kernel-modules.txt
 	rm -rf container/bin
-	rm -rf container/driver
-	rm -rf container/libs
-	rm -rf container/rhel/scripts
-	rm -rf container/rhel/bundle.tar.gz
-	rm -rf container/devel/scripts
-	rm -rf container/devel/bundle.tar.gz
 	rm -rf container/THIRD_PARTY_NOTICES
 	rm -f container/Dockerfile.dev
 

--- a/collector/Version.h.in
+++ b/collector/Version.h.in
@@ -1,10 +1,10 @@
-#ifndef _VERSION_H_
-#define _VERSION_H_
+#ifndef _COLLECTOR_VERSION_H_
+#define _COLLECTOR_VERSION_H_
 
-#define COLLECTOR_VERSION "${COLLECTOR_VERSION}"
+#define COLLECTOR_VERSION "@COLLECTOR_VERSION@"
 
 inline const char* GetCollectorVersion() {
   return COLLECTOR_VERSION;
 }
 
-#endif  // _VERSION_H_
+#endif  // _COLLECTOR_VERSION_H_

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include "CollectorArgs.h"
 #include "CollectorService.h"
 #include "CollectorStatsExporter.h"
+#include "CollectorVersion.h"
 #include "Control.h"
 #include "Diagnostics.h"
 #include "EventNames.h"
@@ -40,7 +41,6 @@ extern "C" {
 #include "LogLevel.h"
 #include "Logging.h"
 #include "Utility.h"
-#include "CollectorVersion.h"
 
 static const int MAX_GRPC_CONNECTION_POLLS = 30;
 

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -40,7 +40,7 @@ extern "C" {
 #include "LogLevel.h"
 #include "Logging.h"
 #include "Utility.h"
-#include "Version.h"
+#include "collector/Version.h"
 
 static const int MAX_GRPC_CONNECTION_POLLS = 30;
 

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -40,7 +40,7 @@ extern "C" {
 #include "LogLevel.h"
 #include "Logging.h"
 #include "Utility.h"
-#include "collector/Version.h"
+#include "CollectorVersion.h"
 
 static const int MAX_GRPC_CONNECTION_POLLS = 30;
 

--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -38,4 +38,4 @@ HEALTHCHECK	\
 	# the command uses /ready API
 	CMD /usr/local/bin/status-check.sh
 
-ENTRYPOINT collector
+ENTRYPOINT ["collector"]

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -149,7 +149,7 @@ COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
 
 EXPOSE 8080 9090
 
-ENTRYPOINT collector
+ENTRYPOINT ["collector"]
 
 LABEL \
     com.redhat.component="rhacs-collector-container" \

--- a/collector/lib/CollectorVersion.h.in
+++ b/collector/lib/CollectorVersion.h.in
@@ -1,7 +1,7 @@
 #ifndef _COLLECTOR_VERSION_H_
 #define _COLLECTOR_VERSION_H_
 
-#define COLLECTOR_VERSION "@COLLECTOR_VERSION@"
+#define COLLECTOR_VERSION "${COLLECTOR_VERSION}"
 
 inline const char* GetCollectorVersion() {
   return COLLECTOR_VERSION;

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -209,15 +209,18 @@ spec:
         - name: COLLECTOR_CONFIG
           value: |
             '{"tlsConfig":{"caCertPath":"/var/run/secrets/stackrox.io/certs/ca.pem","clientCertPath":"/var/run/secrets/stackrox.io/certs/cert.pem","clientKeyPath":"/var/run/secrets/stackrox.io/certs/key.pem"}}'
-        # This will direct collector to run under GDB
-        - name: COLLECTOR_PRE_ARGUMENTS
-          value: gdbserver 0.0.0.0:1337
-        image: quay.io/stackrox-io/collector:<your-built-tag-here>
-        # Expose the port GDB will be listening on
-        ports:
-        - containerPort: 1337
-          name: gdb
-          protocol: TCP
+      # Use command and args to override the entrypoint to run under GDB
+      command:
+      - gdbserver
+      - 0.0.0.0:1337
+      args:
+      - collector
+      image: quay.io/stackrox-io/collector:<your-built-tag-here>
+      # Expose the port GDB will be listening on
+      ports:
+      - containerPort: 1337
+        name: gdb
+        protocol: TCP
 ```
 
 Once the configuration is applied, the collector pod will restart and wait for a GDB client to connect to it.

--- a/integration-tests/pkg/collector/collector_k8s.go
+++ b/integration-tests/pkg/collector/collector_k8s.go
@@ -45,7 +45,6 @@ func newK8sManager(e executor.K8sExecutor, name string) *K8sCollectorManager {
 	env := []coreV1.EnvVar{
 		{Name: "GRPC_SERVER", Value: "tester-svc:9999"},
 		{Name: "COLLECTION_METHOD", Value: collectionMethod},
-		{Name: "COLLECTOR_PRE_ARGUMENTS", Value: collectorOptions.PreArguments},
 		{Name: "ENABLE_CORE_DUMP", Value: "false"},
 	}
 

--- a/integration-tests/pkg/config/config.go
+++ b/integration-tests/pkg/config/config.go
@@ -146,8 +146,7 @@ func RuntimeInfo() *Runtime {
 func CollectorInfo() *CollectorOptions {
 	if collector_options == nil {
 		collector_options = &CollectorOptions{
-			LogLevel:     ReadEnvVarWithDefault(envCollectorLogLevel, "debug"),
-			PreArguments: ReadEnvVar(envCollectorPreArguments),
+			LogLevel: ReadEnvVarWithDefault(envCollectorLogLevel, "debug"),
 		}
 	}
 	return collector_options

--- a/integration-tests/pkg/config/config.go
+++ b/integration-tests/pkg/config/config.go
@@ -81,8 +81,6 @@ type Runtime struct {
 type CollectorOptions struct {
 	// The collector log level, e.g. DEBUG, TRACE
 	LogLevel string
-	// Any arguments to prepend to the collector command
-	PreArguments string
 }
 
 // Benchmarks contains options related to interacting with the benchmarks

--- a/integration-tests/pkg/config/env.go
+++ b/integration-tests/pkg/config/env.go
@@ -9,8 +9,7 @@ const (
 	envCollectionMethod = "COLLECTION_METHOD"
 	envCollectorImage   = "COLLECTOR_IMAGE"
 
-	envCollectorLogLevel     = "COLLECTOR_LOG_LEVEL"
-	envCollectorPreArguments = "COLLECTOR_PRE_ARGUMENTS"
+	envCollectorLogLevel = "COLLECTOR_LOG_LEVEL"
 
 	envHostType = "REMOTE_HOST_TYPE"
 


### PR DESCRIPTION
## Description

- add back json array format for collector entrypoint
- rename collector version file Version.h to CollectorVersion.h to prevent conflicts with libsinsp/version.h on case-insensitive build envs (aka, local mac argh!)
- auto-detect platform arch
- specify arch in builder image name and cmake-dir
- remove references to `COLLECTOR_PRE_ARGUMENTS`


## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

works locally on mac aarch64
