### PR TITLE
build: Konflux cherry-picks for 3.20.3

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -55,14 +55,7 @@ spec:
       secretName: '{{ git_auth_secret }}'
 
   taskRunSpecs:
-  - pipelineTaskName: clone-repository
-    stepSpecs:
-    - name: create-trusted-artifact
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          memory: 3Gi
+
   # Only adjusting computeResources for amd64 build because
   # multi-arch builds happen off cluster
   - pipelineTaskName: build-container-amd64
@@ -75,6 +68,48 @@ spec:
           cpu: 4
         requests:
           cpu: 4
+    - name: use-trusted-artifact
+      # use-/create-trusted-artifact gets OOM-killed when a cluster is loaded. Bigger mem limits==request should help.
+      computeResources: &ta-resources
+        limits:
+          memory: 3Gi
+        requests:
+          memory: 3Gi
+
+  - pipelineTaskName: clone-repository
+    stepSpecs:
+    - name: create-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: determine-image-tag
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: prefetch-dependencies
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+    - name: create-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-s390x
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-ppc64le
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-container-arm64
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   timeouts:
     # The pipeline regularly takes >1h to finish.

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/application: acs
     appstudio.openshift.io/component: collector
     pipelines.appstudio.openshift.io/type: build
-  name: collector-build
+  name: collector-on-push
   namespace: rh-acs-tenant
 
 spec:

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -208,6 +208,9 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
 
   - name: build-container-amd64
     params:
@@ -394,6 +397,8 @@ spec:
       - $(tasks.build-container-s390x.results.IMAGE_REF)
       - $(tasks.build-container-ppc64le.results.IMAGE_REF)
       - $(tasks.build-container-arm64.results.IMAGE_REF)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
     taskRef:
       params:
       - name: name
@@ -425,6 +430,8 @@ spec:
       - $(tasks.build-container-s390x.results.IMAGE_REF)
       - $(tasks.build-container-ppc64le.results.IMAGE_REF)
       - $(tasks.build-container-arm64.results.IMAGE_REF)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
     taskRef:
       params:
       - name: name
@@ -526,6 +533,8 @@ spec:
     params:
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
@@ -583,3 +592,25 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    taskRef:
+      params:
+      - name: name
+        value: push-dockerfile-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:a28f33b69b270c4e8def293ff6d19ecc9789e1fee5a5929f1250a2e6cbabed81
+      - name: kind
+        value: task
+      resolver: bundles


### PR DESCRIPTION
## Description

This cherry-picks the following PRs currently marked with `backport-for-4.6-konflux-release` label:
- https://github.com/stackrox/collector/pull/1913
- https://github.com/stackrox/collector/pull/1916
- https://github.com/stackrox/collector/pull/1932

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~
- [ ] Post-merge: remove `backport-for-4.6-konflux-release` label from the above-mentioned PRs.

**Automated testing**

No change.

## Testing Performed

Only Konflux CI.