### PR TITLE
ROX-26528: add rpms-signature-scan task to pipeline

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -563,3 +563,23 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
+  - name: rpms-signature-scan
+    params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: rpms-signature-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -566,10 +566,10 @@ spec:
 
   - name: rpms-signature-scan
     params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
## Description

Add new required task to pipeline. 

> The task should run after the build-container task and assign its IMAGE_URL and IMAGE_DIGEST results to the tasks parameters.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Updated documentation accordingly~

**Automated testing**
  - ~[ ] Added unit tests~
  - ~[ ] Added integration tests~
  - ~[ ] Added regression tests~

If any of these don't apply, please comment below.

## Testing Performed

No new tests required. Konflux CI pipeline passes.
