### PR TITLE
Fix parsing collection method from environment variables

### DIFF
--- a/collector/lib/CollectionMethod.cpp
+++ b/collector/lib/CollectionMethod.cpp
@@ -1,6 +1,6 @@
 #include "CollectionMethod.h"
 
-#include <sstream>
+#include <algorithm>
 
 #include <sys/types.h>
 
@@ -24,4 +24,21 @@ const char* CollectionMethodName(CollectionMethod method) {
   }
 }
 
+CollectionMethod ParseCollectionMethod(std::string_view method) {
+  // Canonicalize collection method to lowercase, replace '-' with '_'
+  std::string cm(method);
+  std::transform(cm.begin(), cm.end(), cm.begin(), ::tolower);
+  std::replace(cm.begin(), cm.end(), '-', '_');
+
+  if (cm == "ebpf") {
+    return CollectionMethod::EBPF;
+  }
+
+  if (cm == "core_bpf") {
+    return CollectionMethod::CORE_BPF;
+  }
+
+  CLOG(WARNING) << "Invalid collection-method (" << cm << "), using CO-RE BPF";
+  return CollectionMethod::CORE_BPF;
+}
 }  // namespace collector

--- a/collector/lib/CollectionMethod.h
+++ b/collector/lib/CollectionMethod.h
@@ -2,6 +2,7 @@
 #define COLLECTION_METHOD_H
 
 #include <ostream>
+#include <string_view>
 
 namespace collector {
 enum class CollectionMethod : uint8_t {
@@ -12,6 +13,7 @@ enum class CollectionMethod : uint8_t {
 std::ostream& operator<<(std::ostream& os, CollectionMethod method);
 
 const char* CollectionMethodName(CollectionMethod method);
+CollectionMethod ParseCollectionMethod(std::string_view method);
 
 }  // namespace collector
 

--- a/collector/lib/CollectorArgs.cpp
+++ b/collector/lib/CollectorArgs.cpp
@@ -124,13 +124,9 @@ CollectorArgs::checkCollectionMethod(const option::Option& option, bool msg) {
     return ARG_OK;
   }
 
-  // Canonicalize collection method to lowercase, replace '-' with '_'
-  std::string s = option.arg;
-  std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-  std::replace(s.begin(), s.end(), '-', '_');
-  collectionMethod = s;
+  collectionMethod = ParseCollectionMethod(option.arg);
 
-  CLOG(DEBUG) << "CollectionMethod: " << collectionMethod;
+  CLOG(DEBUG) << "CollectionMethod: " << CollectionMethodName(collectionMethod.value());
 
   return ARG_OK;
 }
@@ -174,7 +170,7 @@ CollectorArgs::CollectorConfig() const {
   return collectorConfig;
 }
 
-const std::string&
+std::optional<CollectionMethod>
 CollectorArgs::GetCollectionMethod() const {
   return collectionMethod;
 }

--- a/collector/lib/CollectorArgs.h
+++ b/collector/lib/CollectorArgs.h
@@ -1,10 +1,12 @@
 #ifndef _COLLECTOR_ARGS_H_
 #define _COLLECTOR_ARGS_H_
 
+#include <optional>
 #include <string>
 
 #include <json/json.h>
 
+#include "CollectionMethod.h"
 #include "optionparser.h"
 
 namespace collector {
@@ -22,7 +24,7 @@ class CollectorArgs {
   option::ArgStatus checkOptionalNumeric(const option::Option& option, bool msg);
 
   const Json::Value& CollectorConfig() const;
-  const std::string& GetCollectionMethod() const;
+  std::optional<CollectionMethod> GetCollectionMethod() const;
   const std::string& GRPCServer() const;
   const std::string& Message() const;
 
@@ -33,7 +35,7 @@ class CollectorArgs {
   static CollectorArgs* instance;
 
   Json::Value collectorConfig;
-  std::string collectionMethod;
+  std::optional<CollectionMethod> collectionMethod{std::nullopt};
   std::string message;
   std::string grpcServer;
 };

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -6,6 +6,7 @@
 
 #include <libsinsp/sinsp.h>
 
+#include "CollectionMethod.h"
 #include "CollectorArgs.h"
 #include "EnvVar.h"
 #include "GRPC.h"
@@ -186,22 +187,15 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     }
 
     // Collection Method
-    auto setCollectionMethod = [&](const std::string& cm) {
-      CLOG(INFO) << "User configured collection-method=" << cm;
-      if (cm == "ebpf") {
-        collection_method_ = CollectionMethod::EBPF;
-      } else if (cm == "core_bpf") {
-        collection_method_ = CollectionMethod::CORE_BPF;
-      } else {
-        CLOG(WARNING) << "Invalid collection-method (" << cm << "), using CO-RE BPF";
-        collection_method_ = CollectionMethod::CORE_BPF;
-      }
+    auto setCollectionMethod = [&](const CollectionMethod cm) {
+      CLOG(INFO) << "User configured collection-method=" << CollectionMethodName(cm);
+      collection_method_ = cm;
     };
 
-    if (args->GetCollectionMethod().length() > 0) {
-      setCollectionMethod(args->GetCollectionMethod());
+    if (args->GetCollectionMethod()) {
+      setCollectionMethod(args->GetCollectionMethod().value());
     } else if (collection_method.hasValue()) {
-      setCollectionMethod(collection_method.value());
+      setCollectionMethod(ParseCollectionMethod(collection_method.value()));
     }
 
     // TLS configuration


### PR DESCRIPTION
## Description

When read from an environment variable, the collection method was not being canonicalized, leading to failing to parse it when the collection method was in uppercase. Moved the canonicalization logic to a ParseCollectionMethod and used that on args and environment variables.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Checked the logs for a deployed collector is not complaining about `CORE_BPF` not being valid.