### PR TITLE
Remove unneeded packages from final collector image

### DIFF
--- a/collector/container/devel/install.sh
+++ b/collector/container/devel/install.sh
@@ -2,4 +2,4 @@
 set -eo pipefail
 
 dnf upgrade -y
-dnf install -y kmod libasan elfutils-libelf
+dnf install -y libasan elfutils-libelf

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -106,14 +106,13 @@ COPY ./.konflux /tmp/.konflux
 RUN /tmp/.konflux/scripts/subscription-manager-bro.sh register /mnt && \
     dnf -y --installroot=/mnt upgrade --nobest && \
     dnf -y --installroot=/mnt install --nobest \
-      kmod \
       tbb \
       jq \
       c-ares && \
     /tmp/.konflux/scripts/subscription-manager-bro.sh cleanup && \
     # We can do usual cleanup while we're here: remove packages that would trigger violations. \
     dnf -y --installroot=/mnt clean all && \
-    rpm --root=/mnt --verbose -e --nodeps $(rpm --root=/mnt -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --root=/mnt --verbose -e --nodeps $(rpm --root=/mnt -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*') && \
     rm -rf /mnt/var/cache/dnf /mnt/var/cache/yum
 
 

--- a/collector/container/rhel/install.sh
+++ b/collector/container/rhel/install.sh
@@ -3,8 +3,11 @@ set -eo pipefail
 
 # UBI 9 requires confirmation with -y flag.
 microdnf upgrade -y --nobest
-microdnf install -y kmod findutils elfutils-libelf
+microdnf install -y elfutils-libelf
 
 microdnf clean all
-rpm --query --all 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'findutils' | xargs -t rpm -e --nodeps
+# shellcheck disable=SC2046
+rpm --verbose -e --nodeps $(
+    rpm -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*'
+)
 rm -rf /var/cache/yum


### PR DESCRIPTION
## Description

Reasoning for removing each package:
- kmod has not been needed since we stopped supporting kernel modules
- libyaml and libarchive have vulnerabilities, are unused by the the collector binary and show no other package depend on them when querying with rpm.
- Replaced `xargs rpm -e` with the method used in konflux.Dockerfile, so findutils is no longer needed either.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run tests in the main repo, ensuring collector still works properly in real operation environments.
