### PR TITLE
Determine host architecture without using docker

### DIFF
--- a/Makefile-constants.mk
+++ b/Makefile-constants.mk
@@ -6,13 +6,7 @@ ifeq ($(COLLECTOR_TAG),)
 COLLECTOR_TAG=$(shell git describe --tags --abbrev=10 --dirty)
 endif
 
-DOCKER_CLI := $(shell command -v docker 2>/dev/null)
-
-ifeq ($(DOCKER_CLI),)
-$(error "docker is required for building")
-endif
-
-HOST_ARCH := $(shell docker system info --format '{{.Architecture}}')
+HOST_ARCH := $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 PLATFORM ?= "linux/$(HOST_ARCH)"
 
 USE_VALGRIND ?= false


### PR DESCRIPTION
## Description

The removed lines depend on the docker CLI specifically, it does not work when podman is aliased to docker. Instead, we can just use uname -m and replace it with sed, effectively making it work on any linux system.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Konflux build work in CI.
- [ ] Multi arch builds still work.