### PR TITLE
Jv integration tests for runtime config

### DIFF
--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -55,12 +55,13 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config) {
 bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& node) {
   const auto& config_file = CONFIG_FILE.value();
 
-  if (node.IsNull() || !node.IsDefined()) {
+  if (node.IsNull() || !node.IsDefined() || !node.IsMap()) {
     CLOG(ERROR) << "Unable to read config from " << config_file;
     return false;
   }
+
   YAML::Node networking_node = node["networking"];
-  if (!networking_node) {
+  if (!networking_node || networking_node.IsNull()) {
     CLOG(DEBUG) << "No networking in " << config_file;
     return true;
   }

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -66,14 +66,22 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigInvalid) {
   }
 }
 
-TEST(CollectorConfigTest, TestYamlConfigToConfigEmpty) {
-  YAML::Node yamlNode = YAML::Load("");
-  CollectorConfig config;
-  ASSERT_FALSE(ConfigLoader::LoadConfiguration(config, yamlNode));
+TEST(CollectorConfigTest, TestYamlConfigToConfigEmptyOrMalformed) {
+  std::vector<std::string> tests = {
+      R"(
+                  asdf
+               )",
+      R"()"};
 
-  auto runtime_config = config.GetRuntimeConfig();
+  for (const auto& yamlStr : tests) {
+    YAML::Node yamlNode = YAML::Load(yamlStr);
+    CollectorConfig config;
+    ASSERT_FALSE(ConfigLoader::LoadConfiguration(config, yamlNode));
 
-  EXPECT_FALSE(runtime_config.has_value());
+    auto runtime_config = config.GetRuntimeConfig();
+
+    EXPECT_FALSE(runtime_config.has_value());
+  }
 }
 
 TEST(CollectorConfigTest, TestPerContainerRateLimit) {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -529,3 +529,7 @@ func TestUdpNetworkFlow(t *testing.T) {
 	}
 	suite.Run(t, new(suites.UdpNetworkFlow))
 }
+
+func TestRuntimeConfigFile(t *testing.T) {
+	suite.Run(t, new(suites.RuntimeConfigFileTestSuite))
+}

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -1,7 +1,6 @@
 package assert
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -60,7 +59,6 @@ func AssertRepeated(t *testing.T, tickTime time.Duration, timeout time.Duration,
 	}
 }
 
->>>>>>> 66ca3aa0 (X-Smart-Squash: Squashed 41 commits:)
 func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool) bool {
 	if len(expected) != len(actual) {
 		return false

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -1,13 +1,66 @@
 package assert
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stackrox/collector/integration-tests/pkg/collector"
+	"github.com/stackrox/collector/integration-tests/pkg/log"
+	"github.com/stackrox/collector/integration-tests/pkg/types"
 )
 
+func AssertExternalIps(t *testing.T, enable bool, collectorIP string) {
+	tickTime := 1 * time.Second
+	timeout := 3 * time.Minute
+	AssertRepeated(t, tickTime, timeout, func() bool {
+		body, err := collector.IntrospectionQuery(collectorIP, "/state/config")
+		assert.NoError(t, err)
+		var response types.RuntimeConfig
+		err = json.Unmarshal(body, &response)
+		assert.NoError(t, err)
+
+		return response.Networking.ExternalIps.Enable == enable
+	})
+}
+
+func AssertNoRuntimeConfig(t *testing.T, collectorIP string) {
+	tickTime := 1 * time.Second
+	timeout := 3 * time.Minute
+	AssertRepeated(t, tickTime, timeout, func() bool {
+		body, err := collector.IntrospectionQuery(collectorIP, "/state/config")
+		assert.NoError(t, err)
+		return strings.TrimSpace(string(body)) == "{}"
+	})
+}
+
+func AssertRepeated(t *testing.T, tickTime time.Duration, timeout time.Duration, condition func() bool) {
+	tick := time.NewTicker(tickTime)
+	timer := time.After(timeout)
+
+	for {
+		select {
+		case <-tick.C:
+			if condition() {
+				// Condition has been met
+				return
+			}
+
+		case <-timer:
+			// TODO: This message should be passed in rather than hard coded here
+			log.Error("Timeout reached: Runtime configuration was not updated")
+			t.FailNow()
+		}
+	}
+}
+
+>>>>>>> 66ca3aa0 (X-Smart-Squash: Squashed 41 commits:)
 func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool) bool {
 	if len(expected) != len(actual) {
 		return false

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -19,7 +19,7 @@ var (
 	runtimeConfigErrorMsg = "Runtime configuration was not updated"
 )
 
-func AssertExternalIps(t *testing.T, enable bool, collectorIP string) {
+func AssertExternalIps(t *testing.T, enabled bool, collectorIP string) {
 	tickTime := 1 * time.Second
 	timeout := 3 * time.Minute
 	AssertRepeated(t, tickTime, timeout, runtimeConfigErrorMsg, func() bool {
@@ -29,7 +29,7 @@ func AssertExternalIps(t *testing.T, enable bool, collectorIP string) {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		return response.Networking.ExternalIps.Enable == enable
+		return response.Networking.ExternalIps.Enable == enabled
 	})
 }
 

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -41,6 +41,7 @@ func NewDockerCollectorManager(e executor.Executor, name string) *DockerCollecto
 		"/host/etc:ro":              "/etc",
 		"/host/usr/lib:ro":          "/usr/lib",
 		"/host/sys/kernel/debug:ro": "/sys/kernel/debug",
+		"/etc/stackrox:ro":          "/tmp/collector-test",
 	}
 
 	return &DockerCollectorManager{

--- a/integration-tests/pkg/collector/introspection.go
+++ b/integration-tests/pkg/collector/introspection.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stackrox/collector/integration-tests/pkg/log"
 )
 
-func (k *K8sCollectorManager) IntrospectionQuery(endpoint string) ([]byte, error) {
-	uri := fmt.Sprintf("http://%s:8080%s", k.IP(), endpoint)
+func IntrospectionQuery(collectorIP string, endpoint string) ([]byte, error) {
+	uri := fmt.Sprintf("http://%s:8080%s", collectorIP, endpoint)
 	resp, err := http.Get(uri)
 	if err != nil {
 		return nil, err

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -90,7 +90,7 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 	}
 
 	connections := s.Connections(containerID)
-	if collectorAssert.ElementsMatchFunc(connections, expected, equal) {
+	if collectorAssert.ElementsMatchFunc(expected, connections, equal) {
 		return true
 	}
 
@@ -100,13 +100,13 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 		select {
 		case <-timer:
 			connections := s.Connections(containerID)
-			return collectorAssert.AssertElementsMatchFunc(t, connections, expected, equal)
+			return collectorAssert.AssertElementsMatchFunc(t, expected, connections, equal)
 		case conn := <-s.LiveConnections():
 			if conn.GetContainerId() != containerID {
 				continue
 			}
 			connections := s.Connections(containerID)
-			if collectorAssert.ElementsMatchFunc(connections, expected, equal) {
+			if collectorAssert.ElementsMatchFunc(expected, connections, equal) {
 				return true
 			}
 		}

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -432,8 +432,8 @@ func (m *MockSensor) pushConnection(containerID string, connection *sensorAPI.Ne
 		CloseTimestamp: connection.GetCloseTimestamp().String(),
 	}
 
-	if _, ok := m.connections[containerID]; ok {
-		m.connections[containerID] = append(m.connections[containerID], conn)
+	if c, ok := m.connections[containerID]; ok {
+		m.connections[containerID] = append(c, conn)
 	} else {
 		m.connections[containerID] = []types.NetworkInfo{conn}
 	}

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -16,7 +16,7 @@ func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
 	return n.Networking.ExternalIps.Enable == other.Networking.ExternalIps.Enable
 }
 
-func (s *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
+func (n *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
 	yamlBytes, err := yaml.Marshal(s)
 
 	if err != nil {

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"gopkg.in/yaml.v3"
+)
+
 type RuntimeConfig struct {
 	Networking struct {
 		ExternalIps struct {
@@ -10,4 +14,14 @@ type RuntimeConfig struct {
 
 func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
 	return n.Networking.ExternalIps.Enable == other.Networking.ExternalIps.Enable
+}
+
+func (s *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
+	yamlBytes, err := yaml.Marshal(s)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(yamlBytes), err
 }

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -17,7 +17,7 @@ func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
 }
 
 func (n *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
-	yamlBytes, err := yaml.Marshal(s)
+	yamlBytes, err := yaml.Marshal(n)
 
 	if err != nil {
 		return "", err

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -1,0 +1,13 @@
+package types
+
+type RuntimeConfig struct {
+	Networking struct {
+		ExternalIps struct {
+			Enable bool
+		}
+	}
+}
+
+func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
+	return n.Networking.ExternalIps.Enable == other.Networking.ExternalIps.Enable
+}

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -3,9 +3,9 @@ package types
 type RuntimeConfig struct {
 	Networking struct {
 		ExternalIps struct {
-			Enable bool
-		}
-	}
+			Enable bool `yaml:"enable"`
+		} `yaml:"externalIps"`
+	} `yaml:"networking"`
 }
 
 func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -459,13 +459,19 @@ func (s *IntegrationTestSuiteBase) execShellCommand(command string) error {
 }
 
 func (s *IntegrationTestSuiteBase) createDirectory(dir string) {
-	cmd := "mkdir " + dir
-	s.execShellCommand(cmd)
+	if _, err := os.Stat(dir); err == nil {
+		return
+	}
+	err := os.Mkdir(dir, os.ModePerm)
+	s.Require().NoError(err)
 }
 
 func (s *IntegrationTestSuiteBase) deleteFile(file string) {
-	cmd := "rm " + file
-	s.execShellCommand(cmd)
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return
+	}
+	err := os.Remove(file)
+	s.Require().NoError(err)
 }
 
 func (s *IntegrationTestSuiteBase) waitForFileToBeDeleted(file string) error {

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -458,6 +458,16 @@ func (s *IntegrationTestSuiteBase) execShellCommand(command string) error {
 	return err
 }
 
+func (s *IntegrationTestSuiteBase) createDirectory(dir string) {
+	cmd := "mkdir " + dir
+	s.execShellCommand(cmd)
+}
+
+func (s *IntegrationTestSuiteBase) deleteFile(file string) {
+	cmd := "rm " + file
+	s.execShellCommand(cmd)
+}
+
 func (s *IntegrationTestSuiteBase) waitForFileToBeDeleted(file string) error {
 	timer := time.After(10 * time.Second)
 	ticker := time.NewTicker(time.Second)

--- a/integration-tests/suites/k8s/namespace.go
+++ b/integration-tests/suites/k8s/namespace.go
@@ -63,7 +63,7 @@ func (k *K8sNamespaceTestSuite) TestK8sNamespace() {
 	for _, tt := range k.tests {
 		endpoint := fmt.Sprintf("/state/containers/%s", tt.containerID)
 		log.Info("Querying: %s", endpoint)
-		raw, err := k.Collector().IntrospectionQuery(endpoint)
+		raw, err := collector.IntrospectionQuery(k.Collector().IP(), endpoint)
 		k.Require().NoError(err)
 		log.Info("Response: %s", raw)
 

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -2,8 +2,8 @@ package suites
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/assert"
@@ -61,25 +61,19 @@ type RuntimeConfigFileTestSuite struct {
 	ClientContainer string
 }
 
-func (s *RuntimeConfigFileTestSuite) createDirectory(dir string) {
-	cmd := "mkdir " + dir
-	s.execShellCommand(cmd)
-}
-
-func (s *RuntimeConfigFileTestSuite) deleteFile(file string) {
-	cmd := "rm " + file
-	s.execShellCommand(cmd)
-}
-
 func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, configStr string) {
 	cmd := "echo '" + configStr + "' > " + runtimeConfigFile
 	s.execShellCommand(cmd)
 }
 
 func (s *RuntimeConfigFileTestSuite) setExternalIpsEnable(runtimeConfigFile string, enable bool) {
-	configStr := `networking:
-  externalIps:
-    enable: ` + strconv.FormatBool(enable)
+	var runtimeConfig types.RuntimeConfig
+	runtimeConfig.Networking.ExternalIps.Enable = enable
+
+	yamlBytes, err := yaml.Marshal(runtimeConfig)
+	s.Require().NoError(err)
+
+	configStr := string(yamlBytes)
 	s.setRuntimeConfig(runtimeConfigFile, configStr)
 }
 

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -1,0 +1,195 @@
+package suites
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/stackrox/collector/integration-tests/pkg/assert"
+	"github.com/stackrox/collector/integration-tests/pkg/collector"
+	"github.com/stackrox/collector/integration-tests/pkg/common"
+	"github.com/stackrox/collector/integration-tests/pkg/config"
+	"github.com/stackrox/collector/integration-tests/pkg/types"
+)
+
+var (
+	normalizedIp = "255.255.255.255"
+	externalIp   = "8.8.8.8"
+	serverPort   = 53
+	externalUrl  = fmt.Sprintf("http://%s:%d", externalIp, serverPort)
+
+	activeNormalizedConnection = types.NetworkInfo{
+		LocalAddress:   "",
+		RemoteAddress:  fmt.Sprintf("%s:%d", normalizedIp, serverPort),
+		Role:           "ROLE_CLIENT",
+		SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+		CloseTimestamp: types.NilTimestamp,
+	}
+
+	activeUnnormalizedConnection = types.NetworkInfo{
+		LocalAddress:   "",
+		RemoteAddress:  fmt.Sprintf("%s:%d", externalIp, serverPort),
+		Role:           "ROLE_CLIENT",
+		SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+		CloseTimestamp: types.NilTimestamp,
+	}
+
+	inactiveNormalizedConnection = types.NetworkInfo{
+		LocalAddress:   "",
+		RemoteAddress:  fmt.Sprintf("%s:%d", normalizedIp, serverPort),
+		Role:           "ROLE_CLIENT",
+		SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+		CloseTimestamp: "Not nill time",
+	}
+
+	inactiveUnnormalizedConnection = types.NetworkInfo{
+		LocalAddress:   "",
+		RemoteAddress:  fmt.Sprintf("%s:%d", externalIp, serverPort),
+		Role:           "ROLE_CLIENT",
+		SocketFamily:   "SOCKET_FAMILY_UNKNOWN",
+		CloseTimestamp: "Not nill time",
+	}
+
+	runtimeConfigDir  = "/tmp/collector-test"
+	runtimeConfigFile = filepath.Join(runtimeConfigDir, "/runtime_config.yaml")
+	collectorIP       = "localhost"
+)
+
+type RuntimeConfigFileTestSuite struct {
+	IntegrationTestSuiteBase
+	ClientContainer string
+}
+
+func (s *RuntimeConfigFileTestSuite) createDirectory(dir string) {
+	cmd := "mkdir " + dir
+	s.execShellCommand(cmd)
+}
+
+func (s *RuntimeConfigFileTestSuite) deleteFile(file string) {
+	cmd := "rm " + file
+	s.execShellCommand(cmd)
+}
+
+func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, configStr string) {
+	cmd := "echo '" + configStr + "' > " + runtimeConfigFile
+	s.execShellCommand(cmd)
+}
+
+func (s *RuntimeConfigFileTestSuite) setExternalIpsEnable(runtimeConfigFile string, enable bool) {
+	configStr := `networking:
+  externalIps:
+    enable: ` + strconv.FormatBool(enable)
+	s.setRuntimeConfig(runtimeConfigFile, configStr)
+}
+
+// Launches collector and creates the directory for runtime configuration.
+func (s *RuntimeConfigFileTestSuite) SetupTest() {
+	s.RegisterCleanup("external-connection")
+
+	s.StartContainerStats()
+
+	containerID, err := s.Executor().StartContainer(
+		config.ContainerStartConfig{
+			Name:    "external-connection",
+			Image:   config.Images().QaImageByKey("qa-alpine-curl"),
+			Command: []string{"sh", "-c", "while true; do curl " + externalUrl + "; sleep 1; done"},
+		})
+	s.Require().NoError(err)
+	s.ClientContainer = common.ContainerShortID(containerID)
+
+	collectorOptions := collector.StartupOptions{
+		Env: map[string]string{
+			"ROX_AFTERGLOW_PERIOD":               "6",
+			"ROX_COLLECTOR_INTROSPECTION_ENABLE": "true",
+		},
+	}
+
+	s.createDirectory(runtimeConfigDir)
+	s.deleteFile(runtimeConfigFile)
+	s.StartCollector(false, &collectorOptions)
+}
+
+func (s *RuntimeConfigFileTestSuite) AfterTest() {
+	s.StopCollector()
+	s.cleanupContainers("external-connection")
+	s.WritePerfResults()
+	s.deleteFile(runtimeConfigFile)
+}
+
+func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {
+	// The runtime config file was deleted before starting collector.
+	// Default configuration is external IPs disabled.
+	// We expect normalized connections.
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
+	expectedConnections := []types.NetworkInfo{activeNormalizedConnection}
+	connectionSuccess := s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// External IPs enabled.
+	// Normalized connection must be reported as inactive
+	// Unnormalized connection will now be reported.
+	s.setExternalIpsEnable(runtimeConfigFile, true)
+	assert.AssertExternalIps(s.T(), true, collectorIP)
+	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// The runtime config file is deleted. This disables external IPs. The normalized connection should be active
+	// and the unnormalized connection shoul be inactive.
+	s.deleteFile(runtimeConfigFile)
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
+	expectedConnections = append(expectedConnections, activeNormalizedConnection, inactiveUnnormalizedConnection)
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// Back to having external IPs enabled.
+	s.setExternalIpsEnable(runtimeConfigFile, true)
+	assert.AssertExternalIps(s.T(), true, collectorIP)
+	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+}
+
+func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileDisable() {
+	// The runtime config file was deleted before starting collector.
+	// Default configuration is external IPs disabled.
+	// We expect normalized connections.
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
+	expectedConnections := []types.NetworkInfo{activeNormalizedConnection}
+	connectionSuccess := s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// The runtime config file is created, but external IPs is disables.
+	// There is no change in the state, so there are no changes to the connections
+	s.setExternalIpsEnable(runtimeConfigFile, false)
+	assert.AssertExternalIps(s.T(), false, collectorIP)
+	common.Sleep(3 * time.Second) // Sleep so that collector has a chance to report connections
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// Back to using default behavior of external IPs disabled with no file.
+	s.deleteFile(runtimeConfigFile)
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
+	common.Sleep(3 * time.Second) // Sleep so that collector has a chance to report connections
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+}
+
+func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileInvalid() {
+	// The runtime config file was deleted before starting collector.
+	// Default configuration is external IPs disabled.
+	// We expect normalized connections.
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
+	expectedConnections := []types.NetworkInfo{activeNormalizedConnection}
+	connectionSuccess := s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+
+	// Testing an invalid configuration. There should not be a change in the configuration or reported connections
+	invalidConfig := "asdf"
+	s.setRuntimeConfig(runtimeConfigFile, invalidConfig)
+	assert.AssertExternalIps(s.T(), false, collectorIP)
+	common.Sleep(3 * time.Second) // Sleep so that collector has a chance to report connections
+	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
+	s.Require().True(connectionSuccess)
+}

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -2,6 +2,7 @@ package suites
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -61,8 +62,8 @@ type RuntimeConfigFileTestSuite struct {
 }
 
 func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, configStr string) {
-	cmd := "echo '" + configStr + "' > " + runtimeConfigFile
-	s.execShellCommand(cmd)
+	err := os.WriteFile(runtimeConfigFile, []byte(configStr), 0666)
+	s.Require().NoError(err)
 }
 
 func (s *RuntimeConfigFileTestSuite) getRuntimeConfigEnabledStr(enabled bool) string {


### PR DESCRIPTION
## Description

Integration tests for runtime configuration. The tests create various versions of the runtime configuration file and check that the configuration introspection endpoint returns the correct expected configuration.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [x] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Ran the integration tests locally 2,000 times without a failure using the following script
```
#!/usr/bin/env bash
set -eou pipefail

for ((i = 0; i < 2000; i=i+1)); do
        echo "i= $i"
        sudo -E make -C integration-tests TestRuntimeConfigFile
done
```
