### PR TITLE
Bump Falco to 0.18.1

### DIFF
--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -70,10 +70,7 @@ void Service::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTrac
 
 bool Service::InitKernel(const CollectorConfig& config) {
   if (!inspector_) {
-    // TODO: https://github.com/falcosecurity/libs/pull/2016
-    // Once that change is pulled, fix compilation here by removing the first
-    // 4 arguments.
-    inspector_.reset(new sinsp(false, "", "", "", true));
+    inspector_.reset(new sinsp(true));
 
     // peeking into arguments has a big overhead, so we prevent it from happening
     inspector_->set_snaplen(0);


### PR DESCRIPTION
## Description

Bumping Falco to version 0.18.1 and fixing some compilation errors for our code to be compatible with it.

The new branch can be inspected at [this branch](https://github.com/stackrox/falcosecurity-libs/tree/0.18.1-stackrox) or in this [draft PR](https://github.com/stackrox/falcosecurity-libs/pull/87), (unfortunately, this last one is showing more style changes than I'd like).

Small changes are needed in Falco for fixing compilation as well, so [this PR](https://github.com/stackrox/falcosecurity-libs/pull/88) needs to be merged before this one.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
