### PR TITLE
build: Prevent OOM kills around Collector TAs

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -55,14 +55,7 @@ spec:
       secretName: '{{ git_auth_secret }}'
 
   taskRunSpecs:
-  - pipelineTaskName: clone-repository
-    stepSpecs:
-    - name: create-trusted-artifact
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          memory: 3Gi
+
   # Only adjusting computeResources for amd64 build because
   # multi-arch builds happen off cluster
   - pipelineTaskName: build-container-amd64
@@ -75,6 +68,48 @@ spec:
           cpu: 4
         requests:
           cpu: 4
+    - name: use-trusted-artifact
+      # use-/create-trusted-artifact gets OOM-killed when a cluster is loaded. Bigger mem limits==request should help.
+      computeResources: &ta-resources
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+
+  - pipelineTaskName: clone-repository
+    stepSpecs:
+    - name: create-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: determine-image-tag
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+    - name: create-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-s390x
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-ppc64le
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-arm64
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   timeouts:
     # The pipeline regularly takes >1h to finish.


### PR DESCRIPTION
## Description

Occasionally, I saw `determine-image-tag` failing at `use-trusted-artifact` with OOM. I don't have a working link handy but I think this was the reason for https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/collector-build-gw9zk to fail because https://github.com/stackrox/collector/runs/31840930570 shows this:

![image](https://github.com/user-attachments/assets/c7f83ba1-77ea-4fb0-9311-18e0d4991864)

Note the following in the failure snippet

> Using token for quay.io

it is what gets logged in `use-trusted-artifact` step, e.g.
![image](https://github.com/user-attachments/assets/c08aa190-9e69-403e-a2b2-30c746398945)

There's something special about collector repo that it requires more memory for dealing with TAs.

Failures happen sporadically which I attribute to clusters getting loaded by other tenants and then containers get less memory than `limits` (because OOTB in Konflux `requests` < `limits`).

It's a bit of a question to @tommartensen how he figured that 3Gi is the right value in <https://github.com/stackrox/collector/pull/1843/files#diff-664d74698b59313a5b32d967d3257fc5beb60db5b7c7bc9c08877bddf3701540R62-R65>.

I ran `watch ... kubectl top pod ...` for running pods and saw `create-trusted-artifact` memory usage going over 2Gi.

![image](https://github.com/user-attachments/assets/0551e262-af8e-4067-a323-c6ef98b6de4a)

I couldn't catch `use-trusted-artifact` memory needs this way so just assume 3Gi is not going to be too much.

Otherwise this change pretty straightforward: I applied the same settings to all `create-trusted-artifact`/`use-trusted-artifact` steps that currently exist in the pipeline.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No changes to automated testing.

## Testing Performed

1. Green Konflux CI.
2. I peeked at pods on the cluster to make sure TA step memory limits and requests are indeed 3Gi.