### PR TITLE
Disable afterglow when runtime config is enabled

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -306,6 +306,13 @@ void CollectorConfig::HandleAfterglowEnvVars() {
     enable_afterglow_ = enable_afterglow.value();
   }
 
+  if (enable_runtime_config.value() && (afterglow_period_micros_ > 0 || enable_afterglow)) {
+    CLOG(WARNING) << "Afterglow and runtime configuration are both enabled.";
+    CLOG(WARNING) << "Disabling afterglow since it conflicts with runtime configuration.";
+    afterglow_period_micros_ = 0;
+    enable_afterglow_ = false;
+  }
+
   CLOG(INFO) << "Afterglow is " << (enable_afterglow_ ? "enabled" : "disabled");
 }
 

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -291,6 +291,13 @@ void CollectorConfig::HandleAfterglowEnvVars() {
 
   afterglow_period_micros_ = static_cast<uint64_t>(afterglow_period.value() * SECOND);
 
+  if (enable_runtime_config.value() && (afterglow_period_micros_ > 0 || enable_afterglow)) {
+    CLOG(WARNING) << "Afterglow and runtime configuration are both enabled.";
+    CLOG(WARNING) << "Disabling afterglow since it conflicts with runtime configuration.";
+    afterglow_period_micros_ = 0;
+    enable_afterglow_ = false;
+  }
+
   if (afterglow_period_micros_ < 0) {
     CLOG(ERROR) << "Invalid afterglow period " << afterglow_period_micros_ / SECOND << ". ROX_AFTERGLOW_PERIOD must be positive.";
   } else if (afterglow_period_micros_ == 0) {
@@ -304,13 +311,6 @@ void CollectorConfig::HandleAfterglowEnvVars() {
     }
 
     enable_afterglow_ = enable_afterglow.value();
-  }
-
-  if (enable_runtime_config.value() && (afterglow_period_micros_ > 0 || enable_afterglow)) {
-    CLOG(WARNING) << "Afterglow and runtime configuration are both enabled.";
-    CLOG(WARNING) << "Disabling afterglow since it conflicts with runtime configuration.";
-    afterglow_period_micros_ = 0;
-    enable_afterglow_ = false;
   }
 
   CLOG(INFO) << "Afterglow is " << (enable_afterglow_ ? "enabled" : "disabled");


### PR DESCRIPTION
## Description

Disables afterglow when runtime configuration is enabled. The reason for this is that when external IPs is disabled and then enabled the un-normalized connections will be reported as being opened, but the the normalized connections will not be reported as closed until after the afterglow period has ended.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Deployed ACS on a GKE cluster using `deploy/deploy-local.sh`. Replaced the collector image with one from this PR. The connection reported by collector to sensor where logged. Initially there was no ConfigMap. 

Before deploying ACS the following deployment was created

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: external-dns-deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: external-dns-app
  template:
    metadata:
      labels:
        app: external-dns-app
    spec:
      containers:
      - name: dns-app-container
        image: your-image:latest
        ports:
        - containerPort: 8080
        env:
        - name: EXTERNAL_IP
          value: "8.8.8.8"  # Google's Public DNS IP
        - name: EXTERNAL_PORT
          value: "53"  # DNS runs on port 53
        command: ["sh", "-c"]
        args:
        - |
          # Connect to Google's DNS IP
          while true; do
            nc -zv $EXTERNAL_IP $EXTERNAL_PORT;
            sleep 60;
          done

---
apiVersion: v1
kind: Service
metadata:
  name: external-dns-service
spec:
  selector:
    app: external-dns-app
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
  type: ClusterIP
```

The following was found in the collector logs
```
[WARNING 2024/10/14 03:14:54] Afterglow and runtime configuration are both enabled.
[WARNING 2024/10/14 03:14:54] Disabling afterglow since it conflicts with runtime configuration.
[ERROR   2024/10/14 03:14:54] Afterglow period set to 0.
[INFO    2024/10/14 03:14:54] Afterglow is disabled
```
Along with multiple appearances of
```
[INFO    2024/10/14 03:15:57] e6fc998e3178: :::0 -> 255.255.255.255/0:53 [tcp] active:0
```
Note that the address is correctly normalized.

Also
```
[INFO    2024/10/14 03:14:57] ff271d7a4e6c: :::0 -> 255.255.255.255/0:443 [tcp] active:1
```
Both of these connection will be monitored during the course of these tests.

The following ConfigMap was then created
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: collector-config
  namespace: stackrox
data:
  runtime_config.yaml: |
    networkConnectionConfig:
        enableExternalIps: true
```

The following was observed in the collector logs
```
[INFO    2024/10/14 03:24:22] Runtime configuration:
[INFO    2024/10/14 03:24:22] network_connection_config {
  enable_external_ips: true
}

[INFO    2024/10/14 03:24:22] Waiting for file event
```

Along with multiple appearances of.
```
[INFO    2024/10/14 03:24:57] e6fc998e3178: :::0 -> 8.8.8.8:53 [tcp] active:0
```
Note that the IP address is not normalized. Which is correct.

and
```
[INFO    2024/10/14 03:24:27] ff271d7a4e6c: :::0 -> 34.118.224.73:443 [tcp] active:1
[INFO    2024/10/14 03:24:27] ff271d7a4e6c: :::0 -> 255.255.255.255/0:443 [tcp] active:0
```
Here the un-normalized version is reported active and the normalized version is reported closed.

The collector config was then set to
```
apiVersion: v1
data:
  runtime_config.yaml: |
    networkConnectionConfig:
        enableExternalIps: false
kind: ConfigMap
metadata:
  creationTimestamp: "2024-10-14T03:24:04Z"
  name: collector-config
  namespace: stackrox
  resourceVersion: "4122103"
  uid: 062fa805-6289-49c3-b2cf-c21f4160d76a
```

The following was observed in the collector logs
```
[INFO    2024/10/14 03:30:17] Got event event->mask= 1024
[INFO    2024/10/14 03:30:17] event->mask & IN_MODIFY= 0
[INFO    2024/10/14 03:30:17] File was removed
[INFO    2024/10/14 03:30:17] Runtime configuration:
[INFO    2024/10/14 03:30:17] network_connection_config {
}

[INFO    2024/10/14 03:30:17] Got event event->mask= 32768
[INFO    2024/10/14 03:30:17] event->mask & IN_MODIFY= 0
[INFO    2024/10/14 03:30:17] File was removed
[INFO    2024/10/14 03:30:17] Runtime configuration:
[INFO    2024/10/14 03:30:17] network_connection_config {
}

[INFO    2024/10/14 03:30:17] Waiting for file event
```
Along with
```
[INFO    2024/10/14 03:30:58] e6fc998e3178: :::0 -> 255.255.255.255/0:53 [tcp] active:0
```
Note that the IP address is correctly normalized.

and

```
[INFO    2024/10/14 03:30:28] ff271d7a4e6c: :::0 -> 255.255.255.255/0:443 [tcp] active:1
[INFO    2024/10/14 03:30:28] ff271d7a4e6c: :::0 -> 34.118.224.73:443 [tcp] active:0
```

The normalized version is now reported as being open and the un-normalized version is reported closed.

Next the ConfigMap was deleted
```
[INFO    2024/10/14 03:40:51] Got event event->mask= 1024
[INFO    2024/10/14 03:40:51] event->mask & IN_MODIFY= 0
[INFO    2024/10/14 03:40:51] File was removed
```
Also
```
[INFO    2024/10/14 03:40:58] e6fc998e3178: :::0 -> 255.255.255.255/0:53 [tcp] active:0
```
The connection continues to be correctly normalized.

Nothing was reported for `ff271d7a4e6c` as there was no change in the configuration or change in the state of the connection.

Finally the original ConfigMap was created again.

The following was observed in the collector log
```
[INFO    2024/10/14 03:44:26] Runtime configuration:
[INFO    2024/10/14 03:44:26] network_connection_config {
  enable_external_ips: true
}

[INFO    2024/10/14 03:44:26] Got event event->mask= 32768
[INFO    2024/10/14 03:44:26] event->mask & IN_MODIFY= 0
[INFO    2024/10/14 03:44:26] File was removed
[INFO    2024/10/14 03:44:26] Runtime configuration:
[INFO    2024/10/14 03:44:26] network_connection_config {
  enable_external_ips: true
}

[INFO    2024/10/14 03:44:26] Waiting for file event
```

```
[INFO    2024/10/14 03:44:58] e6fc998e3178: :::0 -> 8.8.8.8:53 [tcp] active:0
```
The IP address is correctly un-normalized.

```
[INFO    2024/10/14 03:44:28] ff271d7a4e6c: :::0 -> 34.118.224.73:443 [tcp] active:1
[INFO    2024/10/14 03:44:28] ff271d7a4e6c: :::0 -> 255.255.255.255/0:443 [tcp] active:0
```
The un-normalized version is reported as being active and the normalized version is reported as being inactive.