### PR TITLE
Add c-ares as a submodule and update to 1.34.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,7 @@
 	path = builder/third_party/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git
 	branch = master
+[submodule "builder/third_party/c-ares"]
+	path = builder/third_party/c-ares
+	url = https://github.com/c-ares/c-ares.git
+	branch = main

--- a/builder/install/30-cares.sh
+++ b/builder/install/30-cares.sh
@@ -12,5 +12,12 @@ cp LICENSE.md "${LICENSE_DIR}/c-ares-${CARES_VERSION}"
 
 mkdir cmake-build
 cd cmake-build
-cmake -DCMAKE_BUILD_TYPE=Release -DCARES_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/usr/local -DCARES_SHARED=OFF -DCARES_STATIC=ON -DCARES_STATIC_PIC=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCARES_INSTALL=ON \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DCARES_SHARED=OFF \
+    -DCARES_STATIC=ON \
+    -DCARES_STATIC_PIC=ON \
+    -DCARES_BUILD_TOOLS=OFF \
+    ..
 cmake --build . --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/30-cares.sh
+++ b/builder/install/30-cares.sh
@@ -7,9 +7,7 @@ if [ -n "${WITH_RHEL_RPMS}" ]; then
     exit 0
 fi
 
-wget "https://github.com/c-ares/c-ares/releases/download/cares-${CARES_VERSION//./_}/c-ares-${CARES_VERSION}.tar.gz"
-tar -zxf "c-ares-${CARES_VERSION}.tar.gz"
-cd "c-ares-${CARES_VERSION}"
+cd third_party/c-ares
 cp LICENSE.md "${LICENSE_DIR}/c-ares-${CARES_VERSION}"
 
 mkdir cmake-build

--- a/builder/install/versions.sh
+++ b/builder/install/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export B64_VERSION=1.2.1
-export CARES_VERSION=1.16.0
+export CARES_VERSION=1.34.2
 export GOOGLETEST_REVISION=release-1.10.0
 export GRPC_REVISION=v1.67.0
 export JQ_VERSION=1.6


### PR DESCRIPTION
## Description

c-ares is added as a submodule in order to unify the way we handle dependencies for the collector builder image. It is also updated to the latest release version.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
