### PR TITLE
ROX-26025: Sanitize UTF-8 strings in process signals

### DIFF
--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -42,7 +42,8 @@ std::string extract_proc_args(sinsp_threadinfo* tinfo) {
   }
   std::ostringstream args;
   for (auto it = tinfo->m_args.begin(); it != tinfo->m_args.end();) {
-    args << *it++;
+    Holder<const std::string> arg = SanitizeUTF8(*it++);
+    args << *arg;
     if (it != tinfo->m_args.end()) {
       args << " ";
     }
@@ -111,26 +112,34 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_evt* event) {
   // set id
   signal->set_id(UUIDStr());
 
-  const std::string* name = event_extractor_->get_comm(event);
-  const std::string* exepath = event_extractor_->get_exepath(event);
+  Holder<const std::string> name;
+  Holder<const std::string> exepath;
 
-  // set name (if name is missing or empty, try to use exec_file_path)
-  if (name && !name->empty() && *name != "<NA>") {
+  if (const std::string* nameptr = event_extractor_->get_comm(event)) {
+    name = SanitizeUTF8(*nameptr);
+  }
+  if (const std::string* exepathptr = event_extractor_->get_exepath(event)) {
+    exepath = SanitizeUTF8(*exepathptr);
+  }
+
+  // set name (if name is empty, try to use exec_file_path)
+  if (!(*name).empty() && *name != "<NA>") {
     signal->set_name(*name);
-  } else if (exepath && !exepath->empty() && *exepath != "<NA>") {
+  } else if (!(*exepath).empty() && *exepath != "<NA>") {
     signal->set_name(*exepath);
   }
 
-  // set exec_file_path (if exec_file_path is missing or empty, try to use name)
-  if (exepath && !exepath->empty() && *exepath != "<NA>") {
+  // set exec_file_path (if exec_file_path is empty, try to use name)
+  if (!(*exepath).empty() && *exepath != "<NA>") {
     signal->set_exec_file_path(*exepath);
-  } else if (name && !name->empty() && *name != "<NA>") {
+  } else if (!(*name).empty() && *name != "<NA>") {
     signal->set_exec_file_path(*name);
   }
 
   // set process arguments
   if (const char* args = event_extractor_->get_proc_args(event)) {
-    signal->set_args(args);
+    std::string args_str(args);
+    signal->set_args(*SanitizeUTF8(args_str));
   }
 
   // set pid
@@ -161,7 +170,8 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_evt* event) {
   this->GetProcessLineage(event->get_thread_info(), lineage);
   for (const auto& p : lineage) {
     auto signal_lineage = signal->add_lineage_info();
-    signal_lineage->set_parent_exec_file_path(p.parent_exec_file_path());
+    auto parent_exec_file_path = SanitizeUTF8(p.parent_exec_file_path());
+    signal_lineage->set_parent_exec_file_path(*parent_exec_file_path);
     signal_lineage->set_parent_uid(p.parent_uid());
   }
 
@@ -179,21 +189,21 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_threadinfo* tin
   // set id
   signal->set_id(UUIDStr());
 
-  const auto& name = tinfo->m_comm;
-  const auto& exepath = tinfo->m_exepath;
+  Holder<const std::string> name = SanitizeUTF8(tinfo->m_comm);
+  Holder<const std::string> exepath = SanitizeUTF8(tinfo->m_exepath);
 
   // set name (if name is missing or empty, try to use exec_file_path)
-  if (!name.empty() && name != "<NA>") {
-    signal->set_name(name);
-  } else if (!exepath.empty() && exepath != "<NA>") {
-    signal->set_name(exepath);
+  if (!(*name).empty() && *name != "<NA>") {
+    signal->set_name(*name);
+  } else if (!(*exepath).empty() && *exepath != "<NA>") {
+    signal->set_name(*exepath);
   }
 
   // set exec_file_path (if exec_file_path is missing or empty, try to use name)
-  if (!exepath.empty() && exepath != "<NA>") {
-    signal->set_exec_file_path(exepath);
-  } else if (!name.empty() && name != "<NA>") {
-    signal->set_exec_file_path(name);
+  if (!(*exepath).empty() && *exepath != "<NA>") {
+    signal->set_exec_file_path(*exepath);
+  } else if (!(*name).empty() && *name != "<NA>") {
+    signal->set_exec_file_path(*name);
   }
 
   // set the process as coming from a scrape as opposed to an exec

--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -139,7 +139,8 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_evt* event) {
   // set process arguments
   if (const char* args = event_extractor_->get_proc_args(event)) {
     std::string args_str(args);
-    signal->set_args(*SanitizeUTF8(args_str));
+    auto sanitized_args = SanitizeUTF8(args_str);
+    signal->set_args(*sanitized_args);
   }
 
   // set pid

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -20,6 +20,8 @@ extern "C" {
 
 #include <libsinsp/sinsp.h>
 
+#include <google/protobuf/stubs/common.h>
+
 #include "HostInfo.h"
 #include "Logging.h"
 #include "Utility.h"
@@ -230,4 +232,18 @@ std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cg
   }
   return std::make_optional(container_id_part.substr(0, SHORT_CONTAINER_ID_LENGTH));
 }
+
+Holder<const std::string> SanitizeUTF8(const std::string& str) {
+  std::unique_ptr<char[]> work_buffer(new char[str.size()]);
+  char* sanitized;
+
+  sanitized = google::protobuf::internal::UTF8CoerceToStructurallyValid(str, work_buffer.get(), '?');
+
+  // we do this to avoid copying if unnecessary
+  if (sanitized == work_buffer.get()) {
+    return Holder<const std::string>::copy(sanitized);
+  }
+  return Holder<const std::string>(&str);
+}
+
 }  // namespace collector

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -242,7 +242,7 @@ std::optional<std::string> SanitizedUTF8(const std::string& str) {
   if (sanitized != work_buffer.get()) {
     return std::nullopt;
   }
-  return sanitized;
+  return std::string(sanitized, str.size());
 }
 
 }  // namespace collector

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -20,6 +20,8 @@ extern "C" {
 
 #include <libsinsp/sinsp.h>
 
+#include <google/protobuf/stubs/common.h>
+
 #include "HostInfo.h"
 #include "Logging.h"
 #include "Utility.h"
@@ -230,4 +232,17 @@ std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cg
   }
   return std::make_optional(container_id_part.substr(0, SHORT_CONTAINER_ID_LENGTH));
 }
+
+std::optional<std::string> SanitizedUTF8(const std::string& str) {
+  std::unique_ptr<char[]> work_buffer(new char[str.size()]);
+  char* sanitized;
+
+  sanitized = google::protobuf::internal::UTF8CoerceToStructurallyValid(str, work_buffer.get(), '?');
+
+  if (sanitized != work_buffer.get()) {
+    return std::nullopt;
+  }
+  return sanitized;
+}
+
 }  // namespace collector

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -20,8 +20,6 @@ extern "C" {
 
 #include <libsinsp/sinsp.h>
 
-#include <google/protobuf/stubs/common.h>
-
 #include "HostInfo.h"
 #include "Logging.h"
 #include "Utility.h"
@@ -232,18 +230,4 @@ std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cg
   }
   return std::make_optional(container_id_part.substr(0, SHORT_CONTAINER_ID_LENGTH));
 }
-
-Holder<const std::string> SanitizeUTF8(const std::string& str) {
-  std::unique_ptr<char[]> work_buffer(new char[str.size()]);
-  char* sanitized;
-
-  sanitized = google::protobuf::internal::UTF8CoerceToStructurallyValid(str, work_buffer.get(), '?');
-
-  // we do this to avoid copying if unnecessary
-  if (sanitized == work_buffer.get()) {
-    return Holder<const std::string>::copy(sanitized);
-  }
-  return Holder<const std::string>(&str);
-}
-
 }  // namespace collector

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -108,6 +108,12 @@ ScopedLock<Mutex> Lock(Mutex& mutex) {
 #define ssizeof(x) static_cast<ssize_t>(sizeof(x))
 
 std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cgroup);
-}  // namespace collector
 
+// Replace any occurrence of an invalid UTF-8 sequence with the '?' character
+// Returns :
+//  - a new string with invalid characters replaced.
+//  - nullopt if there is no invalid character (the input string is valid).
+std::optional<std::string> SanitizedUTF8(const std::string& str);
+
+}  // namespace collector
 #endif  // _UTILITY_H_

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -108,6 +108,36 @@ ScopedLock<Mutex> Lock(Mutex& mutex) {
 #define ssizeof(x) static_cast<ssize_t>(sizeof(x))
 
 std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cgroup);
+
+// A Holder refers to an object that it can own, or not.
+template <class T>
+class Holder {
+ public:
+  // Make a copy of the provided object.
+  // The copy will be destroyed when this Holder is destroyed.
+  static Holder<T> copy(T& v) {
+    Holder h = Holder();
+    h.m_owned.emplace(v);
+    return h;
+  }
+
+  // Make an external reference to the provided object.
+  // This Holder does not own this object.
+  Holder(T* external) : m_external(external) {}
+
+  T& operator*() {
+    return m_owned ? *m_owned : *m_external;
+  }
+
+  Holder() : m_external(0), m_owned(T()) {}
+
+ private:
+  T* m_external;
+  std::optional<std::remove_const_t<T>> m_owned;
+};
+
+Holder<const std::string> SanitizeUTF8(const std::string& str);
+
 }  // namespace collector
 
 #endif  // _UTILITY_H_

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -108,36 +108,6 @@ ScopedLock<Mutex> Lock(Mutex& mutex) {
 #define ssizeof(x) static_cast<ssize_t>(sizeof(x))
 
 std::optional<std::string_view> ExtractContainerIDFromCgroup(std::string_view cgroup);
-
-// A Holder refers to an object that it can own, or not.
-template <class T>
-class Holder {
- public:
-  // Make a copy of the provided object.
-  // The copy will be destroyed when this Holder is destroyed.
-  static Holder<T> copy(T& v) {
-    Holder h = Holder();
-    h.m_owned.emplace(v);
-    return h;
-  }
-
-  // Make an external reference to the provided object.
-  // This Holder does not own this object.
-  Holder(T* external) : m_external(external) {}
-
-  T& operator*() {
-    return m_owned ? *m_owned : *m_external;
-  }
-
-  Holder() : m_external(0), m_owned(T()) {}
-
- private:
-  T* m_external;
-  std::optional<std::remove_const_t<T>> m_owned;
-};
-
-Holder<const std::string> SanitizeUTF8(const std::string& str);
-
 }  // namespace collector
 
 #endif  // _UTILITY_H_

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -124,6 +124,7 @@ TEST(SanitizeUTF8Test, TestSanitizeUTF8_Invalid) {
 
   auto output = SanitizedUTF8(input);
 
+  EXPECT_TRUE(output.has_value());
   EXPECT_EQ(*output, expected_output);
 }
 

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -115,4 +115,25 @@ TEST(ExtractContainerIDFromCgroupTest, TestExtractContainerIDFromCgroup) {
     EXPECT_EQ(short_container_id, c.expected_output);
   }
 }
+
+TEST(SanitizeUTF8Test, TestSanitizeUTF8_Invalid) {
+  std::string input(
+      "ab\x80"
+      "cd");
+  std::string expected_output("ab?cd");
+
+  auto output = SanitizedUTF8(input);
+
+  EXPECT_EQ(*output, expected_output);
+}
+
+TEST(SanitizeUTF8Test, TestSanitizeUTF8_Valid) {
+  std::string input("abcd");
+  std::string expected_output("abcd");
+
+  auto output = SanitizedUTF8(input);
+
+  EXPECT_FALSE(output);
+}
+
 }  // namespace collector

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -115,25 +115,4 @@ TEST(ExtractContainerIDFromCgroupTest, TestExtractContainerIDFromCgroup) {
     EXPECT_EQ(short_container_id, c.expected_output);
   }
 }
-
-TEST(SanitizeUTF8Test, TestSanitizeUTF8_Invalid) {
-  std::string input("ab\x80" "cd");
-  std::string expected_output("ab?cd");
-
-  auto output = SanitizeUTF8(input);
-
-  EXPECT_EQ(*output, expected_output);
-}
-
-TEST(SanitizeUTF8Test, TestSanitizeUTF8_Valid) {
-  std::string input("abcd");
-  std::string expected_output("abcd");
-
-  auto output = SanitizeUTF8(input);
-
-  EXPECT_EQ(*output, expected_output);
-  // no-copy check
-  EXPECT_EQ(&(*output), &input);
-}
-
 }  // namespace collector

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -115,4 +115,25 @@ TEST(ExtractContainerIDFromCgroupTest, TestExtractContainerIDFromCgroup) {
     EXPECT_EQ(short_container_id, c.expected_output);
   }
 }
+
+TEST(SanitizeUTF8Test, TestSanitizeUTF8_Invalid) {
+  std::string input("ab\x80" "cd");
+  std::string expected_output("ab?cd");
+
+  auto output = SanitizeUTF8(input);
+
+  EXPECT_EQ(*output, expected_output);
+}
+
+TEST(SanitizeUTF8Test, TestSanitizeUTF8_Valid) {
+  std::string input("abcd");
+  std::string expected_output("abcd");
+
+  auto output = SanitizeUTF8(input);
+
+  EXPECT_EQ(*output, expected_output);
+  // no-copy check
+  EXPECT_EQ(&(*output), &input);
+}
+
 }  // namespace collector

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -129,7 +129,6 @@ TEST(SanitizeUTF8Test, TestSanitizeUTF8_Invalid) {
 
 TEST(SanitizeUTF8Test, TestSanitizeUTF8_Valid) {
   std::string input("abcd");
-  std::string expected_output("abcd");
 
   auto output = SanitizedUTF8(input);
 


### PR DESCRIPTION
## Description

Containers can produce non-UTF8 process names or paths. We want to prevent this from causing issues in protobuf, which doesn't like it at all.

As a quick workaround, we reuse `google::protobuf::internal::UTF8CoerceToStructurallyValid` to replace any invalid sequence with '?'.

In order to minimize string copies in the "no modifications required" case, we introduce a Holder<> class to either point to the original unmodified string, or to an altered copy of it.

## Checklist
- [ ] Investigated and inspected CI test results
