### PR TITLE
ROX-26344: adds runtime configuration to collector

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -47,7 +47,7 @@ BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
 
-BoolEnvVar enable_external_ips("ROX_ENABLE_EXTERNAL_IPS", false);
+BoolEnvVar enable_external_ips("ROX_EXTERNAL_IPS", false);
 
 BoolEnvVar enable_connection_stats("ROX_COLLECTOR_ENABLE_CONNECTION_STATS", true);
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -47,7 +47,7 @@ BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
 
-BoolEnvVar enable_external_ips("ROX_EXTERNAL_IPS", false);
+BoolEnvVar enable_external_ips("ROX_ENABLE_EXTERNAL_IPS", false);
 
 BoolEnvVar enable_connection_stats("ROX_COLLECTOR_ENABLE_CONNECTION_STATS", true);
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -84,8 +84,8 @@ class CollectorConfig {
   // otherwise, we rely on the feature flag (env var)
   bool EnableExternalIPs() const {
     if (runtime_config_.has_value()) {
-      auto cfg = runtime_config_.value();
-      auto network_cfg = cfg.network_connection_config();
+      const auto& cfg = runtime_config_.value();
+      const auto& network_cfg = cfg.network_connection_config();
       return network_cfg.enable_external_ips();
     }
     return enable_external_ips_;
@@ -112,7 +112,7 @@ class CollectorConfig {
     runtime_config_ = std::move(runtime_config);
   }
 
-  std::optional<sensor::CollectorConfig> GetRuntimeConfig() const {
+  const std::optional<sensor::CollectorConfig>& GetRuntimeConfig() const {
     return runtime_config_;
   }
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -1,12 +1,15 @@
 #ifndef _COLLECTOR_CONFIG_H_
 #define _COLLECTOR_CONFIG_H_
 
+#include <optional>
 #include <ostream>
 #include <vector>
 
 #include <json/json.h>
 
 #include <grpcpp/channel.h>
+
+#include <internalapi/sensor/collector.pb.h>
 
 #include "CollectionMethod.h"
 #include "HostConfig.h"
@@ -75,7 +78,19 @@ class CollectorConfig {
   bool IsProcessesListeningOnPortsEnabled() const { return enable_processes_listening_on_ports_; }
   bool ImportUsers() const { return import_users_; }
   bool CollectConnectionStatus() const { return collect_connection_status_; }
-  bool EnableExternalIPs() const { return enable_external_ips_; }
+
+  // EnableExternalIPs will check for the existence
+  // of a runtime configuration, and defer to that value
+  // otherwise, we rely on the feature flag (env var)
+  bool EnableExternalIPs() const {
+    if (runtime_config_.has_value()) {
+      auto cfg = runtime_config_.value();
+      auto network_cfg = cfg.network_connection_config();
+      return network_cfg.enable_external_ips();
+    }
+    return enable_external_ips_;
+  }
+
   bool EnableConnectionStats() const { return enable_connection_stats_; }
   bool EnableDetailedMetrics() const { return enable_detailed_metrics_; }
   bool EnableRuntimeConfig() const { return enable_runtime_config_; }
@@ -92,6 +107,14 @@ class CollectorConfig {
   unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
 
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
+
+  void SetRuntimeConfig(sensor::CollectorConfig runtime_config) {
+    runtime_config_ = std::move(runtime_config);
+  }
+
+  std::optional<sensor::CollectorConfig> GetRuntimeConfig() const {
+    return runtime_config_;
+  }
 
   std::shared_ptr<grpc::Channel> grpc_channel;
 
@@ -146,6 +169,8 @@ class CollectorConfig {
 
   std::optional<TlsConfig> tls_config_;
 
+  std::optional<sensor::CollectorConfig> runtime_config_;
+
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
@@ -155,6 +180,10 @@ class CollectorConfig {
   void SetSinspTotalBufferSize(unsigned int total_buffer_size);
   void SetSinspCpuPerBuffer(unsigned int buffer_size);
   void SetHostConfig(HostConfig* config);
+
+  void SetEnableExternalIPs(bool value) {
+    enable_external_ips_ = value;
+  }
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -108,6 +108,10 @@ class CollectorConfig {
 
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
+  void SetRuntimeConfig(sensor::CollectorConfig&& runtime_config) {
+    runtime_config_ = runtime_config;
+  }
+
   void SetRuntimeConfig(sensor::CollectorConfig runtime_config) {
     runtime_config_ = std::move(runtime_config);
   }


### PR DESCRIPTION
## Description

Includes support for enabling/disabling external IPs based on runtime config, deferring to existing feature flag if none is provided

In subsequent PRs, the runtime configuration will be populated. 

## Checklist
- [x] Investigated and inspected CI test results
~- [x] Updated documentation accordingly~

**Automated testing**
  - [x] Added unit tests
  ~- [ ] Added integration tests~
  ~- [ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests added to exercise the intended behaviour. It is not possible to integration-test this until Sensor->Collector communication has been built.
