### PR TITLE
Capture logs for all containers used in tests

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -127,6 +127,6 @@ jobs:
         with:
           name: ${{ inputs.vm_type }}-logs
           path: |
-            ${{ github.workspace }}/integration-tests/container-logs/
-            ${{ github.workspace }}/integration-tests/performance-logs/
+            ${{ github.workspace }}/integration-tests/container-logs/**/**
+            ${{ github.workspace }}/integration-tests/performance-logs/**/**
           if-no-files-found: ignore

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -127,5 +127,5 @@ jobs:
         with:
           name: ${{ inputs.vm_type }}-logs
           path: |
-            ${{ github.workspace }}/integration-tests/container-logs/**/*
-            ${{ github.workspace }}/integration-tests/performance-logs/**/*
+            ${{ github.workspace }}/integration-tests/container-logs/**/**
+            ${{ github.workspace }}/integration-tests/performance-logs/**/**

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -127,6 +127,6 @@ jobs:
         with:
           name: ${{ inputs.vm_type }}-logs
           path: |
-            ${{ github.workspace }}/integration-tests/container-logs/**/**
-            ${{ github.workspace }}/integration-tests/performance-logs/**/**
+            ${{ github.workspace }}/integration-tests/container-logs/
+            ${{ github.workspace }}/integration-tests/performance-logs/
           if-no-files-found: ignore

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -127,5 +127,6 @@ jobs:
         with:
           name: ${{ inputs.vm_type }}-logs
           path: |
-            ${{ github.workspace }}/integration-tests/container-logs/**/**
-            ${{ github.workspace }}/integration-tests/performance-logs/**/**
+            ${{ github.workspace }}/integration-tests/container-logs/
+            ${{ github.workspace }}/integration-tests/performance-logs/
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ teardown-builder:
 clean:
 	rm -rf cmake-build*
 	make -C collector clean
-	make -C integration-tests docker-clean
+	make -C integration-tests clean
 
 .PHONY: shfmt-check
 shfmt-check:

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -125,6 +125,7 @@
     - name: Get log files
       find:
         paths: "{{ remote_log_mount }}/{{ vm_config }}/{{ collection_method }}/"
+        recurse: true
       register: remote_log_files
 
     - name: Fetch log files

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -8,7 +8,7 @@
 #
 
 - set_fact:
-    logs_root: "{{ collector_root }}/integration-tests/container-logs/{{ vm_config }}/{{ collection_method }}"
+    logs_root: "{{ collector_root }}/integration-tests/container-logs"
 
 - name: Cleanup old containers
   become: "{{ runtime_as_root }}"
@@ -122,20 +122,16 @@
         path: "{{ logs_root }}"
       delegate_to: localhost
 
-    - name: Get log files
-      find:
-        paths: "{{ remote_log_mount }}/{{ vm_config }}/{{ collection_method }}/"
-        recurse: true
-      register: remote_log_files
+    - name: Compress log files
+      ansible.builtin.archive:
+        path: "{{ remote_log_mount }}"
+        dest: /tmp/{{ vm_config }}-{{ collection_method }}.tar.gz
 
     - name: Fetch log files
       fetch:
-        src: "{{ remote_log_path }}"
+        src: /tmp/{{ vm_config }}-{{ collection_method }}.tar.gz
         dest: "{{ logs_root }}/"
         flat: true
-      loop: "{{ remote_log_files.files | map(attribute='path') | list }}"
-      loop_control:
-        loop_var: remote_log_path
 
     - name: Write integration test log
       copy:

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -95,6 +95,10 @@ ci-benchmarks: benchmark
 docker-clean:
 	docker rm -fv container-stats benchmark collector grpc-server 2>/dev/null || true
 
+.PHONY: clean
+clean: docker-clean
+	rm -rf container-logs/
+
 .PHONY:
 benchmark: TestBenchmarkCollector
 

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stackrox/collector/integration-tests/pkg/executor"
-	"github.com/stackrox/collector/integration-tests/pkg/log"
 )
 
 type DockerCollectorManager struct {
@@ -156,19 +155,7 @@ func (c *DockerCollectorManager) launchCollector() error {
 }
 
 func (c *DockerCollectorManager) captureLogs(containerName string) (string, error) {
-	logs, err := c.executor.GetContainerLogs(containerName)
-	if err != nil {
-		return "", log.Error("logs error (%v) for container %s\n", err, containerName)
-	}
-
-	logFile, err := common.PrepareLog(c.testName, "collector.log")
-	if err != nil {
-		return "", err
-	}
-	defer logFile.Close()
-
-	_, err = logFile.WriteString(logs)
-	return logs, nil
+	return c.executor.CaptureLogs(c.testName, containerName)
 }
 
 func (c *DockerCollectorManager) killContainer(name string) error {

--- a/integration-tests/pkg/common/utils.go
+++ b/integration-tests/pkg/common/utils.go
@@ -62,7 +62,7 @@ func PrepareLog(testName string, logName string) (*os.File, error) {
 		".", "container-logs",
 		config.VMInfo().Config,
 		config.CollectionMethod(),
-		strings.ReplaceAll(testName, "/", "_"),
+		testName,
 	}
 
 	logDirectory := filepath.Join(pathSections...)

--- a/integration-tests/pkg/common/utils.go
+++ b/integration-tests/pkg/common/utils.go
@@ -58,13 +58,20 @@ func ArchSupported(supported ...string) (bool, string) {
 
 // Creates a new file to dump logs into
 func PrepareLog(testName string, logName string) (*os.File, error) {
-	logDirectory := filepath.Join(".", "container-logs", config.VMInfo().Config, config.CollectionMethod())
+	pathSections := []string{
+		".", "container-logs",
+		config.VMInfo().Config,
+		config.CollectionMethod(),
+		strings.ReplaceAll(testName, "/", "_"),
+	}
+
+	logDirectory := filepath.Join(pathSections...)
 	err := os.MkdirAll(logDirectory, os.ModePerm)
 	if err != nil {
 		return nil, err
 	}
 
-	logPath := filepath.Join(logDirectory, strings.ReplaceAll(testName, "/", "_")+"-"+logName)
+	logPath := filepath.Join(logDirectory, logName)
 	return os.Create(logPath)
 }
 

--- a/integration-tests/pkg/executor/executor.go
+++ b/integration-tests/pkg/executor/executor.go
@@ -16,6 +16,10 @@ type ContainerLogs struct {
 	Stderr string
 }
 
+func (c *ContainerLogs) Empty() bool {
+	return *c == (ContainerLogs{})
+}
+
 // Will return Stderr if it is not empty, otherwise it returns Stdout.
 // Useful for accessing the logs for collector and container-stats
 // that use a single stream.

--- a/integration-tests/pkg/executor/executor.go
+++ b/integration-tests/pkg/executor/executor.go
@@ -11,6 +11,21 @@ type ContainerFilter struct {
 	Namespace string
 }
 
+type ContainerLogs struct {
+	Stdout string
+	Stderr string
+}
+
+// Will return Stderr if it is not empty, otherwise it returns Stdout.
+// Useful for accessing the logs for collector and container-stats
+// that use a single stream.
+func (l *ContainerLogs) GetSingleLog() string {
+	if l.Stderr != "" {
+		return l.Stderr
+	}
+	return l.Stdout
+}
+
 type Executor interface {
 	PullImage(image string) error
 	IsContainerRunning(container string) (bool, error)
@@ -23,7 +38,8 @@ type Executor interface {
 	StartContainer(config config.ContainerStartConfig) (string, error)
 	GetContainerHealthCheck(containerID string) (string, error)
 	GetContainerIP(containerID string) (string, error)
-	GetContainerLogs(containerID string) (string, error)
+	GetContainerLogs(containerID string) (ContainerLogs, error)
+	CaptureLogs(testName, containerName string) (string, error)
 	GetContainerPort(containerID string) (string, error)
 	IsContainerFoundFiltered(containerID, filter string) (bool, error)
 }

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -17,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
-	"github.com/stackrox/collector/integration-tests/pkg/config"
+	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/types"
 )
 
@@ -223,10 +222,7 @@ func (m *MockSensor) HasEndpoint(containerID string, endpoint types.EndpointInfo
 func (m *MockSensor) Start() {
 	var err error
 
-	m.logFile, err = os.OpenFile(
-		filepath.Join(config.LogPath(), strings.ReplaceAll(m.testName, "/", "_")+"-events.log"),
-		os.O_CREATE|os.O_WRONLY, 0644,
-	)
+	m.logFile, err = common.PrepareLog(m.testName, "events.log")
 
 	if err != nil {
 		log.Fatalf("failed to open log file: %v", err)

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -406,7 +406,7 @@ func (s *IntegrationTestSuiteBase) cleanupContainers(containers ...string) {
 		exists, _ := s.Executor().ContainerExists(executor.ContainerFilter{Name: container})
 		if exists {
 			s.Executor().KillContainer(container)
-			s.Executor().CaptureLogs(s.collector.TestName(), container)
+			s.Executor().CaptureLogs(s.T().Name(), container)
 			s.Executor().RemoveContainer(executor.ContainerFilter{Name: container})
 		}
 	}

--- a/integration-tests/suites/perf_event_open.go
+++ b/integration-tests/suites/perf_event_open.go
@@ -42,13 +42,13 @@ func (s *PerfEventOpenTestSuite) TestReadingTracepoints() {
 	if finished, _ := s.waitForContainerToExit("perf-event-open", containerID, 5*time.Second, 0); finished {
 		logs, err := s.containerLogs("perf-event-open")
 		if err != nil {
-			log.Info(logs)
+			log.Info(logs.GetSingleLog())
 			assert.FailNow(s.T(), "Failed to initialize host for performance testing")
 		}
 
-		count, err := strconv.Atoi(strings.TrimSpace(logs))
+		count, err := strconv.Atoi(strings.TrimSpace(logs.GetSingleLog()))
 		if err != nil {
-			log.Info(logs)
+			log.Info(logs.GetSingleLog())
 			assert.FailNow(s.T(), "Cannot convert result to the integer type")
 		}
 


### PR DESCRIPTION
## Description

Some flakes we have in CI may be due to errors on the auxiliar containers we run alongside collector. In order to make it easier to debug this type of flakes, container logs could be used to get more information on what is going on.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.

- [x] Check log artifacts don't become huge