### PR TITLE
Unarchive log files before uploading artifacts

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -122,6 +122,7 @@ jobs:
           make -C "${{ github.workspace }}/ansible" destroy-vms
 
       - name: Unarchive logs
+        if: always()
         run: |
           cd ${{ github.workspace }}/integration-tests/
           for file in container-logs/*.tar.gz; do

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/integration-tests/
           for file in container-logs/*.tar.gz; do
-            tar -C xzf "$file"
+            tar xzf "$file"
             rm -f "$file"
           done
 

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -121,6 +121,14 @@ jobs:
           fi
           make -C "${{ github.workspace }}/ansible" destroy-vms
 
+      - name: Unarchive logs
+        run: |
+          cd ${{ github.workspace }}/integration-tests/
+          for file in container-logs/*.tar.gz; do
+            tar -C xzf "$file"
+            rm -f "$file"
+          done
+
       - name: Store artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION

## Description

Doing this makes the artifacts easier to use, since it doesn't require unzip and unarchiving the logs separately. It also fixes an error with the benchmark steps, since these expect the perf.json files to be readily accessible.

Unfortunately, I wasn't able to do this in ansible, so running the test manually on remote systems still creates archives on the local host.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Test benchmark steps pass.
