### PR TITLE
Output the number of times a log has been throttled

### DIFF
--- a/collector/lib/Logging.cpp
+++ b/collector/lib/Logging.cpp
@@ -101,6 +101,8 @@ bool ParseLogLevelName(std::string name, LogLevel* level) {
 }
 
 void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
+  using namespace collector::logging;
+
   auto collector_severity = (LogLevel)severity;
 
   if (collector_severity == LogLevel::DEBUG && msg.rfind("libbpf:", 0) == 0) {
@@ -109,11 +111,12 @@ void InspectorLogCallback(std::string&& msg, sinsp_logger::severity severity) {
     collector_severity = LogLevel::TRACE;
   }
 
-  if (!collector::logging::CheckLogLevel(collector_severity)) {
+  if (!CheckLogLevel(collector_severity)) {
     return;
   }
 
-  collector::logging::LogMessage(__FILE__, __LINE__, false, collector_severity) << msg;
+  static LogHeader header(__FILE__, __LINE__, collector_severity);
+  LogMessage(header) << msg;
 }
 
 const char* GetGlobalLogPrefix() {

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -124,8 +124,8 @@ class ThrottledLogHeader : public ILogHeader {
 
   bool ShouldPrint() {
     std::chrono::duration elapsed = std::chrono::steady_clock::now() - last_log_;
+    count_++;
     if (elapsed < interval_) {
-      count_++;
       return false;
     }
 

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -154,6 +154,16 @@ class ThrottledLogHeader : public ILogHeader {
     PrintFile();
   }
 
+  /**
+   * Check if the log message should be suppressed.
+   *
+   * Throttled logs only output a message every interval_ time windows.
+   * If the log is to be suppressed, we increment count_ so the next
+   * time it is print we can add the amount of times the log has
+   * happened.
+   *
+   * @returns true if the log has to be suppressed.
+   */
   bool Suppress() {
     std::chrono::duration elapsed = std::chrono::steady_clock::now() - last_log_;
     count_++;

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -131,7 +131,7 @@ class LogHeader : public ILogHeader {
  * Throttled log header.
  *
  * When the same log message is triggered multiple times, this header
- * help prevent flooding the logs and instead counts the occurrences
+ * helps prevent flooding the logs and instead counts the occurrences
  * of the message, which will be output after a given time window
  * expires.
  *
@@ -158,8 +158,8 @@ class ThrottledLogHeader : public ILogHeader {
    * Check if the log message should be suppressed.
    *
    * Throttled logs only output a message every interval_ time windows.
-   * If the log is to be suppressed, we increment count_ so the next
-   * time it is print we can add the amount of times the log has
+   * Every time this method is called, we increment count_ so the next
+   * time the log is printed we can add the amount of times the log has
    * happened.
    *
    * @returns true if the log has to be suppressed.


### PR DESCRIPTION

## Description

Adding the number of times a log message has been throttled can add value in the sense that having the message show up once or twice may not be as worrisome as it showing up thousands of times.

In order to achieve this, the log message can be split between its header and the actual message. The header will now be handled by classes separate to LogMessage that will hold the information necessary to print them and use a common ILogHeader interface. This is done in order to reduce the amount of code necessary in macros, there shouldn't be a huge performance difference, but the current approach might take a bit more memory in order to store this data, some testing is needed. Calling virtual methods for printing the header could also have a performance impact, but given we don't print that many logs in info severity, would not consider this a problem.

Supersedes #1520. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Manually checked logging still works as expected.

Added a throttle message in `system-inspector::Service::GetNext` and checked the output happened every 10 seconds:
![image](https://github.com/user-attachments/assets/5ea27a13-3989-490e-99ff-8fceb751cea9)