### PR TITLE
Revert "Remove --platform from start-builder target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ start-builder: builder teardown-builder
 	docker run -d \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		--pull missing \
+		--platform ${PLATFORM} \
 		-v $(CURDIR):$(CURDIR) \
 		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\
 		-w $(CURDIR) \


### PR DESCRIPTION
Reverts stackrox/collector#1922

Turns out that argument is needed when building for multi-arch, I'll figure out a different way to work around the podman bug mentioned in the original PR.