### PR TITLE
Pin GHA runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
 
   calculate-baseline:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - benchmarks
     steps:

--- a/.github/workflows/check-drivers-failures.yml
+++ b/.github/workflows/check-drivers-failures.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-failures:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   builder-needs-rebuilding:
     name: Determine if builder image needs to be built
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       build-image: ${{ steps.changed.outputs.builder-changed }}
 
@@ -40,7 +40,7 @@ jobs:
 
   build-builder-image:
     name: Build the builder image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Multiarch builds sometimes take for eeeeeeeeeever
     timeout-minutes: 480
     needs:
@@ -168,7 +168,7 @@ jobs:
     needs:
     - build-builder-image
     name: Create Multiarch manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event_name != 'pull_request' ||
       (needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
@@ -210,7 +210,7 @@ jobs:
     needs:
     - build-builder-image
     name: Retag x86 builder image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event_name == 'pull_request' &&
       needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build-collector-image:
     name: Build Collector
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
 
   build-collector-image-remote-vm:
     name: Build Collector on a remote VM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     strategy:
       fail-fast: false
@@ -165,7 +165,7 @@ jobs:
     - build-collector-image
     - build-collector-image-remote-vm
     name: Create Multiarch manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
@@ -247,7 +247,7 @@ jobs:
     needs:
     - build-collector-image
     name: Retag x86 slim image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')

--- a/.github/workflows/cpaas-sync-drivers.yml
+++ b/.github/workflows/cpaas-sync-drivers.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   sync-drivers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -147,7 +147,7 @@ jobs:
           process_gcloudignore: false
 
   merge-drivers-failures:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: sync-drivers
     steps:
       - name: Merge drivers failures
@@ -157,7 +157,7 @@ jobs:
           pattern: drivers-build-failures-*
 
   update-index:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: sync-drivers
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
           process_gcloudignore: false
 
   copy-to-merged-bucket:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
     - sync-drivers
     steps:

--- a/.github/workflows/cpaas.yml
+++ b/.github/workflows/cpaas.yml
@@ -19,7 +19,7 @@ jobs:
   should-run:
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: should-run
         run: |
@@ -56,7 +56,7 @@ jobs:
         drivers-build-failures
 
   build-collector:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: init
     strategy:
       matrix:
@@ -86,7 +86,7 @@ jobs:
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
   multiarch-manifest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       COLLECTOR_TAG: ${{ needs.init.outputs.collector-tag }}-cpaas
       ARCHS: amd64 ppc64le s390x
@@ -148,7 +148,7 @@ jobs:
     secrets: inherit
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'schedule'
     needs:
     - init

--- a/.github/workflows/gardenlinux-bumper.yml
+++ b/.github/workflows/gardenlinux-bumper.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run-bumper:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
           draft: false
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'schedule'
     needs:
     - run-bumper

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   common-variables:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       collector-tag: ${{ steps.collector-env.outputs.collector-tag }}
       collector-qa-tag: ${{ steps.collector-env.outputs.collector-qa-tag }}

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   should-build-test-image:
     name: Determine if tests image needs to be built
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       build-image: ${{ steps.changed.outputs.tests-changed }}
 
@@ -47,7 +47,7 @@ jobs:
 
   build-test-image:
     name: Build the integration test image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - should-build-test-image
     if: |
@@ -109,7 +109,7 @@ jobs:
             ansible/ci-build-tests.yml
 
   common-variables:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       build-dirs: ${{ steps.variables.outputs.build-dirs }}
 
@@ -133,7 +133,7 @@ jobs:
       - common-variables
 
     if: inputs.rebuild-qa-containers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -43,7 +43,7 @@ on:
 jobs:
   tests:
     name: Testing ${{ inputs.vm_type }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       COLLECTOR_IMAGE: ${{ inputs.collector-repo }}:${{ inputs.collector-tag }}
       COLLECTOR_QA_TAG: ${{ inputs.collector-qa-tag }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -143,7 +143,7 @@ jobs:
     secrets: inherit
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
     needs:
       - amd64-integration-tests

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   k8s-integration-tests:
     name: Run k8s integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
             ${{ github.workspace }}/integration-tests/container-logs/**/*
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
     needs:
       - k8s-integration-tests

--- a/.github/workflows/konflux.yml
+++ b/.github/workflows/konflux.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       collector-tag: ${{ steps.generate-tag.outputs.collector-tag }}
       collector-qa-tag: ${{ steps.generate-tag.outputs.collector-qa-tag }}
@@ -53,7 +53,7 @@ jobs:
           echo "collector-qa-tag=${COLLECTOR_QA_TAG}" >> "$GITHUB_OUTPUT"
 
   wait-for-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
     - init
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     secrets: inherit
 
   memory-checked-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: quay.io/stackrox-io/collector-builder:${{ needs.build-builder-image.outputs.collector-builder-tag }}
     needs:

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -29,7 +29,7 @@ provision-vms:
 
 .PHONY: destroy-vms
 destroy-vms:
-	ansible-playbook -i $(CONTEXT) \
+	ansible-playbook -i $(CONTEXT) -vvvv \
 		--tags teardown \
 		-e job_id="$(JOB_ID)" \
 		vm-lifecycle.yml

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -29,7 +29,7 @@ provision-vms:
 
 .PHONY: destroy-vms
 destroy-vms:
-	ansible-playbook -i $(CONTEXT) -vvvv \
+	ansible-playbook -i $(CONTEXT) \
 		--tags teardown \
 		-e job_id="$(JOB_ID)" \
 		vm-lifecycle.yml


### PR DESCRIPTION
## Description

Having runners configured to `ubuntu-latest` means that the underlying VM could be updated to a newer version without us knowing. This should only be a problem when a new LTS version of Ubuntu is made the default for GHA and shouldn't be a major problem for us, since we mostly use generic tools pre-installed on all runners but, just in case, we should be explicit about what version of runner we want to use.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run as many workflows as possible and checked none of them is broken.
