### PR TITLE
ROX-26578: Improvements to CollectorConfig protobuf definitions

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -410,14 +410,14 @@ void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   }
   YAML::Node networking = yamlConfig["networking"];
   if (!networking) {
-    CLOG(WARNING) << "No networking in config file";
+    CLOG(INFO) << "No networking in config file";
     return;
   }
 
   bool enableExternalIps = false;
   YAML::Node externalIpsNode = networking["externalIps"];
   if (!externalIpsNode) {
-    CLOG(WARNING) << "No external IPs in config file";
+    CLOG(INFO) << "No external IPs in config file";
     return;
   }
   enableExternalIps = externalIpsNode["enable"].as<bool>(false);

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -403,22 +403,22 @@ void CollectorConfig::HandleSinspEnvVars() {
   }
 }
 
-bool CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
+void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   if (yamlConfig.IsNull() || !yamlConfig.IsDefined()) {
     CLOG(FATAL) << "Unable to read config from config file";
-    return false;
+    return;
   }
   YAML::Node networking = yamlConfig["networking"];
   if (!networking) {
     CLOG(WARNING) << "No networking in config file";
-    return false;
+    return;
   }
 
   bool enableExternalIps = false;
   YAML::Node externalIpsNode = networking["externalIps"];
   if (!externalIpsNode) {
     CLOG(WARNING) << "No external IPs in config file";
-    return false;
+    return;
   }
   enableExternalIps = externalIpsNode["enable"].as<bool>(false);
 
@@ -431,7 +431,7 @@ bool CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   CLOG(INFO) << "Runtime configuration:";
   CLOG(INFO) << GetRuntimeConfigStr();
 
-  return true;
+  return;
 }
 
 void CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -408,20 +408,24 @@ bool CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
     CLOG(FATAL) << "Unable to read config from config file";
     return false;
   }
-  YAML::Node networkConnectionConfig = yamlConfig["networkConnectionConfig"];
-  if (!networkConnectionConfig) {
-    CLOG(WARNING) << "No networkConnectionConfig in config file";
+  YAML::Node networking = yamlConfig["networking"];
+  if (!networking) {
+    CLOG(WARNING) << "No networking in config file";
     return false;
   }
 
   bool enableExternalIps = false;
-  if (networkConnectionConfig["enableExternalIps"]) {
-    enableExternalIps = networkConnectionConfig["enableExternalIps"].as<bool>(false);
+  YAML::Node externalIpsNode = networking["externalIps"];
+  if (!externalIpsNode) {
+    CLOG(WARNING) << "No external IPs in config file";
+    return false;
   }
+  enableExternalIps = externalIpsNode["enable"].as<bool>(false);
 
   sensor::CollectorConfig runtime_config;
-  auto* networkConfig = runtime_config.mutable_network_connection_config();
-  networkConfig->set_enable_external_ips(enableExternalIps);
+  auto* networkingConfig = runtime_config.mutable_networking();
+  auto* externalIpsConfig = networkingConfig->mutable_external_ips();
+  externalIpsConfig->set_enable(enableExternalIps);
 
   SetRuntimeConfig(runtime_config);
   CLOG(INFO) << "Runtime configuration:";

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -94,8 +94,9 @@ class CollectorConfig {
   bool EnableExternalIPs() const {
     if (runtime_config_.has_value()) {
       const auto& cfg = runtime_config_.value();
-      const auto& network_cfg = cfg.network_connection_config();
-      return network_cfg.enable_external_ips();
+      const auto& networking = cfg.networking();
+      const auto& external_ips = networking.external_ips();
+      return external_ips.enable();
     }
     return enable_external_ips_;
   }

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -198,7 +198,7 @@ class CollectorConfig {
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
-  bool YamlConfigToConfig(YAML::Node& yamlConfig);
+  void YamlConfigToConfig(YAML::Node& yamlConfig);
   void HandleConfig(const std::filesystem::path& filePath);
 
   // Protected, used for testing purposes

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -93,10 +93,10 @@ class CollectorConfig {
   // otherwise, we rely on the feature flag (env var)
   bool EnableExternalIPs() const {
     if (runtime_config_.has_value()) {
-      const auto& cfg = runtime_config_.value();
-      const auto& networking = cfg.networking();
-      const auto& external_ips = networking.external_ips();
-      return external_ips.enable();
+      return runtime_config_.value()
+          .networking()
+          .external_ips()
+          .enable();
     }
     return enable_external_ips_;
   }

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -183,10 +183,11 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
 
     EXPECT_TRUE(runtime_config.has_value());
 
-    const auto& cfg = runtime_config.value();
-    const auto& networking_cfg = cfg.networking();
-    const auto& external_ips = networking_cfg.external_ips();
-    EXPECT_EQ(external_ips.enable(), expected);
+    bool enabled = runtime_config.value()
+                       .networking()
+                       .external_ips()
+                       .enable();
+    EXPECT_EQ(enabled, expected);
     EXPECT_EQ(config.EnableExternalIPs(), expected);
   }
 }

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -135,8 +135,8 @@ TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig) {
   config.MockSetEnableExternalIPs(true);
 
   sensor::CollectorConfig runtime_config;
-  sensor::CollectorConfig_Networking* networking_config = runtime_config.mutable_networking();
-  sensor::CollectorConfig_ExternalIPs* external_ips_config = networking_config->mutable_external_ips();
+  auto* networking_config = runtime_config.mutable_networking();
+  auto* external_ips_config = networking_config->mutable_external_ips();
 
   external_ips_config->set_enable(false);
 

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -35,8 +35,8 @@ class MockCollectorConfig : public CollectorConfig {
     SetEnableExternalIPs(value);
   }
 
-  bool MockYamlConfigToConfig(YAML::Node& yamlConfig) {
-    return YamlConfigToConfig(yamlConfig);
+  void MockYamlConfigToConfig(YAML::Node& yamlConfig) {
+    YamlConfigToConfig(yamlConfig);
   }
 };
 
@@ -178,10 +178,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
 
     MockCollectorConfig config;
 
-    bool result = config.MockYamlConfigToConfig(yamlNode);
+    config.MockYamlConfigToConfig(yamlNode);
     auto runtime_config = config.GetRuntimeConfig();
 
-    EXPECT_TRUE(result);
     EXPECT_TRUE(runtime_config.has_value());
 
     const auto& cfg = runtime_config.value();
@@ -210,10 +209,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigInvalid) {
 
     MockCollectorConfig config;
 
-    bool result = config.MockYamlConfigToConfig(yamlNode);
+    config.MockYamlConfigToConfig(yamlNode);
     auto runtime_config = config.GetRuntimeConfig();
 
-    EXPECT_FALSE(result);
     EXPECT_FALSE(runtime_config.has_value());
   }
 }

--- a/docs/references.md
+++ b/docs/references.md
@@ -114,8 +114,9 @@ When using collector by itself a file can be mounted to it at /etc/stackrox/runt
 following is an example of the contents
 
 ```
-networkConnectionConfig:
-    enableExternalIps: true
+networking:
+  externalIps:
+    enable: true
 ```
 
 Alternatively, if collector is used as a part of Stackrox, the configuration can be set
@@ -129,8 +130,9 @@ metadata:
   namespace: stackrox
 data:
   runtime_config.yaml: |
-    networkConnectionConfig:
-        enableExternalIps: true
+    networking:
+      externalIps:
+        enable: true
 ```
 
 The file path can be set using the `ROX_COLLECTOR_CONFIG_PATH` environment variable.


### PR DESCRIPTION
## Description

The protobuf definitions for collector config were changed here https://github.com/stackrox/stackrox/pull/12972

This makes use of the updated protobuf definitions. The changes impact the code to read the configuration, associated tests, and documentation.

The following is an example of how the config file has changed

```
 networkConnectionConfig:
   enableExternalIps: true
```

```
networking:
  externalIps:
    enable: true
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

### External IPs set to true
ACS was deployed on a GKE cluster using a commit from https://github.com/stackrox/stackrox/pull/12972 

A config map with the following contents was created

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: collector-config
  namespace: stackrox
data:
  runtime_config.yaml: |
    networking:
        externalIps:
          enable: true
```

The collector version was replaced with one from this branch. The collector logs were checked and the following was found.

```
[INFO    2024/10/10 17:14:57] Runtime configuration:
[INFO    2024/10/10 17:14:57] networking {
  external_ips {
    enable: true
  }
}
```

### External IPs set to false
The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
    networking:
        externalIps:
          enable: false
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "927630"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found in the collector logs
```
[INFO    2024/10/10 17:46:24] Runtime configuration:
[INFO    2024/10/10 17:46:24] networking {
  external_ips {
  }
}
```

### Enable not set
The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
    networking:
        externalIps:
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "933454"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found in the collector logs
```
[INFO    2024/10/10 17:54:55] Runtime configuration:
[INFO    2024/10/10 17:54:55] networking {
  external_ips {
  }
}

```

### ExternalIps not set

The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
    networking:
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "936283"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found int the collector logs
```
[WARNING 2024/10/10 17:59:09] No external IPs in config file
```

### Unknown field in networking
The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
    networking:
      unknownField: asdf
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "936283"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found int the collector logs
```
[WARNING 2024/10/10 18:03:06] No external IPs in config file
```

### Unknown field in place of networking
The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
    unknownField: asdf
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "938877"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found int the collector logs
```
[WARNING 2024/10/10 18:06:50] No networking in config file
```

### Empty config
The configmap was set to the following
```
apiVersion: v1
data:
  runtime_config.yaml: |
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-10T17:13:59Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "941409"
  uid: 5f741877-e26e-4d51-8ab4-66a7d6e09d58
```

The following was found in the collector logs
```
[FATAL   2024/10/10 18:10:30] Unable to read config from config file
```

Collector went into a crashloop. This is expected behavior.

### No configmap

Collector ran normally with no logging regarding the runtime config or configmap.