### PR TITLE
Refactor RunSingle and RunSingleAfterglow into a single method

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -285,7 +285,7 @@ void CollectorConfig::HandleAfterglowEnvVars() {
   afterglow_period_micros_ = static_cast<uint64_t>(afterglow_period.value() * SECOND);
 
   if (afterglow_period_micros_ < 0) {
-    CLOG(ERROR) << "Invalid afterglow period " << afterglow_period_micros_ / 1000000 << ". ROX_AFTERGLOW_PERIOD must be positive.";
+    CLOG(ERROR) << "Invalid afterglow period " << afterglow_period_micros_ / SECOND << ". ROX_AFTERGLOW_PERIOD must be positive.";
   } else if (afterglow_period_micros_ == 0) {
     CLOG(ERROR) << "Afterglow period set to 0.";
   } else {
@@ -299,11 +299,7 @@ void CollectorConfig::HandleAfterglowEnvVars() {
     enable_afterglow_ = enable_afterglow.value();
   }
 
-  if (enable_afterglow_) {
-    CLOG(INFO) << "Afterglow is enabled";
-  } else {
-    CLOG(INFO) << "Afterglow is disabled";
-  }
+  CLOG(INFO) << "Afterglow is " << (enable_afterglow_ ? "enabled" : "disabled");
 }
 
 void CollectorConfig::HandleConnectionStatsEnvVars() {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -109,8 +109,8 @@ class CollectorConfig {
   std::vector<IPNet> non_aggregated_networks_;
 
   HostConfig host_config_;
-  int64_t afterglow_period_micros_ = 300000000;  // 5 minutes in microseconds
-  bool enable_afterglow_ = true;
+  int64_t afterglow_period_micros_ = 300'000'000;  // 5 minutes in microseconds
+  bool enable_afterglow_ = false;
   bool enable_core_dump_ = false;
   bool enable_processes_listening_on_ports_;
   bool import_users_;

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -110,6 +110,13 @@ struct ParsePath {
     return true;
   }
 };
+
+struct ParseFloat {
+  bool operator()(float* out, const std::string& str_val) {
+    *out = std::stof(str_val);
+    return true;
+  }
+};
 }  // namespace internal
 
 using BoolEnvVar = EnvVar<bool, internal::ParseBool>;
@@ -117,6 +124,7 @@ using StringListEnvVar = EnvVar<std::vector<std::string>, internal::ParseStringL
 using StringEnvVar = EnvVar<std::string, internal::ParseString>;
 using IntEnvVar = EnvVar<int, internal::ParseInt>;
 using PathEnvVar = EnvVar<std::filesystem::path, internal::ParsePath>;
+using FloatEnvVar = EnvVar<float, internal::ParseFloat>;
 
 }  // namespace collector
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -52,7 +52,6 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   void WaitUntilWriterStarted(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer, int wait_time);
   bool UpdateAllConnsAndEndpoints();
   void RunSingle(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
-  void RunSingleAfterglow(IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>* writer);
   void ReceivePublicIPs(const sensor::IPAddressList& public_ips);
   void ReceiveIPNetworks(const sensor::IPNetworkList& networks);
 

--- a/integration-tests/container/schedule-curls/schedule-curls.sh
+++ b/integration-tests/container/schedule-curls/schedule-curls.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -ex
+
 num_meta_iter=$1
 num_iter=$2
 sleep_between_curl_time=$3


### PR DESCRIPTION
## Description

Original motivation for this PR was to narrow down a flake we've been having with some of the afterglow tests. However, in order to make it easy to add the log messages, the RunSingle and RunSingleAfterglow methods have been unified, since their difference was minimal.

Unrelated to this, the HandleAfterglowEnvVars method has been slightly rewritten to make its workflow more streamlined and easier to follow.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.