### PR TITLE
Don't read the ConfigMap when runtime config not used

### DIFF
--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -58,7 +58,9 @@ void CollectorService::RunForever() {
   prometheus::Exposer exposer("9090");
   exposer.RegisterCollectable(registry);
 
-  config_->Start();
+  if (config_->EnableRuntimeConfig()) {
+    config_->Start();
+  }
   CollectorStatsExporter exporter(registry, config_, &system_inspector_);
 
   std::unique_ptr<NetworkStatusNotifier> net_status_notifier;
@@ -137,7 +139,9 @@ void CollectorService::RunForever() {
   if (net_status_notifier) {
     net_status_notifier->Stop();
   }
-  config_->Stop();
+  if (config_->EnableRuntimeConfig()) {
+    config_->Stop();
+  }
   // Shut down these first since they access the system inspector object.
   exporter.stop();
   server.close();


### PR DESCRIPTION
## Description

Make it so that the runtime configuration is only read when `ROX_COLLECTOR_RUNTIME_CONFIG_ENABLED` is set to true.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
