### PR TITLE
Wait for a container to be running

### DIFF
--- a/integration-tests/pkg/executor/executor_docker_api.go
+++ b/integration-tests/pkg/executor/executor_docker_api.go
@@ -130,6 +130,31 @@ func (d *dockerAPIExecutor) StartContainer(startConfig config.ContainerStartConf
 		return "", errors.Wrapf(err, "start %s", startConfig.Name)
 	}
 
+	RetryWithTimeout(func() (output string, err error) {
+		inspect, err := d.client.ContainerExecInspect(ctx, resp.ID)
+
+		if err != nil {
+			// The client doesn't expose any specific error type in this
+			// case, but "no exec session" is a general error we will see
+			// when a container is not started yet.
+			prefix := "Error response from daemon: no exec session with ID"
+			if strings.HasPrefix(fmt.Sprint(err), prefix) {
+				return NoOutput, err
+			}
+
+			// If it's something outstanding, log it
+			log.Warn("Failed to inspect %s: %+v", startConfig.Name, err)
+			return NoOutput, err
+		}
+
+		if inspect.Running == true {
+			return NoOutput, nil
+		} else {
+			return NoOutput, fmt.Errorf("Container %s is not running",
+				startConfig.Name)
+		}
+	}, fmt.Errorf("Container %s didn't start in time", startConfig.Name))
+
 	log.Info("start %s with %s (%s)\n",
 		startConfig.Name, startConfig.Image, common.ContainerShortID(resp.ID))
 	return resp.ID, nil


### PR DESCRIPTION
## Description

TestProcessListeningOnPort has became flaky in a nasty way, leaving no logs
from the flask container. Most likely reason is that it takes some time to
start the container, while the client method ContainerCreate doesn't wait for
"running" status.

Make the test more robust by waiting until it reports running status. It's been
done using ContainerExecInspect, not ContainerWait, because the latter one
isn't suitable despite the name. ContainerWait [[1]] could only wait for a
non-running state, and is designed to wait until a container has finished it's
job.

[1]: https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerWait

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing, running the flaky test.