### PR TITLE
Replace some unneeded mocks with friend tests

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <vector>
 
+#include <gtest/gtest_prod.h>
 #include <json/json.h>
 #include <yaml-cpp/yaml.h>
 
@@ -209,6 +210,15 @@ class CollectorConfig {
   void SetEnableExternalIPs(bool value) {
     enable_external_ips_ = value;
   }
+
+  // Friend tests
+  FRIEND_TEST(CollectorConfigTest, TestSinspBufferSizeReturnUnmodified);
+  FRIEND_TEST(CollectorConfigTest, TestSinspCpuPerBufferAdjusted);
+  FRIEND_TEST(CollectorConfigTest, TestEnableExternalIpsFeatureFlag);
+  FRIEND_TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig);
+  FRIEND_TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple);
+  FRIEND_TEST(CollectorConfigTest, TestYamlConfigToConfigInvalid);
+  FRIEND_TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty);
 };
 
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -2,7 +2,6 @@
 
 #include <internalapi/sensor/collector.pb.h>
 
-#include "CollectorArgs.h"
 #include "CollectorConfig.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -11,58 +10,29 @@ using namespace testing;
 
 namespace collector {
 
-class MockCollectorConfig : public CollectorConfig {
- public:
-  MockCollectorConfig() = default;
-
-  void MockSetSinspBufferSize(unsigned int value) {
-    SetSinspBufferSize(value);
-  }
-
-  void MockSetSinspTotalBufferSize(unsigned int value) {
-    SetSinspTotalBufferSize(value);
-  }
-
-  void MockSetHostConfig(HostConfig* config) {
-    SetHostConfig(config);
-  }
-
-  void MockSetSinspCpuPerBuffer(unsigned int value) {
-    SetSinspCpuPerBuffer(value);
-  }
-
-  void MockSetEnableExternalIPs(bool value) {
-    SetEnableExternalIPs(value);
-  }
-
-  bool MockYamlConfigToConfig(YAML::Node& yamlConfig) {
-    return YamlConfigToConfig(yamlConfig);
-  }
-};
-
 // Test that unmodified value is returned, when some dependency values are
 // missing
 TEST(CollectorConfigTest, TestSinspBufferSizeReturnUnmodified) {
   using namespace collector;
 
-  MockCollectorConfig config;
+  CollectorConfig config;
   HostConfig hconfig;
   hconfig.SetNumPossibleCPUs(0);
-  config.MockSetSinspCpuPerBuffer(0);
-  config.MockSetSinspTotalBufferSize(0);
-  config.MockSetSinspBufferSize(1);
-  config.MockSetHostConfig(&hconfig);
+  config.SetSinspCpuPerBuffer(0);
+  config.SetSinspTotalBufferSize(0);
+  config.SetSinspBufferSize(1);
+  config.SetHostConfig(&hconfig);
 
   // CPU-per-buffer is not initialized
   EXPECT_EQ(1, config.GetSinspBufferSize());
 
   // Number of CPUs is not initialized
-  config.MockSetSinspCpuPerBuffer(1);
+  config.SetSinspCpuPerBuffer(1);
   EXPECT_EQ(1, config.GetSinspBufferSize());
 
   // Total buffers size is not initialized
   hconfig.SetNumPossibleCPUs(1);
-  config.MockSetHostConfig(&hconfig);
+  config.SetHostConfig(&hconfig);
   EXPECT_EQ(1, config.GetSinspBufferSize());
 }
 
@@ -70,37 +40,37 @@ TEST(CollectorConfigTest, TestSinspBufferSizeReturnUnmodified) {
 TEST(CollectorConfigTest, TestSinspCpuPerBufferAdjusted) {
   using namespace collector;
 
-  MockCollectorConfig config;
+  CollectorConfig config;
   HostConfig hconfig;
-  config.MockSetSinspTotalBufferSize(512 * 1024 * 1024);
-  config.MockSetSinspBufferSize(8 * 1024 * 1024);
-  config.MockSetSinspCpuPerBuffer(1);
+  config.SetSinspTotalBufferSize(512 * 1024 * 1024);
+  config.SetSinspBufferSize(8 * 1024 * 1024);
+  config.SetSinspCpuPerBuffer(1);
 
   // Low number of CPUs, raw value
   hconfig.SetNumPossibleCPUs(16);
-  config.MockSetHostConfig(&hconfig);
+  config.SetHostConfig(&hconfig);
   EXPECT_EQ(8 * 1024 * 1024, config.GetSinspBufferSize());
 
   // High number of CPUs, adjusted value to power of 2
   hconfig.SetNumPossibleCPUs(150);
-  config.MockSetHostConfig(&hconfig);
+  config.SetHostConfig(&hconfig);
   EXPECT_EQ(2 * 1024 * 1024, config.GetSinspBufferSize());
 
   // Extreme number of CPUs, adjusted value to power of 2
   hconfig.SetNumPossibleCPUs(1024);
-  config.MockSetHostConfig(&hconfig);
+  config.SetHostConfig(&hconfig);
   EXPECT_EQ(512 * 1024, config.GetSinspBufferSize());
 
   // Extreme number of CPUs and low total buffer size, adjusted value is not
   // less than one page
-  config.MockSetSinspTotalBufferSize(512 * 1024);
+  config.SetSinspTotalBufferSize(512 * 1024);
   hconfig.SetNumPossibleCPUs(1024);
-  config.MockSetHostConfig(&hconfig);
+  config.SetHostConfig(&hconfig);
   EXPECT_EQ(16384, config.GetSinspBufferSize());
 }
 
 TEST(CollectorConfigTest, TestSetRuntimeConfig) {
-  MockCollectorConfig config;
+  CollectorConfig config;
 
   EXPECT_EQ(std::nullopt, config.GetRuntimeConfig());
 
@@ -112,27 +82,27 @@ TEST(CollectorConfigTest, TestSetRuntimeConfig) {
 }
 
 TEST(CollectorConfigTest, TestEnableExternalIpsFeatureFlag) {
-  MockCollectorConfig config;
+  CollectorConfig config;
 
   // without the presence of the runtime configuration
   // the enable_external_ips_ flag should be used
 
-  config.MockSetEnableExternalIPs(false);
+  config.SetEnableExternalIPs(false);
 
   EXPECT_FALSE(config.EnableExternalIPs());
 
-  config.MockSetEnableExternalIPs(true);
+  config.SetEnableExternalIPs(true);
 
   EXPECT_TRUE(config.EnableExternalIPs());
 }
 
 TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig) {
-  MockCollectorConfig config;
+  CollectorConfig config;
 
   // With the presence of runtime config, the feature
   // flag should be ignored
 
-  config.MockSetEnableExternalIPs(true);
+  config.SetEnableExternalIPs(true);
 
   sensor::CollectorConfig runtime_config;
   sensor::NetworkConnectionConfig* network_config = runtime_config.mutable_network_connection_config();
@@ -143,7 +113,7 @@ TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig) {
 
   EXPECT_FALSE(config.EnableExternalIPs());
 
-  config.MockSetEnableExternalIPs(false);
+  config.SetEnableExternalIPs(false);
 
   network_config->set_enable_external_ips(true);
   config.SetRuntimeConfig(runtime_config);
@@ -176,9 +146,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
   for (const auto& [yamlStr, expected] : tests) {
     YAML::Node yamlNode = YAML::Load(yamlStr);
 
-    MockCollectorConfig config;
+    CollectorConfig config;
 
-    bool result = config.MockYamlConfigToConfig(yamlNode);
+    bool result = config.YamlConfigToConfig(yamlNode);
     auto runtime_config = config.GetRuntimeConfig();
 
     EXPECT_TRUE(result);
@@ -198,9 +168,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigInvalid) {
 
   YAML::Node yamlNode = YAML::Load(yamlStr);
 
-  MockCollectorConfig config;
+  CollectorConfig config;
 
-  bool result = config.MockYamlConfigToConfig(yamlNode);
+  bool result = config.YamlConfigToConfig(yamlNode);
   auto runtime_config = config.GetRuntimeConfig();
 
   EXPECT_FALSE(result);
@@ -211,9 +181,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty) {
   std::string yamlStr = R"()";
   YAML::Node yamlNode = YAML::Load(yamlStr);
 
-  MockCollectorConfig config;
+  CollectorConfig config;
 
-  EXPECT_DEATH({ config.MockYamlConfigToConfig(yamlNode); }, ".*");
+  EXPECT_DEATH({ config.YamlConfigToConfig(yamlNode); }, ".*");
 }
 
 }  // namespace collector

--- a/collector/test/HostHeuristicsTest.cpp
+++ b/collector/test/HostHeuristicsTest.cpp
@@ -31,11 +31,6 @@ using namespace testing;
 
 namespace collector {
 
-class MockCPUHeuristic : public CPUHeuristic {
- public:
-  MockCPUHeuristic() = default;
-};
-
 class MockHostInfoHeuristics : public HostInfo {
  public:
   MockHostInfoHeuristics() = default;
@@ -48,23 +43,10 @@ class MockHostInfoHeuristics : public HostInfo {
   MOCK_METHOD0(NumPossibleCPU, int());
 };
 
-class MockCollectorConfig : public CollectorConfig {
- public:
-  MockCollectorConfig()
-      : CollectorConfig() {};
-
-  void SetCollectionMethod(CollectionMethod cm) {
-    if (host_config_.HasCollectionMethod()) {
-      host_config_.SetCollectionMethod(cm);
-    }
-    collection_method_ = cm;
-  }
-};
-
 TEST(HostHeuristicsTest, TestCPUHeuristic) {
-  MockCPUHeuristic cpuHeuristic;
+  CPUHeuristic cpuHeuristic;
   MockHostInfoHeuristics host;
-  MockCollectorConfig config;
+  CollectorConfig config;
   HostConfig hconfig;
 
   EXPECT_CALL(host, NumPossibleCPU()).WillOnce(Return(10));

--- a/collector/test/UtilityTest.cpp
+++ b/collector/test/UtilityTest.cpp
@@ -1,6 +1,3 @@
-#include <gmock/gmock-actions.h>
-#include <gmock/gmock-spec-builders.h>
-
 #include "Utility.cpp"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
## Description

Small cleanup for our unit tests. 

We have some mocks that are only used to call private/protected methods of classes, gtest provides the `FRIEND_TEST` macro that enables doing this directly with no mock class needed.

I'm also removing a few unused mock classes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run the unit tests manually and they are still building and passing. CI will do the same.
