### PR TITLE
Build bpftool from source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,7 +48,7 @@
 [submodule "third_party/libbpf"]
 	path = builder/third_party/libbpf
 	url = https://github.com/libbpf/libbpf
-	branch = v1.3.0
+	branch = v1.3.4
 [submodule "builder/third_party/gperftools"]
 	path = builder/third_party/gperftools
 	url = https://github.com/gperftools/gperftools.git
@@ -68,3 +68,7 @@
 	path = builder/third_party/tbb
 	url = https://github.com/oneapi-src/oneTBB.git
 	branch = master
+[submodule "builder/third_party/bpftool"]
+	path = builder/third_party/bpftool
+	url = https://github.com/libbpf/bpftool
+	branch = v7.3.0

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y update \
         bison \
         ca-certificates \
         clang-17.0.6 \
+        llvm-17.0.6 \
         cmake \
         cracklib-dicts \
         diffutils \
@@ -42,7 +43,6 @@ RUN dnf -y update \
         valgrind \
         wget \
         which \
-        bpftool \
         # for USDT support
         systemtap-sdt-devel \
     && dnf clean all

--- a/builder/install/90-bpftool.sh
+++ b/builder/install/90-bpftool.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd third_party/bpftool
+
+# Replace libbpf with our submodule
+rm -rf libbpf/
+ln -s ../libbpf libbpf
+
+mkdir src/build
+make V=1 -C src ${NPROCS:+-j ${NPROCS}} all install

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -19,7 +19,7 @@ RUN /tmp/.konflux/scripts/subscription-manager-bro.sh register /mnt && \
         wget \
         unzip \
         clang \
-        bpftool \
+        llvm \
         cmake-3.18.2-9.el8 \
         gcc-c++ \
         openssl-devel \


### PR DESCRIPTION


## Description

Downstream builds with ubi 8, which ships a bpftool that is old and doesn't work with the latest Falco changes on Arm and Z. In order to circumvent this, we can simply build from source.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
CI is enough.
