### PR TITLE
Remove krb5-libs from the final image.

### DIFF
--- a/collector/container/rhel/install.sh
+++ b/collector/container/rhel/install.sh
@@ -8,6 +8,6 @@ microdnf install -y elfutils-libelf
 microdnf clean all
 # shellcheck disable=SC2046
 rpm --verbose -e --nodeps $(
-    rpm -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*'
+    rpm -qa 'curl' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*' 'libyaml*' 'libarchive*' 'krb5-libs'
 )
 rm -rf /var/cache/yum


### PR DESCRIPTION
## Description

krb5 is not used by Collector and triggers vulnerability scanners. Remove it.

## Checklist
- [ ] Investigated and inspected CI test results
