### PR TITLE
Add Ubuntu 24.04 to the VMs used during testing

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -113,6 +113,7 @@ virtual_machines:
     families:
       - ubuntu-2004-lts
       - ubuntu-2204-lts
+      - ubuntu-2404-lts-amd64
 
   ubuntu-arm:
     project: ubuntu-os-cloud
@@ -121,6 +122,7 @@ virtual_machines:
     families:
       - ubuntu-2004-lts-arm64
       - ubuntu-2204-lts-arm64
+      - ubuntu-2404-lts-arm64
 
   ubuntu-os-pro:
     project: ubuntu-os-pro-cloud


### PR DESCRIPTION
## Description

Simply adding Ubuntu 24.04 to the list of VMs used in our integration tests.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run multiarch builds.