### PR TITLE
ROX-26711: Collector mock server should handle external ips

### DIFF
--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -504,11 +504,11 @@ func (m *MockSensor) translateAddress(addr *sensorAPI.NetworkAddress) string {
 	}
 
 	ipNetwork := utils.IPNetworkFromCIDRBytes(ipNetworkData)
-	numBytes := len(ipNetworkData)
 	prefixLen := ipNetwork.PrefixLen()
 	// If this is IPv4 and the prefix length is 32 or this is IPv6 and the prefix length
 	// is 128 this is a regular IP address and not a CIDR block
-	if (numBytes == 5 && prefixLen == byte(32)) || (numBytes == 17 && prefixLen == byte(128)) {
+	if (ipNetwork.Family() == utils.IPv4 && prefixLen == byte(32)) ||
+		(ipNetwork.Family() == utils.IPv6 && prefixLen == byte(128)) {
 		peerId.Address = ipNetwork.IP()
 	} else {
 		peerId.IPNetwork = ipNetwork

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -503,11 +503,12 @@ func (m *MockSensor) translateAddress(addr *sensorAPI.NetworkAddress) string {
 		return peerId.String()
 	}
 
+	ipNetwork := utils.IPNetworkFromCIDRBytes(ipNetworkData)
+	numBytes := len(ipNetworkData)
+	prefixLen := ipNetwork.PrefixLen()
 	// If this is IPv4 and the prefix length is 32 or this is IPv6 and the prefix length
 	// is 128 this is a regular IP address and not a CIDR block
-	ipNetwork := utils.IPNetworkFromCIDRBytes(ipNetworkData)
-	if (len(ipNetworkData) == 5 && ipNetwork.PrefixLen() == byte(32)) ||
-		(len(ipNetworkData) == 17 && ipNetwork.PrefixLen() == byte(128)) {
+	if (numBytes == 5 && prefixLen == byte(32)) || (numBytes == 17 && prefixLen == byte(128)) {
 		peerId.Address = ipNetwork.IP()
 	} else {
 		peerId.IPNetwork = ipNetwork

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -498,9 +498,13 @@ func (m *MockSensor) translateAddress(addr *sensorAPI.NetworkAddress) string {
 			Port:    uint16(addr.GetPort()),
 		}
 	} else {
+		// If there is no address data IpNetwork should be set and represent
+		// a CIDR block or external IP address.
 		ipNetworkData := addr.GetIpNetwork()
 		if len(ipNetworkData) > 0 {
 			ipNetwork := utils.IPNetworkFromCIDRBytes(ipNetworkData)
+			// If the prefix length is 32 this is a regular IP address
+			// and not a CIDR block
 			if ipNetwork.PrefixLen() == byte(32) {
 				address := ipNetwork.IP()
 				ipPortPair = utils.NetworkPeerID{

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -489,8 +489,16 @@ func (m *MockSensor) pushEndpoint(containerID string, endpoint *sensorAPI.Networ
 // translateAddress is a helper function for converting binary representations
 // of network addresses (in the signals) to usable forms for testing
 func (m *MockSensor) translateAddress(addr *sensorAPI.NetworkAddress) string {
+	address := utils.IPFromBytes(addr.GetAddressData())
+	if (address == utils.IPAddress{}) {
+		ipNetworkData := addr.GetIpNetwork()
+		if len(ipNetworkData) > 0 {
+			ipNetworkData = ipNetworkData[:len(ipNetworkData)-1]
+			address = utils.IPFromBytes(ipNetworkData)
+		}
+	}
 	ipPortPair := utils.NetworkPeerID{
-		Address: utils.IPFromBytes(addr.GetAddressData()),
+		Address: address,
 		Port:    uint16(addr.GetPort()),
 	}
 	return ipPortPair.String()

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -496,17 +496,18 @@ func (m *MockSensor) translateAddress(addr *sensorAPI.NetworkAddress) string {
 		return peerId.String()
 	}
 
-	// If there is no address data, IpNetwork should be set and represent
-	// a CIDR block or external IP address.
+	// If there is no address data, this is either the source address or
+	// IpNetwork should be set and represent a CIDR block or external IP address.
 	ipNetworkData := addr.GetIpNetwork()
 	if len(ipNetworkData) == 0 {
 		return peerId.String()
 	}
 
-	// If the prefix length is 32 this is a regular IP address
-	// and not a CIDR block
+	// If this is IPv4 and the prefix length is 32 or this is IPv6 and the prefix length
+	// is 128 this is a regular IP address and not a CIDR block
 	ipNetwork := utils.IPNetworkFromCIDRBytes(ipNetworkData)
-	if ipNetwork.PrefixLen() == byte(32) {
+	if (len(ipNetworkData) == 5 && ipNetwork.PrefixLen() == byte(32)) ||
+		(len(ipNetworkData) == 17 && ipNetwork.PrefixLen() == byte(128)) {
 		peerId.Address = ipNetwork.IP()
 	} else {
 		peerId.IPNetwork = ipNetwork


### PR DESCRIPTION
## Description

This makes it so that the mock server for collector integration tests can handle external IP addresses and CIDR blocks. Currently the mock server can only handle the `AddressData` field of the `NetworkAddress` struct. However, for external IP addressed and CIDR blocks the `IpNetwork` field is used. This change is needed for testing runtime configuration and the external IPs feature. See https://github.com/stackrox/collector/pull/1899

The function modified here is used to convert objects of type `NetworkConnection` to `NetworkInfo`. In the future `NetworkInfo` will not be used and `NetworkConnection` will be used directly. The same will be done for all of the types in ` integration-tests/pkg/types`. See https://issues.redhat.com/browse/ROX-26716

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

The code change here was tested by using it in integration tests here https://github.com/stackrox/collector/pull/1899 