### PR TITLE
ROX-26784: Configure tekton pipelines for release branch

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -8,7 +8,13 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" || (
+        event == "push" && (
+          target_branch.startsWith("release-") ||
+          target_branch.startsWith("refs/tags/")
+        )
+      )
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: collector-4-6

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-3.20" && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-3.20" || target_branch.matches("^3\\.20\\..?")) && event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: collector-4-6

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: (target_branch == "release-3.20" || target_branch.matches("^3\\.20\\..?")) && event in ["push", "pull_request"]
+    pipelinesascode.tekton.dev/on-cel-expression: event in ["push", "pull_request"]
   labels:
     appstudio.openshift.io/application: acs-4-6
     appstudio.openshift.io/component: collector-4-6

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -8,11 +8,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      (event == "push" && target_branch.matches("^(master|release-.*)$")) || event == "pull_request"
+    pipelinesascode.tekton.dev/on-cel-expression: target_branch == "release-3.20" && event in ["push", "pull_request"]
   labels:
-    appstudio.openshift.io/application: acs
-    appstudio.openshift.io/component: collector
+    appstudio.openshift.io/application: acs-4-6
+    appstudio.openshift.io/component: collector-4-6
     pipelines.appstudio.openshift.io/type: build
   name: collector-on-push
   namespace: rh-acs-tenant


### PR DESCRIPTION
There are a couple of changes to the PipelineRun files:

* Update application and component names to match the ACS 4.6 release versions
* Update the CEL expression to only run ACS 4.6 pipelines on Collector 3.20 PRs and pushes. All PRs to the release-3.20 branch will trigger Konflux builds.