### PR TITLE
Fix logging of wrong grpc server address

### DIFF
--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
       CLOG(INFO) << "Successfully connected to Sensor.";
     } else {
       startup_diagnostics.Log();
-      CLOG(FATAL) << "Unable to connect to Sensor at '" << args->GRPCServer() << "'.";
+      CLOG(FATAL) << "Unable to connect to Sensor at '" << config.GetGrpcServer().value() << "'.";
     }
     startup_diagnostics.ConnectedToSensor();
   } else {
@@ -171,7 +171,7 @@ int main(int argc, char** argv) {
 
   CollectorService collector(config, &g_control, &g_signum);
 
-  if (!SetupKernelDriver(collector, args->GRPCServer(), config)) {
+  if (!SetupKernelDriver(collector, config)) {
     startup_diagnostics.Log();
     CLOG(FATAL) << "Failed to initialize collector kernel components.";
   }

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -150,7 +150,7 @@ bool CollectorService::WaitForGRPCServer() {
   return WaitForChannelReady(config_.grpc_channel, interrupt);
 }
 
-bool SetupKernelDriver(CollectorService& collector, const std::string& GRPCServer, const CollectorConfig& config) {
+bool SetupKernelDriver(CollectorService& collector, const CollectorConfig& config) {
   auto& startup_diagnostics = StartupDiagnostics::GetInstance();
   std::string cm_name(CollectionMethodName(config.GetCollectionMethod()));
 

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -26,7 +26,7 @@ class CollectorService {
   system_inspector::Service system_inspector_;
 };
 
-bool SetupKernelDriver(CollectorService& collector, const std::string& GRPCServer, const CollectorConfig& config);
+bool SetupKernelDriver(CollectorService& collector, const CollectorConfig& config);
 
 }  // namespace collector
 


### PR DESCRIPTION

## Description

After the changes made by #1817, the args variable in the main function should only be used to initialize the CollectorConfig object which is the source or truth for all configuration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
