### PR TITLE
Always run multi-arch tests for konflux builds

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
   arm64-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || inputs.is-konflux ||
       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     strategy:
       # ensure that if one part of the matrix fails, the
@@ -117,7 +117,7 @@ jobs:
   s390x-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || inputs.is-konflux ||
       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     with:
       vm_type: rhel-s390x
@@ -131,7 +131,7 @@ jobs:
   ppc64le-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
     if: |
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' || inputs.is-konflux ||
       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     with:
       vm_type: rhel-ppc64le


### PR DESCRIPTION
## Description

Konflux always builds multi-arch images and manifests, so we might as well always test all of them.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Successful konflux GHA workflow with all archs in it.
