### PR TITLE
Remove --platform from start-builder target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ start-builder: builder teardown-builder
 	docker run -d \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		--pull missing \
-		--platform ${PLATFORM} \
 		-v $(CURDIR):$(CURDIR) \
 		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\
 		-w $(CURDIR) \


### PR DESCRIPTION

## Description

Podman has a bug in it which makes it so when using the --platform argument, it will ignore existing images in cache and always attempt to pull. This is particularly annoying when trying to test a change to the builder image, since running the start-builder target will:
- Build the image from source.
- Pull the image from quay.
- Run the image without the local modifications.

Removing the argument fixes the issue and it should have no major impact on developer workflow, since it is meant to be used locally anyways.

See: containers/podman#24420

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Tested manually a new image is not pulled without the argument.

