### PR TITLE
Rename the external-IPs feature-flag [ROX_COLLECTOR_EXTERNAL_IPS_ENABLE]

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -49,7 +49,7 @@ BoolEnvVar set_import_users("ROX_COLLECTOR_SET_IMPORT_USERS", false);
 
 BoolEnvVar collect_connection_status("ROX_COLLECT_CONNECTION_STATUS", true);
 
-BoolEnvVar enable_external_ips("ROX_ENABLE_EXTERNAL_IPS", false);
+BoolEnvVar enable_external_ips("ROX_COLLECTOR_EXTERNAL_IPS_ENABLE", false);
 
 BoolEnvVar enable_connection_stats("ROX_COLLECTOR_ENABLE_CONNECTION_STATS", true);
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -89,7 +89,12 @@ internal state of Collector. Refer to the
 [troubleshooting](troubleshooting.md#introspection-endpoints) section for more details.
 The default is false.
 
-* `ROX_ENABLE_EXTERNAL_IPS`: Enables or disables the external IPs feature.
+* `ROX_COLLECTOR_EXTERNAL_IPS_ENABLE`: Manually enables or disables the external
+IPs feature. When enabled, Collector will send full details about IPs communicating
+with the cluster. When disabled, external IPs are aggregated as an "External sources"
+bucket (unless they match a defined CIDR-block). Runtime configuration is the
+preferred method to control external IPs, and it overrides this variable.
+Default is disabled.
 
 NOTE: Using environment variables is a preferred way of configuring Collector,
 so if you're adding a new configuration knob, keep this in mind.


### PR DESCRIPTION
## Description

Let's start to converge on a normalized feature-flag naming: `ROX_COLLECTOR_<feature>_<option>`

This PR is only about the name of the env-var (and updating the associated doc). The code is not touched.