### PR TITLE
Prevent pulling builder when building from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ ifneq ($(BUILD_BUILDER_IMAGE), false)
 		-t quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG) \
 		-f "$(CURDIR)/builder/Dockerfile" \
 		"$(CURDIR)/builder"
+else
+	docker pull --platform ${PLATFORM} \
+		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)
 endif
 
 collector: check-builder
@@ -82,7 +85,7 @@ endif
 start-builder: builder teardown-builder
 	docker run -d \
 		--name $(COLLECTOR_BUILDER_NAME) \
-		--pull missing \
+		--pull never \
 		--platform ${PLATFORM} \
 		-v $(CURDIR):$(CURDIR) \
 		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\


### PR DESCRIPTION
## Description

This is a workaround to a podman issue in which, adding --platform to a pull command, will cause podman to always pull the image. This is particularly annoying when testing changes to the builder image, since setting it to run will overwrite the local image and pull an existing one instead.

See #1922 for more context.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Run multi-arch steps.