### PR TITLE
Allow to ignore process arguments

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -83,6 +83,7 @@ PathEnvVar tls_client_key_path("ROX_COLLECTOR_TLS_CLIENT_KEY");
 
 PathEnvVar config_file("ROX_COLLECTOR_CONFIG_PATH", "/etc/stackrox/runtime_config.yaml");
 
+BoolEnvVar disable_process_arguments("ROX_COLLECTOR_NO_PROCESS_ARGUMENTS", false);
 }  // namespace
 
 constexpr bool CollectorConfig::kTurnOffScrape;
@@ -113,6 +114,7 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
   use_podman_ce_ = use_podman_ce.value();
   enable_introspection_ = enable_introspection.value();
   track_send_recv_ = track_send_recv.value();
+  disable_process_arguments_ = disable_process_arguments.value();
 
   for (const auto& syscall : kSyscalls) {
     syscalls_.emplace_back(syscall);

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -132,6 +132,7 @@ class CollectorConfig {
   unsigned int GetSinspThreadCacheSize() const { return sinsp_thread_cache_size_; }
   void Start();
   void Stop();
+  bool DisableProcessArguments() const { return disable_process_arguments_; }
 
   static std::pair<option::ArgStatus, std::string> CheckConfiguration(const char* config, Json::Value* root);
 
@@ -183,6 +184,8 @@ class CollectorConfig {
 
   // URL to the GRPC server
   std::optional<std::string> grpc_server_;
+
+  bool disable_process_arguments_ = false;
 
   // One ring buffer will be initialized for this many CPUs
   unsigned int sinsp_cpu_per_buffer_ = 0;

--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -148,11 +148,13 @@ ProcessSignal* ProcessSignalFormatter::CreateProcessSignal(sinsp_evt* event) {
     signal->set_exec_file_path(name_sanitized ? *name_sanitized : *name);
   }
 
-  // set process arguments
-  if (const char* args = event_extractor_->get_proc_args(event)) {
-    std::string args_str = args;
-    auto args_sanitized = SanitizedUTF8(args_str);
-    signal->set_args(args_sanitized ? *args_sanitized : args_str);
+  // set process arguments, if not explicitely disabled
+  if (!config_.DisableProcessArguments()) {
+    if (const char* args = event_extractor_->get_proc_args(event)) {
+      std::string args_str = args;
+      auto args_sanitized = SanitizedUTF8(args_str);
+      signal->set_args(args_sanitized ? *args_sanitized : args_str);
+    }
   }
 
   // set pid

--- a/collector/lib/ProcessSignalFormatter.cpp
+++ b/collector/lib/ProcessSignalFormatter.cpp
@@ -56,7 +56,12 @@ std::string extract_proc_args(sinsp_threadinfo* tinfo) {
 
 }  // namespace
 
-ProcessSignalFormatter::ProcessSignalFormatter(sinsp* inspector) : event_names_(EventNames::GetInstance()), event_extractor_(std::make_unique<system_inspector::EventExtractor>()), container_metadata_(inspector) {
+ProcessSignalFormatter::ProcessSignalFormatter(
+    sinsp* inspector,
+    const CollectorConfig& config) : event_names_(EventNames::GetInstance()),
+                                     event_extractor_(std::make_unique<system_inspector::EventExtractor>()),
+                                     container_metadata_(inspector),
+                                     config_(config) {
   event_extractor_->Init(inspector);
 }
 

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -3,6 +3,8 @@
 
 #include <memory>
 
+#include <gtest/gtest_prod.h>
+
 #include "api/v1/signal.pb.h"
 #include "internalapi/sensor/signal_iservice.pb.h"
 #include "storage/process_indicator.pb.h"
@@ -39,8 +41,11 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
   void GetProcessLineage(sinsp_threadinfo* tinfo, std::vector<LineageInfo>& lineage);
 
  private:
-  Signal* CreateSignal(sinsp_evt* event);
+  FRIEND_TEST(ProcessSignalFormatterTest, NoProcessArguments);
+  FRIEND_TEST(ProcessSignalFormatterTest, ProcessArguments);
+
   ProcessSignal* CreateProcessSignal(sinsp_evt* event);
+  Signal* CreateSignal(sinsp_evt* event);
   bool ValidateProcessDetails(const sinsp_threadinfo* tinfo);
   bool ValidateProcessDetails(sinsp_evt* event);
   std::string ProcessDetails(sinsp_evt* event);

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -7,6 +7,7 @@
 #include "internalapi/sensor/signal_iservice.pb.h"
 #include "storage/process_indicator.pb.h"
 
+#include "CollectorConfig.h"
 #include "CollectorStats.h"
 #include "ContainerMetadata.h"
 #include "EventNames.h"
@@ -25,7 +26,7 @@ namespace collector {
 
 class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamMessage> {
  public:
-  ProcessSignalFormatter(sinsp* inspector);
+  ProcessSignalFormatter(sinsp* inspector, const CollectorConfig& config);
   ~ProcessSignalFormatter();
 
   using Signal = v1::Signal;
@@ -52,6 +53,8 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
   const EventNames& event_names_;
   std::unique_ptr<system_inspector::EventExtractor> event_extractor_;
   ContainerMetadata container_metadata_;
+
+  const CollectorConfig& config_;
 };
 
 }  // namespace collector

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -5,6 +5,7 @@
 
 #include <grpcpp/channel.h>
 
+#include "CollectorConfig.h"
 #include "ProcessSignalFormatter.h"
 #include "RateLimit.h"
 #include "SignalHandler.h"
@@ -19,8 +20,15 @@ namespace collector {
 
 class ProcessSignalHandler : public SignalHandler {
  public:
-  ProcessSignalHandler(sinsp* inspector, ISignalServiceClient* client, system_inspector::Stats* stats)
-      : client_(client), formatter_(inspector), stats_(stats) {}
+  ProcessSignalHandler(
+      sinsp* inspector,
+      ISignalServiceClient* client,
+      system_inspector::Stats* stats,
+      const CollectorConfig& config)
+      : client_(client),
+        formatter_(inspector, config),
+        stats_(stats),
+        config_(config) {}
 
   bool Start() override;
   bool Stop() override;
@@ -34,6 +42,8 @@ class ProcessSignalHandler : public SignalHandler {
   ProcessSignalFormatter formatter_;
   system_inspector::Stats* stats_;
   RateLimitCache rate_limiter_;
+
+  const CollectorConfig& config_;
 };
 
 }  // namespace collector

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -58,7 +58,8 @@ void Service::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTrac
   }
   AddSignalHandler(MakeUnique<ProcessSignalHandler>(inspector_.get(),
                                                     signal_client_.get(),
-                                                    &userspace_stats_));
+                                                    &userspace_stats_,
+                                                    config));
 
   if (signal_handlers_.size() == 2) {
     // self-check handlers do not count towards this check, because they

--- a/collector/test/ProcessSignalFormatterTest.cpp
+++ b/collector/test/ProcessSignalFormatterTest.cpp
@@ -18,8 +18,9 @@ namespace {
 TEST(ProcessSignalFormatterTest, NoProcessTest) {
   sinsp* inspector = NULL;
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector);
+  ProcessSignalFormatter processSignalFormatter(inspector, config);
 
   sinsp_threadinfo* tinfo = NULL;
   std::vector<LineageInfo> lineage;
@@ -42,8 +43,9 @@ TEST(ProcessSignalFormatterTest, NoProcessTest) {
 TEST(ProcessSignalFormatterTest, ProcessWithoutParentTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 0;
@@ -76,8 +78,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithoutParentTest) {
 TEST(ProcessSignalFormatterTest, ProcessWithParentTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -120,8 +123,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithParentTest) {
 TEST(ProcessSignalFormatterTest, ProcessWithParentWithPid0Test) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 0;
@@ -159,8 +163,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithParentWithPid0Test) {
 TEST(ProcessSignalFormatterTest, ProcessWithParentWithSameNameTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -203,8 +208,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithParentWithSameNameTest) {
 TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -261,8 +267,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsTest) {
 TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsWithTheSameNameTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -316,8 +323,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithTwoParentsWithTheSameNameTest) {
 TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -380,8 +388,9 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameNameTest) {
 TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -447,8 +456,9 @@ TEST(ProcessSignalFormatterTest, ProcessCollapseParentChildWithSameName2Test) {
 TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;
@@ -514,8 +524,9 @@ TEST(ProcessSignalFormatterTest, ProcessWithUnrelatedProcessTest) {
 TEST(ProcessSignalFormatterTest, CountTwoCounterCallsTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 1;
@@ -561,8 +572,9 @@ TEST(ProcessSignalFormatterTest, CountTwoCounterCallsTest) {
 TEST(ProcessSignalFormatterTest, Rox3377ProcessLineageWithNoVPidTest) {
   std::unique_ptr<sinsp> inspector(new sinsp());
   CollectorStats& collector_stats = CollectorStats::GetOrCreate();
+  CollectorConfig config;
 
-  ProcessSignalFormatter processSignalFormatter(inspector.get());
+  ProcessSignalFormatter processSignalFormatter(inspector.get(), config);
 
   auto tinfo = inspector->build_threadinfo();
   tinfo->m_pid = 3;


### PR DESCRIPTION
## Description

Add an internal option to not collect process arguments, as a workaround for [ROX-25845](https://issues.redhat.com/browse/ROX-25845).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [x] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Previous evaluation in the field with the debugging image.