### PR TITLE
ROX-25723: add ecosystem preflight check

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -505,6 +505,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT
@@ -526,24 +544,6 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
-
-  - name: ecosystem-cert-preflight-checks
-    params:
-    - name: image-url
-      value: $(tasks.build-image-manifest.results.IMAGE_URL)
-    taskRef:
-      params:
-      - name: name
-        value: ecosystem-cert-preflight-checks
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values: ["false"]
 
   - name: clamav-scan
     params:

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -527,6 +527,24 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-manifest.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: clamav-scan
     params:
     - name: image-digest

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -147,6 +147,8 @@ ENV COLLECTOR_HOST_ROOT=/host
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/collector /usr/local/bin/
 COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
 
+COPY LICENSE /licenses/LICENSE
+
 EXPOSE 8080 9090
 
 ENTRYPOINT collector


### PR DESCRIPTION
## Description

Adds ecosystem cert preflight check to Konflux pipeline.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Passing Konflux CI is sufficient.