### PR TITLE
ROX-26047: Switch to prod subscription-manager activation key

### DIFF
--- a/.konflux/scripts/subscription-manager-bro.sh
+++ b/.konflux/scripts/subscription-manager-bro.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}")"  &> /dev/null && pwd)"
 
-SECRET_NAME_IN_KONFLUX="subscription-manager-activation-key"
+SECRET_NAME_IN_KONFLUX="subscription-manager-activation-key-prod"
 # The mount is provided by the buildah task when the ACTIVATION_KEY parameter is set to a valid secret name.
 SECRET_MOUNT_PATH="/activation-key"
 SECRET_KEY="activation-key"

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -236,7 +236,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     taskRef:
       params:
       - name: name
@@ -277,7 +277,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     - name: PLATFORM
       value: linux/s390x
     taskRef:
@@ -321,7 +321,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     - name: PLATFORM
       value: linux/ppc64le
     taskRef:
@@ -365,7 +365,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ACTIVATION_KEY
-      value: subscription-manager-activation-key
+      value: subscription-manager-activation-key-prod
     - name: PLATFORM
       value: linux/arm64
     taskRef:


### PR DESCRIPTION
## Description

See the ticket's description. The key is already set up.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change to automated tests.

## Testing Performed

If things still build in Konflux, all is fine.