### PR TITLE
ROX-26726: Collector integration tests should record all connections

### DIFF
--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -25,12 +25,10 @@ func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool)
 
 func ListsToAssertMsg[N any](expected []N, actual []N) string {
 	var expectedBuf, actualBuf bytes.Buffer
-	spew.Fdump(&expectedBuf, expected)
-	spew.Fdump(&actualBuf, actual)
 	return fmt.Sprintf(
 		"Expected elements:\n%s\n\nActual elements:\n%s\n",
-		expectedBuf.String(),
-		actualBuf.String(),
+		spew.Sdump(expected),
+		spew.Sdump(actual),
 	)
 }
 

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -36,7 +36,7 @@ func AssertElementsMatchFunc[N any](t *testing.T, expected []N, actual []N, equa
 	match := ElementsMatchFunc(expected, actual, equal)
 	if !match {
 		assertMsg := ListsToAssertMsg(expected, actual)
-		assert.True(t, match, assertMsg)
+		assert.Fail(t, assertMsg)
 	}
 	return match
 }

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -1,10 +1,12 @@
 package assert
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,18 +24,13 @@ func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool)
 }
 
 func ListsToAssertMsg[N any](expected []N, actual []N) string {
-	formatList := func(list []N) string {
-		data, err := json.MarshalIndent(list, "", "  ")
-		if err != nil {
-			return fmt.Sprintf("Failed to format list: %v", err)
-		}
-		return string(data)
-	}
-
+	var expectedBuf, actualBuf bytes.Buffer
+	spew.Fdump(&expectedBuf, expected)
+	spew.Fdump(&actualBuf, actual)
 	return fmt.Sprintf(
 		"Expected elements:\n%s\n\nActual elements:\n%s\n",
-		formatList(expected),
-		formatList(actual),
+		expectedBuf.String(),
+		actualBuf.String(),
 	)
 }
 

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -1,0 +1,47 @@
+package assert
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+
+	for i := range expected {
+		if !equal(expected[i], actual[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func ListsToAssertMsg[N any](expected []N, actual []N) string {
+	formatList := func(list []N) string {
+		data, err := json.MarshalIndent(list, "", "  ")
+		if err != nil {
+			return fmt.Sprintf("Failed to format list: %v", err)
+		}
+		return string(data)
+	}
+
+	return fmt.Sprintf(
+		"Expected elements:\n%s\n\nActual elements:\n%s\n",
+		formatList(expected),
+		formatList(actual),
+	)
+}
+
+func AssertElementsMatchFunc[N any](t *testing.T, expected []N, actual []N, equal func(a, b N) bool) bool {
+	match := ElementsMatchFunc(expected, actual, equal)
+	if !match {
+		assertMsg := ListsToAssertMsg(expected, actual)
+		assert.True(t, match, assertMsg)
+	}
+	return match
+}

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -1,8 +1,6 @@
 package assert
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -24,7 +22,6 @@ func ElementsMatchFunc[N any](expected []N, actual []N, equal func(a, b N) bool)
 }
 
 func ListsToAssertMsg[N any](expected []N, actual []N) string {
-	var expectedBuf, actualBuf bytes.Buffer
 	return fmt.Sprintf(
 		"Expected elements:\n%s\n\nActual elements:\n%s\n",
 		spew.Sdump(expected),

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -86,7 +86,6 @@ func (s *MockSensor) checkIfConnectionsMatchExpected(t *testing.T, connections [
 	}
 
 	if len(connections) == len(expected) {
-		types.SortConnections(connections)
 		for i := range expected {
 			if !expected[i].Equal(connections[i]) {
 				return assert.ElementsMatch(t, expected, connections, "networking connections do not match")

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -103,8 +103,7 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 	types.SortConnections(expected)
 
 	connections := s.SortedConnections(containerID)
-	success := s.checkIfConnectionsMatchExpected(t, connections, expected)
-	if success {
+	if s.checkIfConnectionsMatchExpected(t, connections, expected) {
 		return true
 	}
 

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -2,7 +2,6 @@ package mock_sensor
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -85,7 +85,7 @@ loop:
 func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID string, timeout time.Duration, expected ...types.NetworkInfo) bool {
 	types.SortConnections(expected)
 
-	equal := func(c1 types.NetworkInfo, c2 types.NetworkInfo) bool {
+	equal := func(c1, c2 types.NetworkInfo) bool {
 		return c1.Equal(c2)
 	}
 

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -125,8 +125,7 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 				continue
 			}
 			connections := s.Connections(containerID)
-			success := s.checkIfConnectionsMatchExpected(t, connections, expected)
-			if success {
+			if s.checkIfConnectionsMatchExpected(t, connections, expected) {
 				return true
 			}
 		}

--- a/integration-tests/pkg/mock_sensor/expect_conn.go
+++ b/integration-tests/pkg/mock_sensor/expect_conn.go
@@ -102,7 +102,7 @@ func (s *MockSensor) checkIfConnectionsMatchExpected(t *testing.T, connections [
 func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID string, timeout time.Duration, expected ...types.NetworkInfo) bool {
 	types.SortConnections(expected)
 
-	connections := s.SortedConnections(containerID)
+	connections := s.Connections(containerID)
 	if s.checkIfConnectionsMatchExpected(t, connections, expected) {
 		return true
 	}
@@ -112,7 +112,7 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 	for {
 		select {
 		case <-timer:
-			connections := s.SortedConnections(containerID)
+			connections := s.Connections(containerID)
 			success := s.checkIfConnectionsMatchExpected(t, connections, expected)
 			if !success {
 				return assert.ElementsMatch(t, expected, connections, "networking connections do not match")
@@ -122,7 +122,7 @@ func (s *MockSensor) ExpectSameElementsConnections(t *testing.T, containerID str
 			if conn.GetContainerId() != containerID {
 				continue
 			}
-			connections := s.SortedConnections(containerID)
+			connections := s.Connections(containerID)
 			success := s.checkIfConnectionsMatchExpected(t, connections, expected)
 			if success {
 				return true

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -155,7 +155,9 @@ func (m *MockSensor) Connections(containerID string) []types.NetworkInfo {
 	defer m.networkMutex.Unlock()
 
 	if connections, ok := m.connections[containerID]; ok {
-		return connections
+        conns := make([]types.NetworkInfo, len(connections))
+        copy(conns, connections)
+        return conns
 	}
 	return make([]types.NetworkInfo, 0)
 }

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -32,7 +32,8 @@ const (
 // us to use any comparable type as the key)
 type ProcessMap map[types.ProcessInfo]interface{}
 type LineageMap map[types.ProcessLineage]interface{}
-type ConnMap map[types.NetworkInfo]interface{}
+
+// type ConnMap map[types.NetworkInfo]interface{}
 type EndpointMap map[types.EndpointInfo]interface{}
 
 type MockSensor struct {
@@ -47,7 +48,8 @@ type MockSensor struct {
 	processLineages map[string]LineageMap
 	processMutex    sync.Mutex
 
-	connections  map[string]ConnMap
+	connections map[string][]types.NetworkInfo
+	//connections  map[string]ConnMap
 	endpoints    map[string]EndpointMap
 	networkMutex sync.Mutex
 
@@ -65,8 +67,9 @@ func NewMockSensor(test string) *MockSensor {
 		testName:        test,
 		processes:       make(map[string]ProcessMap),
 		processLineages: make(map[string]LineageMap),
-		connections:     make(map[string]ConnMap),
-		endpoints:       make(map[string]EndpointMap),
+		connections:     make(map[string][]types.NetworkInfo),
+		//connections:     make(map[string]ConnMap),
+		endpoints: make(map[string]EndpointMap),
 	}
 }
 
@@ -155,11 +158,12 @@ func (m *MockSensor) Connections(containerID string) []types.NetworkInfo {
 	defer m.networkMutex.Unlock()
 
 	if connections, ok := m.connections[containerID]; ok {
-		keys := make([]types.NetworkInfo, 0, len(connections))
-		for k := range connections {
-			keys = append(keys, k)
-		}
-		return keys
+		//keys := make([]types.NetworkInfo, 0, len(connections))
+		//for k := range connections {
+		//	keys = append(keys, k)
+		//}
+		//return keys
+		return connections
 	}
 	return make([]types.NetworkInfo, 0)
 }
@@ -171,8 +175,11 @@ func (m *MockSensor) HasConnection(containerID string, conn types.NetworkInfo) b
 	defer m.networkMutex.Unlock()
 
 	if conns, ok := m.connections[containerID]; ok {
-		_, exists := conns[conn]
-		return exists
+		for _, connection := range conns {
+			if connection.Equal(conn) {
+				return true
+			}
+		}
 	}
 
 	return false
@@ -271,7 +278,7 @@ func (m *MockSensor) Stop() {
 
 	m.processes = make(map[string]ProcessMap)
 	m.processLineages = make(map[string]LineageMap)
-	m.connections = make(map[string]ConnMap)
+	m.connections = make(map[string][]types.NetworkInfo)
 	m.endpoints = make(map[string]EndpointMap)
 
 	m.processChannel.Stop()
@@ -432,11 +439,16 @@ func (m *MockSensor) pushConnection(containerID string, connection *sensorAPI.Ne
 		CloseTimestamp: connection.GetCloseTimestamp().String(),
 	}
 
-	if connections, ok := m.connections[containerID]; ok {
-		connections[conn] = true
+	//if connections, ok := m.connections[containerID]; ok {
+	//	connections[conn] = true
+	//} else {
+	//	connections := ConnMap{conn: true}
+	//	m.connections[containerID] = connections
+	//}
+	if _, ok := m.connections[containerID]; ok {
+		m.connections[containerID] = append(m.connections[containerID], conn)
 	} else {
-		connections := ConnMap{conn: true}
-		m.connections[containerID] = connections
+		m.connections[containerID] = []types.NetworkInfo{conn}
 	}
 }
 

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -155,18 +155,12 @@ func (m *MockSensor) Connections(containerID string) []types.NetworkInfo {
 	defer m.networkMutex.Unlock()
 
 	if connections, ok := m.connections[containerID]; ok {
-        conns := make([]types.NetworkInfo, len(connections))
-        copy(conns, connections)
-        return conns
+		conns := make([]types.NetworkInfo, len(connections))
+		copy(conns, connections)
+		types.SortConnections(conns)
+		return conns
 	}
 	return make([]types.NetworkInfo, 0)
-}
-
-func (m *MockSensor) SortedConnections(containerID string) []types.NetworkInfo {
-	connections := m.Connections(containerID)
-	types.SortConnections(connections)
-
-	return connections
 }
 
 // HasConnection returns whether a given connection has been seen for a given

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -166,11 +167,9 @@ func (m *MockSensor) HasConnection(containerID string, conn types.NetworkInfo) b
 	defer m.networkMutex.Unlock()
 
 	if conns, ok := m.connections[containerID]; ok {
-		for _, connection := range conns {
-			if connection.Equal(conn) {
-				return true
-			}
-		}
+		return slices.ContainsFunc(conns, func(c types.NetworkInfo) bool {
+			return c.Equal(conn)
+		})
 	}
 
 	return false

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -160,6 +160,13 @@ func (m *MockSensor) Connections(containerID string) []types.NetworkInfo {
 	return make([]types.NetworkInfo, 0)
 }
 
+func (m *MockSensor) SortedConnections(containerID string) []types.NetworkInfo {
+	connections := m.Connections(containerID)
+	types.SortConnections(connections)
+
+	return connections
+}
+
 // HasConnection returns whether a given connection has been seen for a given
 // container ID
 func (m *MockSensor) HasConnection(containerID string, conn types.NetworkInfo) bool {

--- a/integration-tests/pkg/mock_sensor/server.go
+++ b/integration-tests/pkg/mock_sensor/server.go
@@ -32,8 +32,6 @@ const (
 // us to use any comparable type as the key)
 type ProcessMap map[types.ProcessInfo]interface{}
 type LineageMap map[types.ProcessLineage]interface{}
-
-// type ConnMap map[types.NetworkInfo]interface{}
 type EndpointMap map[types.EndpointInfo]interface{}
 
 type MockSensor struct {
@@ -48,8 +46,7 @@ type MockSensor struct {
 	processLineages map[string]LineageMap
 	processMutex    sync.Mutex
 
-	connections map[string][]types.NetworkInfo
-	//connections  map[string]ConnMap
+	connections  map[string][]types.NetworkInfo
 	endpoints    map[string]EndpointMap
 	networkMutex sync.Mutex
 
@@ -68,8 +65,7 @@ func NewMockSensor(test string) *MockSensor {
 		processes:       make(map[string]ProcessMap),
 		processLineages: make(map[string]LineageMap),
 		connections:     make(map[string][]types.NetworkInfo),
-		//connections:     make(map[string]ConnMap),
-		endpoints: make(map[string]EndpointMap),
+		endpoints:       make(map[string]EndpointMap),
 	}
 }
 
@@ -158,11 +154,6 @@ func (m *MockSensor) Connections(containerID string) []types.NetworkInfo {
 	defer m.networkMutex.Unlock()
 
 	if connections, ok := m.connections[containerID]; ok {
-		//keys := make([]types.NetworkInfo, 0, len(connections))
-		//for k := range connections {
-		//	keys = append(keys, k)
-		//}
-		//return keys
 		return connections
 	}
 	return make([]types.NetworkInfo, 0)
@@ -439,12 +430,6 @@ func (m *MockSensor) pushConnection(containerID string, connection *sensorAPI.Ne
 		CloseTimestamp: connection.GetCloseTimestamp().String(),
 	}
 
-	//if connections, ok := m.connections[containerID]; ok {
-	//	connections[conn] = true
-	//} else {
-	//	connections := ConnMap{conn: true}
-	//	m.connections[containerID] = connections
-	//}
 	if _, ok := m.connections[containerID]; ok {
 		m.connections[containerID] = append(m.connections[containerID], conn)
 	} else {

--- a/integration-tests/pkg/types/network.go
+++ b/integration-tests/pkg/types/network.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"sort"
+)
+
 const (
 	NilTimestamp = "<nil>"
 )
@@ -15,4 +19,40 @@ type NetworkInfo struct {
 func (n *NetworkInfo) IsActive() bool {
 	// no close timestamp means the connection is open, and active
 	return n.CloseTimestamp == NilTimestamp
+}
+
+func (n *NetworkInfo) Equal(other NetworkInfo) bool {
+	return n.LocalAddress == other.LocalAddress &&
+		n.RemoteAddress == other.RemoteAddress &&
+		n.Role == other.Role &&
+		n.SocketFamily == other.SocketFamily &&
+		n.IsActive() == other.IsActive()
+}
+
+func (n *NetworkInfo) Less(other NetworkInfo) bool {
+	if n.LocalAddress != other.LocalAddress {
+		return n.LocalAddress < other.LocalAddress
+	}
+
+	if n.RemoteAddress != other.RemoteAddress {
+		return n.RemoteAddress < other.RemoteAddress
+	}
+
+	if n.Role != other.Role {
+		return n.Role < other.Role
+	}
+
+	if n.SocketFamily != other.SocketFamily {
+		return n.SocketFamily < other.SocketFamily
+	}
+
+	if n.IsActive() != other.IsActive() {
+		return n.IsActive()
+	}
+
+	return false
+}
+
+func SortConnections(connections []NetworkInfo) {
+	sort.Slice(connections, func(i, j int) bool { return connections[i].Less(connections[j]) })
 }


### PR DESCRIPTION
## Description

Currently the mock server only maintains a map where the key is a networking connection, instead of a full list of all connections that it sees, this means that if a connection is opened and closed multiple times it will only save the opening event once. For some tests all of the opening events will need to be recorded. For the runtime configuration tests the same connection will be opened and closed multiple times, so the changes here are needed for it. See https://github.com/stackrox/collector/pull/1899


This PR is built on another PR that makes it so that the mock server can properly handle connections involving external IPs and CIDR blocks. https://github.com/stackrox/collector/pull/1901

Other changes are also made. 

1. The addition of a function that requires that the elements of the list of expected connections matches the elements of the list of observed. This differs from the existing function, which only requires that each expected connection be seen. The old function would tolerate having extra observed connections that were not expected.

2. Connections with different last active timestamps are considered equivalent. 

In the future similar changes will be made for networking endpoints and processes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

The changes in this PR were used to add more integration tests here https://github.com/stackrox/collector/pull/1899