### PR TITLE
Backport cos and rhel-sap verifier issues

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -90,8 +90,7 @@ virtual_machines:
     families:
       - cos-stable
       - cos-beta
-      # ROX-24938: disabled until the verifier issue is fixed.
-      # - cos-dev
+      - cos-dev
 
   sles:
     project: suse-cloud


### PR DESCRIPTION
## Description

cos-beta started to fail on 3.19/4.5, and this was patched on master.

Also re-enable cos-dev in the meantime.