### PR TITLE
Prevent overwriting test logs on multi VM tests

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -99,7 +99,7 @@ jobs:
         if: |
            failure() && !inputs.run-benchmarks
         with:
-          paths: integration-tests/container-logs/**/integration-test-report.xml
+          paths: integration-tests/container-logs/**/integration-test-report-*.xml
 
       - name: Create Benchmark VMs
         if: inputs.run-benchmarks

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -136,7 +136,7 @@
     - name: Write integration test log
       copy:
         content: "{{ test_result.stdout }}"
-        dest: "{{ logs_root }}/integration-test.log"
+        dest: "{{ logs_root }}/integration-test-{{ vm_config }}.log"
       delegate_to: localhost
 
     - name: Get core dump file paths
@@ -160,7 +160,8 @@
         chdir: "{{ integration_tests_root }}"
         target: report
       environment:
-        LOG_FILE: "{{ logs_root }}/integration-test.log"
+        LOG_FILE: "{{ logs_root }}/integration-test-{{ vm_config }}.log"
+        JUNIT_FILE: "integration-test-report-{{ vm_config }}.xml"
       delegate_to: localhost
 
   # If this host is just for a certain collection method, skip running

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -106,17 +106,18 @@ benchmark: TestBenchmarkCollector
 baseline: TestBenchmarkBaseline
 
 LOG_FILE ?= integration-test.log
+JUNIT_FILE ?= integration-test-report.xml
 .PHONY: report
 report:
 	go install github.com/jstemmer/go-junit-report/v2@latest
 	@echo "+ $@"
-	@cat $(LOG_FILE) | go-junit-report > `dirname $(LOG_FILE)`/integration-test-report.xml
+	@cat $(LOG_FILE) | go-junit-report > `dirname $(LOG_FILE)`/$(JUNIT_FILE)
 	@echo
 	@echo "Test coverage summary:"
 	@grep "^coverage: " -A1 $(LOG_FILE) | grep -v -e '--' | paste -d " "  - -
 	@echo
 	@echo "Test pass/fail summary:"
-	@grep failures `dirname $(LOG_FILE)`/integration-test-report.xml | awk -vOFS="  " 'NF > 0 { $$1 = $$1 } 1'
+	@grep failures `dirname $(LOG_FILE)`/$(JUNIT_FILE) | awk -vOFS="  " 'NF > 0 { $$1 = $$1 } 1'
 	@echo
 	@echo "`grep 'FAIL  github.com/stackrox/collector' $(LOG_FILE) | wc -l` package(s) detected with compilation or test failures."
 	@-grep 'FAIL    github.com/stackrox/collector' $(LOG_FILE) || true

--- a/integration-tests/suites/process_network.go
+++ b/integration-tests/suites/process_network.go
@@ -2,6 +2,7 @@ package suites
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/stackrox/collector/integration-tests/pkg/common"
@@ -26,6 +27,10 @@ func (s *ProcessNetworkTestSuite) SetupSuite() {
 	s.RegisterCleanup("nginx", "nginx-curl")
 	s.StartContainerStats()
 	s.StartCollector(false, nil)
+
+	if strings.Contains(config.VMInfo().Config, "2404") {
+		s.FailNow("Testing failure on Ubuntu 24.04")
+	}
 
 	image_store := config.Images()
 


### PR DESCRIPTION
## Description

When running integration tests on multiple VMs with ansible, the logs
generated may be overwritten as the different VMs end. This also causes
the reports on the test summary to only show the result for the VMs that
finish last. This situation is fine if all VMs have the same failures,
but when only one of them is failing, (i.e: a verifier issue on a
specific kernel) the error can get masked and incorrectly show all tests
have passed.

In order to fix this issue, logs and reports generated by CI should now
have the VM name as part of their file name.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Check a unique failure on multi VM tests is preserved on CI.
- [ ] Check all logs are kept.
