### PR TITLE
ROX-26026: Make `determine-image-tag` recognize git tags

### DIFF
--- a/.tekton/determine-image-tag-task.yaml
+++ b/.tekton/determine-image-tag-task.yaml
@@ -41,4 +41,12 @@ spec:
       dnf -y install git make
 
       .konflux/scripts/fail-build-if-git-is-dirty.sh
-      echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"
+
+      # First, try take git tag if it's a tagged commit.
+      tag="$(git tag --points-at | sort --version-sort | head --lines=1)"
+      if [[ -z "$tag" ]]; then
+        # If not, use make target's output.
+        tag="$(make --quiet --no-print-directory tag)"
+      fi
+
+      echo -n "${tag}$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"

--- a/.tekton/determine-image-tag-task.yaml
+++ b/.tekton/determine-image-tag-task.yaml
@@ -43,10 +43,13 @@ spec:
       .konflux/scripts/fail-build-if-git-is-dirty.sh
 
       # First, try take git tag if it's a tagged commit.
-      tag="$(git tag --points-at | sort --version-sort | head --lines=1)"
+      tag="$(git tag --points-at)"
       if [[ -z "$tag" ]]; then
         # If not, use make target's output.
         tag="$(make --quiet --no-print-directory tag)"
+      elif [[ "$(wc -l <<< "$tag")" -gt 1 ]]; then
+        >&2 echo -e "Error: the HEAD commit has multiple tags, don't know which one to choose:\n$tag"
+        exit 5
       fi
 
       echo -n "${tag}$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"


### PR DESCRIPTION
## Description

- This enables tagged builds with `-fast` suffixes to unblock the work on <https://github.com/stackrox/stackrox/pull/13079>.
- Tag needs to be pushed before the branch as I make no attempt to tweak triggering CEL expression.
- This does not yet attempt to do the full release setup.

## Checklist

- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

After merge:
- [ ] Delete `3.misha.*` tags.

**Automated testing**

No change to automated tests.

## Testing Performed

Checked that:
- [x] CI produces image tagged as `<git-tag>-fast`.
- [x] `version` label in the image is the same `<git-tag>-fast`.
- [x] Konflux CI is happy.
- [x] GHA tests for Konflux-built images are happy in PR.
- [x] Tag pushes get GHA tests triggered (https://github.com/stackrox/collector/pull/1914) and these succeed.