### PR TITLE
[integration-test] Remove a duplicated expected listening endpoint

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -103,19 +103,6 @@ func TestProcfsScraper(t *testing.T) {
 					ProcessExecFilePath: "/usr/sbin/nginx",
 					ProcessArgs:         "",
 				},
-			}, {
-				Protocol:       "L4_PROTOCOL_TCP",
-				CloseTimestamp: types.NilTimestamp,
-				Address: types.ListenAddress{
-					AddressData: "\x00\x00\x00\x00",
-					Port:        80,
-					IpNetwork:   "\x00\x00\x00\x00 ",
-				},
-				Originator: types.ProcessOriginator{
-					ProcessName:         "nginx",
-					ProcessExecFilePath: "/usr/sbin/nginx",
-					ProcessArgs:         "",
-				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

One of the expected endpoints in the ProfsScraper integration-test seems to be duplicated.

Remove it.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

