### PR TITLE
ROX-26637: Reread configmap when it is updated

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -400,6 +400,8 @@ void CollectorConfig::HandleSinspEnvVars() {
 }
 
 void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
+  std::lock_guard<std::mutex> lock(*mutex_);
+
   if (yamlConfig.IsNull() || !yamlConfig.IsDefined()) {
     CLOG(FATAL) << "Unable to read config from config file";
     return;

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -400,7 +400,7 @@ void CollectorConfig::HandleSinspEnvVars() {
 
 void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   // Don't read the file during a scrape
-  std::lock_guard<std::mutex> lock(*mutex_);
+  std::unique_lock<std::shared_mutex> lock(mutex_);
 
   if (yamlConfig.IsNull() || !yamlConfig.IsDefined()) {
     CLOG(FATAL) << "Unable to read config from config file";
@@ -457,7 +457,7 @@ void CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {
 
 void WaitForFileToExist(const std::filesystem::path& filePath) {
   while (!std::filesystem::exists(filePath)) {
-    sleep(5);
+    sleep(1);
   }
 }
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -459,14 +459,11 @@ bool CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {
 
 void CollectorConfig::WaitForFileToExist(const std::filesystem::path& filePath) {
   int count = 0;
-  while (!std::filesystem::exists(filePath)) {
+  while (!std::filesystem::exists(filePath) && !thread_.should_stop()) {
     sleep(1);
     count++;
     if (count > 45) {
       runtime_config_.reset();
-    }
-    if (thread_.should_stop()) {
-      break;
     }
   }
 }

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -425,8 +425,7 @@ void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   externalIpsConfig->set_enable(enableExternalIps);
 
   SetRuntimeConfig(runtime_config);
-  CLOG(INFO) << "Runtime configuration:";
-  CLOG(INFO) << GetRuntimeConfigStr();
+  CLOG(INFO) << "Runtime configuration:\n" + GetRuntimeConfigStr();
 
   return;
 }

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -457,8 +457,12 @@ bool CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {
   return true;
 }
 
-void WaitForFileToExist(const std::filesystem::path& filePath) {
+void CollectorConfig::WaitForFileToExist(const std::filesystem::path& filePath) {
   while (!std::filesystem::exists(filePath)) {
+    if (runtime_config_.has_value()) {
+      CLOG(INFO) << "The configuration file has been deleted. Resetting the configuration";
+      runtime_config_.reset();
+    }
     sleep(1);
   }
 }

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -463,7 +463,7 @@ void CollectorConfig::WaitForFileToExist(const std::filesystem::path& filePath) 
   while (!std::filesystem::exists(filePath) && !thread_.should_stop()) {
     sleep(1);
     count++;
-    if (count > 45) {
+    if (count == 45) {
       std::unique_lock<std::shared_mutex> lock(mutex_);
       runtime_config_.reset();
     }

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -463,6 +463,7 @@ void CollectorConfig::WaitForFileToExist(const std::filesystem::path& filePath) 
     sleep(1);
     count++;
     if (count > 45) {
+      std::unique_lock<std::shared_mutex> lock(mutex_);
       runtime_config_.reset();
     }
   }

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -425,7 +425,8 @@ void CollectorConfig::YamlConfigToConfig(YAML::Node& yamlConfig) {
   externalIpsConfig->set_enable(enableExternalIps);
 
   SetRuntimeConfig(runtime_config);
-  CLOG(INFO) << "Runtime configuration:\n" + GetRuntimeConfigStr();
+  CLOG(INFO) << "Runtime configuration:\n"
+             << GetRuntimeConfigStr();
 
   return;
 }
@@ -457,12 +458,13 @@ bool CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {
 }
 
 void CollectorConfig::WaitForFileToExist(const std::filesystem::path& filePath) {
+  int count = 0;
   while (!std::filesystem::exists(filePath)) {
-    if (runtime_config_.has_value()) {
-      CLOG(INFO) << "The configuration file has been deleted. Resetting the configuration.";
+    sleep(1);
+    count++;
+    if (count > 45) {
       runtime_config_.reset();
     }
-    sleep(1);
   }
 }
 
@@ -499,7 +501,7 @@ void CollectorConfig::WatchConfigFile(const std::filesystem::path& filePath) {
       CLOG(ERROR) << "Unable to read event for " << filePath;
     }
 
-    struct inotify_event *event = buffer;
+    struct inotify_event* event = buffer;
     for (int i = 0; i < length; i += sizeof(struct inotify_event) + event->len) {
       event = (struct inotify_event*)&buffer[i];
       if (event->mask & IN_MODIFY) {

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -454,13 +454,14 @@ void CollectorConfig::HandleConfig(const std::filesystem::path& filePath) {
 }
 
 void CollectorConfig::WatchConfigFile(const std::filesystem::path& filePath) {
+  CLOG(INFO) << "In WatchConfigFile";
   int fd = inotify_init();
   if (fd < 0) {
     CLOG(FATAL) << "inotify_init failed";
     return;
   }
 
-  int wd = inotify_add_watch(fd, filePath.c_str(), IN_MODIFY);
+  int wd = inotify_add_watch(fd, filePath.c_str(), IN_MODIFY | IN_MOVE_SELF | IN_DELETE_SELF);
   if (wd < 0) {
     CLOG(FATAL) << "Failed to add inotify watch for " << filePath;
     close(fd);
@@ -469,20 +470,33 @@ void CollectorConfig::WatchConfigFile(const std::filesystem::path& filePath) {
 
   char buffer[1024];
   while (true) {
+    CLOG(INFO) << "Waiting for file event";
     int length = read(fd, buffer, sizeof(buffer));
     if (length < 0) {
-      CLOG(FATAL) << "read error";
+      CLOG(FATAL) << "Unable to read event for " << filePath;
     }
 
     for (int i = 0; i < length; i += sizeof(struct inotify_event)) {
       struct inotify_event* event = (struct inotify_event*)&buffer[i];
+      CLOG(INFO) << "Got event event->mask= " << event->mask;
+      CLOG(INFO) << "event->mask & IN_MODIFY= " << (event->mask & IN_MODIFY);
       if (event->mask & IN_MODIFY) {
-        CLOG(INFO) << "Configuration file modified. Reloading...";
-        HandleConfig(filePath);  // Reload configuration
+        CLOG(INFO) << "File was replace";
+        HandleConfig(filePath);
+      } else if ((event->mask & IN_MOVE_SELF) || (event->mask & IN_DELETE_SELF) || (event->mask & IN_IGNORED)) {
+        CLOG(INFO) << "File was removed";
+        wd = inotify_add_watch(fd, filePath.c_str(), IN_MODIFY | IN_MOVE_SELF | IN_DELETE_SELF);
+        HandleConfig(filePath);
+        if (wd < 0) {
+          CLOG(FATAL) << "Failed to add inotify watch for " << filePath;
+          close(fd);
+          return;
+        }
       }
     }
   }
 
+  CLOG(INFO) << "Leaving WatchingConfigFile " << filePath;
   inotify_rm_watch(fd, wd);
   close(fd);
 }
@@ -494,6 +508,7 @@ void CollectorConfig::Start() {
 
 void CollectorConfig::Stop() {
   thread_.Stop();
+  CLOG(INFO) << "No longer watching config file" << config_file.value();
 }
 
 bool CollectorConfig::TurnOffScrape() const {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -131,6 +131,10 @@ class CollectorConfig {
   void Start();
   void Stop();
 
+  std::mutex* GetMutex() const {
+    return mutex_;
+  }
+
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
   void SetRuntimeConfig(sensor::CollectorConfig&& runtime_config) {
@@ -201,6 +205,7 @@ class CollectorConfig {
 
   std::optional<sensor::CollectorConfig> runtime_config_;
   StoppableThread thread_;
+  std::mutex* mutex_ = new std::mutex();
 
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -208,7 +208,6 @@ class CollectorConfig {
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
-  void LogRuntimeConfigError(const std::string& str);
   void YamlConfigToConfig(YAML::Node& yamlConfig);
   bool HandleConfig(const std::filesystem::path& filePath);
   void WaitForFileToExist(const std::filesystem::path& filePath);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -210,7 +210,7 @@ class CollectorConfig {
   void HandleSinspEnvVars();
   void LogRuntimeConfigError(const std::string& str);
   void YamlConfigToConfig(YAML::Node& yamlConfig);
-  void HandleConfig(const std::filesystem::path& filePath);
+  bool HandleConfig(const std::filesystem::path& filePath);
   void WatchConfigFile(const std::filesystem::path& filePath);
 
   // Protected, used for testing purposes

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -208,6 +208,7 @@ class CollectorConfig {
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
+  void LogRuntimeConfigError(const std::string& str);
   void YamlConfigToConfig(YAML::Node& yamlConfig);
   void HandleConfig(const std::filesystem::path& filePath);
   void WatchConfigFile(const std::filesystem::path& filePath);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -15,6 +15,7 @@
 #include "CollectionMethod.h"
 #include "HostConfig.h"
 #include "NetworkConnection.h"
+#include "StoppableThread.h"
 #include "TlsConfig.h"
 #include "json/value.h"
 #include "optionparser.h"
@@ -127,6 +128,8 @@ class CollectorConfig {
   unsigned int GetSinspBufferSize() const;
   unsigned int GetSinspTotalBufferSize() const { return sinsp_total_buffer_size_; }
   unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
+  void Start();
+  void Stop();
 
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
@@ -197,12 +200,14 @@ class CollectorConfig {
   std::optional<TlsConfig> tls_config_;
 
   std::optional<sensor::CollectorConfig> runtime_config_;
+  StoppableThread thread_;
 
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();
   void HandleSinspEnvVars();
   void YamlConfigToConfig(YAML::Node& yamlConfig);
   void HandleConfig(const std::filesystem::path& filePath);
+  void WatchConfigFile(const std::filesystem::path& filePath);
 
   // Protected, used for testing purposes
   void SetSinspBufferSize(unsigned int buffer_size);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -211,6 +211,7 @@ class CollectorConfig {
   void YamlConfigToConfig(YAML::Node& yamlConfig);
   bool HandleConfig(const std::filesystem::path& filePath);
   void WaitForFileToExist(const std::filesystem::path& filePath);
+  int WaitForInotifyAddWatch(int fd, const std::filesystem::path& filePath);
   void WatchConfigFile(const std::filesystem::path& filePath);
 
   // Protected, used for testing purposes

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -211,6 +211,7 @@ class CollectorConfig {
   void LogRuntimeConfigError(const std::string& str);
   void YamlConfigToConfig(YAML::Node& yamlConfig);
   bool HandleConfig(const std::filesystem::path& filePath);
+  void WaitForFileToExist(const std::filesystem::path& filePath);
   void WatchConfigFile(const std::filesystem::path& filePath);
 
   // Protected, used for testing purposes

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -131,9 +131,6 @@ class CollectorConfig {
   void Start();
   void Stop();
 
-  std::mutex* GetMutex() const {
-    return mutex_;
-  }
 
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
@@ -205,7 +202,7 @@ class CollectorConfig {
 
   std::optional<sensor::CollectorConfig> runtime_config_;
   StoppableThread thread_;
-  std::mutex* mutex_ = new std::mutex();
+  std::mutex mutex_{};
 
   void HandleAfterglowEnvVars();
   void HandleConnectionStatsEnvVars();

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -32,7 +32,7 @@ namespace collector {
 CollectorService::CollectorService(CollectorConfig& config, std::atomic<ControlValue>* control,
                                    const std::atomic<int>* signum)
     : config_(config), control_(control), signum_(*signum) {
-  CLOG(INFO) << "Config: " << *config;
+  CLOG(INFO) << "Config: " << config;
 }
 
 void CollectorService::RunForever() {
@@ -59,7 +59,7 @@ void CollectorService::RunForever() {
   exposer.RegisterCollectable(registry);
 
   CollectorStatsExporter exporter(registry, &config_, &system_inspector_);
-  config_->Start();
+  config_.Start();
 
   std::unique_ptr<NetworkStatusNotifier> net_status_notifier;
 
@@ -137,7 +137,7 @@ void CollectorService::RunForever() {
   if (net_status_notifier) {
     net_status_notifier->Stop();
   }
-  config_->Stop();
+  config_.Stop();
   // Shut down these first since they access the system inspector object.
   exporter.stop();
   server.close();

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -32,7 +32,7 @@ namespace collector {
 CollectorService::CollectorService(CollectorConfig& config, std::atomic<ControlValue>* control,
                                    const std::atomic<int>* signum)
     : config_(config), control_(control), signum_(*signum) {
-  CLOG(INFO) << "Config: " << config;
+  CLOG(INFO) << "Config: " << *config;
 }
 
 void CollectorService::RunForever() {
@@ -59,6 +59,7 @@ void CollectorService::RunForever() {
   exposer.RegisterCollectable(registry);
 
   CollectorStatsExporter exporter(registry, &config_, &system_inspector_);
+  config_->Start();
 
   std::unique_ptr<NetworkStatusNotifier> net_status_notifier;
 
@@ -136,6 +137,7 @@ void CollectorService::RunForever() {
   if (net_status_notifier) {
     net_status_notifier->Stop();
   }
+  config_->Stop();
   // Shut down these first since they access the system inspector object.
   exporter.stop();
   server.close();

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -301,7 +301,7 @@ sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(c
 
 void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<sensor::NetworkConnection>* updates, const ConnMap& delta) {
   for (const auto& delta_entry : delta) {
-    CLOG(DEBUG) << delta_entry.first << " active:" << delta_entry.second.IsActive();
+    CLOG(INFO) << delta_entry.first << " active:" << delta_entry.second.IsActive();
     auto* conn_proto = ConnToProto(delta_entry.first);
     if (!delta_entry.second.IsActive()) {
       *conn_proto->mutable_close_timestamp() = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -224,8 +224,6 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
   int64_t time_at_last_scrape = NowMicros();
 
   while (writer->Sleep(next_scrape)) {
-    // We don't want to scrape while reading the config file
-    std::lock_guard<std::mutex> lock(*(config_.GetMutex()));
     CLOG(DEBUG) << "Starting network status notification";
     next_scrape = std::chrono::system_clock::now() + std::chrono::seconds(scrape_interval_);
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -301,7 +301,6 @@ sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(c
 
 void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<sensor::NetworkConnection>* updates, const ConnMap& delta) {
   for (const auto& delta_entry : delta) {
-    CLOG(INFO) << delta_entry.first << " active:" << delta_entry.second.IsActive();
     auto* conn_proto = ConnToProto(delta_entry.first);
     if (!delta_entry.second.IsActive()) {
       *conn_proto->mutable_close_timestamp() = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -225,7 +225,7 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
 
   while (writer->Sleep(next_scrape)) {
     // We don't want to scrape while reading the config file
-    std::lock_guard<std::mutex> lock(*(config_->GetMutex()));
+    std::lock_guard<std::mutex> lock(*(config_.GetMutex()));
     CLOG(DEBUG) << "Starting network status notification";
     next_scrape = std::chrono::system_clock::now() + std::chrono::seconds(scrape_interval_);
 

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -301,6 +301,7 @@ sensor::NetworkConnectionInfoMessage* NetworkStatusNotifier::CreateInfoMessage(c
 
 void NetworkStatusNotifier::AddConnections(::google::protobuf::RepeatedPtrField<sensor::NetworkConnection>* updates, const ConnMap& delta) {
   for (const auto& delta_entry : delta) {
+    CLOG(DEBUG) << delta_entry.first << " active:" << delta_entry.second.IsActive();
     auto* conn_proto = ConnToProto(delta_entry.first);
     if (!delta_entry.second.IsActive()) {
       *conn_proto->mutable_close_timestamp() = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -224,6 +224,8 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
   int64_t time_at_last_scrape = NowMicros();
 
   while (writer->Sleep(next_scrape)) {
+    // We don't want to scrape while reading the config file
+    std::lock_guard<std::mutex> lock(*(config_->GetMutex()));
     CLOG(DEBUG) << "Starting network status notification";
     next_scrape = std::chrono::system_clock::now() + std::chrono::seconds(scrape_interval_);
 

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -224,6 +224,9 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty) {
   MockCollectorConfig config;
 
   EXPECT_THROW({ config.MockYamlConfigToConfig(yamlNode); }, std::runtime_error);
+
+  auto runtime_config = config.GetRuntimeConfig();
+
   EXPECT_FALSE(runtime_config.has_value());
 }
 

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -224,6 +224,7 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty) {
   MockCollectorConfig config;
 
   EXPECT_THROW({ config.MockYamlConfigToConfig(yamlNode); }, std::runtime_error);
+  EXPECT_FALSE(runtime_config.has_value());
 }
 
 }  // namespace collector

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -223,7 +223,7 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty) {
 
   MockCollectorConfig config;
 
-  EXPECT_DEATH({ config.MockYamlConfigToConfig(yamlNode); }, ".*");
+  EXPECT_THROW({ config.MockYamlConfigToConfig(yamlNode); }, std::runtime_error);
 }
 
 }  // namespace collector

--- a/docs/references.md
+++ b/docs/references.md
@@ -141,6 +141,9 @@ data:
 ```
 
 The file path can be set using the `ROX_COLLECTOR_CONFIG_PATH` environment variable.
+Whenever the ConfigMap or config file is updated or created, collector will update
+the configuration. If the ConfigMap or config file is deleted the environment variable
+will be used instead. The ConfigMap can be created after collector start up.
 
 ### Other arguments
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -142,8 +142,8 @@ data:
 
 The file path can be set using the `ROX_COLLECTOR_CONFIG_PATH` environment variable.
 Whenever the configuration file is updated or created, collector will update
-the configuration. If the configuration file is deleted the environment variable
-will be used instead. The configuration file can be created after collector start up.
+the configuration. If the configuration file is deleted the configuration will revert
+to the default. The configuration file can be created after collector start up.
 
 ### Other arguments
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -141,9 +141,9 @@ data:
 ```
 
 The file path can be set using the `ROX_COLLECTOR_CONFIG_PATH` environment variable.
-Whenever the ConfigMap or config file is updated or created, collector will update
-the configuration. If the ConfigMap or config file is deleted the environment variable
-will be used instead. The ConfigMap can be created after collector start up.
+Whenever the configuration file is updated or created, collector will update
+the configuration. If the configuration file is deleted the environment variable
+will be used instead. The configuration file can be created after collector start up.
 
 ### Other arguments
 


### PR DESCRIPTION
## Description

Makes it so that when the ConfigMap or config file is updated collector reads it and updates the runtime configuration. Also handles cases were the ConfigMap does not exist at collector startup, is created later, and is deleted during runtime.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Deployed ACS on a GKE cluster using `deploy/deploy-local.sh`. Replaced the collector image with one from this PR. The connection reported by collector to sensor where logged. Initially there was no ConfigMap. 

Before deploying ACS the following deployment was created

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: external-dns
spec:
  replicas: 2
  selector:
    matchLabels:
      app: external-dns-app
  template:
    metadata:
      labels:
        app: external-dns-app
    spec:
      containers:
      - name: dns-app-container
        image: alpine:latest
        ports:
        - containerPort: 8080
        env:
        - name: EXTERNAL_IP
          value: "8.8.8.8"  # Google's Public DNS IP
        - name: EXTERNAL_PORT
          value: "53"  # DNS runs on port 53
        command: ["sh", "-c"]
        args:
        - |
          # Connect to Google's DNS IP
          while true; do
            nc -zv $EXTERNAL_IP $EXTERNAL_PORT;
            sleep 60;
          done
---
apiVersion: v1
kind: Service
metadata:
  name: external-dns-service
spec:
  selector:
    app: external-dns-app
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
  type: ClusterIP
```

One of the containers of the pods was the following
```
$ kubectl describe pod external-dns-54879dc46d-jfjdp | grep "Container ID"
    Container ID:  containerd://df6e7a3a43d22e448d8fe49ccda1dd5b428bd3c8d9f18b69c67145cb4b87fcdb
```

The following was observed in the collector logs.
```
[INFO    2024/10/15 18:41:31] df6e7a3a43d2: :::0 -> 255.255.255.255/0:53 [tcp] active:1
```
Along with many other connections. No logging involving the runtime configuration or the ConfigMap was found. Note that the normalized connection above corresponds to the one created by the deployment specified above.

The following ConfigMap was then created
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: collector-config
  namespace: stackrox
data:
  runtime_config.yaml: |
    networking:
        externalIps:
          enable: true
```

The following was observed in the collector logs
```
[INFO    2024/10/15 18:44:39] Runtime configuration:
[INFO    2024/10/15 18:44:39] networking {
  external_ips {
    enable: true
  }
}

[INFO    2024/10/15 18:44:39] Waiting for file event
```
and
```
[INFO    2024/10/15 18:45:31] df6e7a3a43d2: :::0 -> 8.8.8.8:53 [tcp] active:1
[INFO    2024/10/15 18:49:31] df6e7a3a43d2: :::0 -> 255.255.255.255/0:53 [tcp] active:0
```

The connection with the un-normalized IP address is reported as active and after the afterglow period is over the normalized connection is reported as inactive.

External IPs was then disabled by editing the ConfigMap to the following

```
apiVersion: v1
data:
  runtime_config.yaml: |
    networking:
        externalIps:
          enable: false
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-15T18:43:37Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "1046248"
  uid: 8722e73b-ffb9-45fe-a52d-a13132383779
```

The following was observed in the collector logs

```
[INFO    2024/10/15 18:59:06] Got event event->mask= 1024
[INFO    2024/10/15 18:59:06] event->mask & IN_MODIFY= 0
[INFO    2024/10/15 18:59:06] File was removed
[INFO    2024/10/15 18:59:06] Runtime configuration:
[INFO    2024/10/15 18:59:06] networking {
  external_ips {
  }
}

[INFO    2024/10/15 18:59:06] Got event event->mask= 32768
[INFO    2024/10/15 18:59:06] event->mask & IN_MODIFY= 0
[INFO    2024/10/15 18:59:06] File was removed
[INFO    2024/10/15 18:59:06] Runtime configuration:
[INFO    2024/10/15 18:59:06] networking {
  external_ips {
  }
}

[INFO    2024/10/15 18:59:06] Waiting for file event
```
and

```
[INFO    2024/10/15 18:59:32] df6e7a3a43d2: :::0 -> 255.255.255.255/0:53 [tcp] active:1
[INFO    2024/10/15 19:03:32] df6e7a3a43d2: :::0 -> 8.8.8.8:53 [tcp] active:0
```
The connection with the normalized IP address is reported open and the connection with the un-normalized IP address is reported closed after the afterglow period.

The ConfigMap was deleted and the collector logs were checked

```
[INFO    2024/10/15 21:12:45] Got event event->mask= 1024
[INFO    2024/10/15 21:12:45] event->mask & IN_MODIFY= 0
[INFO    2024/10/15 21:12:45] File was removed
[INFO    2024/10/15 21:12:45] The configuration file has been deleted. Resetting the configuration
[INFO    2024/10/15 21:15:08] 7fbe41e81a75: :::0 -> 255.255.255.255/0:53 [udp] active:0
[INFO    2024/10/15 21:15:08] a6523116184e: :::0 -> 104.16.0.0/13:443 [tcp] active:1
[INFO    2024/10/15 21:17:38] 2b9112868a44: :::0 -> 255.255.255.255/0:53 [udp] active:0
[INFO    2024/10/15 21:20:38] 038e0a736e89: :::0 -> 255.255.255.255/0:53 [udp] active:0
[INFO    2024/10/15 21:21:38] a6523116184e: :::0 -> 104.16.0.0/13:443 [tcp] active:0
``` 

The collector logs show that the configuration was reset. The connection that has been traced above did not change state so did not appear in the logs, but other connections are shown to be normalized.

The original ConfigMap was then recreated

The following was observed in the collector logs

```
[INFO    2024/10/15 21:29:08] Runtime configuration:
[INFO    2024/10/15 21:29:08] networking {
  external_ips {
    enable: true
  }
}

[INFO    2024/10/15 21:29:08] Got event event->mask= 32768
[INFO    2024/10/15 21:29:08] event->mask & IN_MODIFY= 0
[INFO    2024/10/15 21:29:08] File was removed
[INFO    2024/10/15 21:29:08] Runtime configuration:
[INFO    2024/10/15 21:29:08] networking {
  external_ips {
    enable: true
  }
}

[INFO    2024/10/15 21:29:08] Waiting for file event
```

```
[INFO    2024/10/15 21:29:38] df6e7a3a43d2: :::0 -> 8.8.8.8:53 [tcp] active:1
[INFO    2024/10/15 21:33:38] df6e7a3a43d2: :::0 -> 255.255.255.255/0:53 [tcp] active:0
```

The connection with the un-normalized IP address is reported open and after the afterglow period the normalized version is reported as being closed.

All of this is as expected.