### PR TITLE
Build the builder image on native systems

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -23,7 +23,8 @@ jobs:
     name: Determine if builder image needs to be built
     runs-on: ubuntu-24.04
     outputs:
-      build-image: ${{ steps.changed.outputs.builder-changed }}
+      build-image: ${{ steps.check-builder.outputs.build-image }}
+      build-multiarch: ${{ steps.build-multiarch.outputs.build-multiarch }}
       collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
 
     steps:
@@ -52,6 +53,60 @@ jobs:
           echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
           echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Check if the builder image should be built
+        id: check-builder
+        run: |
+          function build_builder() {
+            echo "build-image=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [[ "${{ steps.changed.outputs.builder-changed }}" == "true" ]]; then
+            build_builder "true"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            build_builder "true"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            if [[ "${GITHUB_REF_TYPE}" == "tag" || "${GITHUB_REF_NAME}" == release-* ]]; then
+              build_builder "true"
+            fi
+
+            build_builder "false"
+          fi
+
+          # If we got here, we are on a PR event
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'build-builder-image') }}" == "true" ]]; then
+            build_builder "true"
+          fi
+
+          build_builder "false"
+
+      - name: Specify if multiarch image should be built
+        id: build-multiarch
+        run: |
+          function run_multiarch() {
+            echo "build-multiarch=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [[ "${{ steps.check-builder.outputs.build-image }}" == "false" ]]; then
+            run_multiarch "false"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # PRs only run multiarch on demand
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') }}" == "true" ]]; then
+              run_multiarch "true"
+            fi
+            run_multiarch "false"
+          fi
+
+          # Events that are not on PRs always run multiarch
+          run_multiarch "true"
+
   build-builder-image:
     name: Build the builder image
     runs-on: ubuntu-24.04
@@ -59,13 +114,7 @@ jobs:
     timeout-minutes: 480
     needs:
     - builder-needs-rebuilding
-    if: |
-      needs.builder-needs-rebuilding.outputs.build-image == 'true' ||
-      (github.event_name == 'push' && (
-        github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
-      )) ||
-      contains(github.event.pull_request.labels.*.name, 'build-builder-image') ||
-      github.event_name == 'schedule'
+    if: needs.builder-needs-rebuilding.outputs.build-image == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -118,14 +167,7 @@ jobs:
     timeout-minutes: 480
     needs:
     -  builder-needs-rebuilding
-    if: |
-      needs.builder-needs-rebuilding.outputs.build-image == 'true' || (
-        github.event_name == 'push' && (
-        github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
-      )) || (
-        contains(github.event.pull_request.labels.*.name, 'build-builder-image') &&
-        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-      ) || github.event_name == 'schedule'
+    if: needs.builder-needs-rebuilding.outputs.build-multiarch == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -206,11 +248,7 @@ jobs:
     - build-builder-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name != 'pull_request' || (
-        needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
-        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-      )
+    if : needs.builder-needs-rebuilding.outputs.build-multiarch == 'true'
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x arm64
@@ -250,10 +288,7 @@ jobs:
     - build-builder-image
     name: Retag x86 builder image
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
-      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+    if : needs.builder-needs-rebuilding.outputs.build-multiarch == 'false'
     env:
       COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
     steps:

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -11,7 +11,7 @@ on:
     outputs:
       collector-builder-tag:
         description: The builder tag used by the build
-        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag || 'master' }}
+        value: ${{ jobs.builder-needs-rebuilding.outputs.collector-builder-tag || 'master' }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       build-image: ${{ steps.changed.outputs.builder-changed }}
+      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +38,19 @@ jobs:
               - builder/third_party/**
               - builder/Dockerfile
               - .github/workflows/collector-builder.yml
+
+      - name: Define builder tag
+        id: builder-tag
+        run: |
+          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
+          if [[ "${{ github.event_name }}" == 'pull_request' || \
+                "${{ github.ref_type }}" == 'tag' || \
+                "${{ github.ref_name }}" =~ ^release- ]]; then
+            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
+          fi
+
+          echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
+          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
 
   build-builder-image:
     name: Build the builder image
@@ -52,16 +66,15 @@ jobs:
       )) ||
       contains(github.event.pull_request.labels.*.name, 'build-builder-image') ||
       github.event_name == 'schedule'
-    outputs:
-      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, s390x, arm64]
+        arch: [amd64]
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
       BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -74,13 +87,65 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create ansible vars
+        run: |
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          clone_repository: false
+          EOF
+
+      - name: Build images
+        timeout-minutes: 480
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e arch='${{ matrix.arch }}' \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-builder.yml
+
+  build-builder-image-remote-vm:
+    name: Build the builder image on a native VM
+    runs-on: ubuntu-24.04
+    timeout-minutes: 480
+    needs:
+    -  builder-needs-rebuilding
+    if: |
+      needs.builder-needs-rebuilding.outputs.build-image == 'true' || (
+        github.event_name == 'push' && (
+        github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
+      )) || (
+        contains(github.event.pull_request.labels.*.name, 'build-builder-image') &&
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      ) || github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ppc64le, s390x, arm64]
+
+    env:
+      PLATFORM: linux/${{ matrix.arch }}
+      BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_SVC_ACCT }}'
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS_COLLECTOR_CI_VM_SVC_ACCT }}'
 
       - uses: 'google-github-actions/setup-gcloud@v2'
 
@@ -95,63 +160,33 @@ jobs:
           ppc64le-key: ${{ secrets.IBM_CLOUD_POWER_API_KEY }}
           redhat-username: ${{ secrets.REDHAT_USERNAME }}
           redhat-password: ${{ secrets.REDHAT_PASSWORD }}
-          vm-type: all
+          # TODO: this only works because RHEL VMs for power, Z and arm only
+          # have a single VM each, we might need to define builder VMs
+          # explicitly in ansible/group_vars/all.yml
+          vm-type: rhel-${{ matrix.arch }}
           job-tag: builder
 
       - name: Create Build VMs
-        if: |
-          matrix.arch == 's390x' &&
-          (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
 
-      - name: Define builder tag
-        id: builder-tag
-        run: |
-          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
-          if [[ "${{ github.event_name }}" == 'pull_request' || \
-                "${{ github.ref_type }}" == 'tag' || \
-                "${{ github.ref_name }}" =~ ^release- ]]; then
-            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
-          fi
-
-          echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
-          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Create ansible vars
         run: |
-          {
-            echo "---"
-            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
-            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
-            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
-            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
-            echo "collector_git_ref: ${{ github.ref }}"
-            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
-          } > ${{ github.workspace }}/ansible/secrets.yml
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          clone_repository: true
+          EOF
 
       - name: Build images
-        if: |
-          (github.event_name != 'pull_request' && matrix.arch != 's390x') ||
-          matrix.arch == 'amd64' ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
         timeout-minutes: 480
         run: |
           ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook \
-            --connection local \
-            -i localhost, \
-            --limit localhost \
-            -e arch='${{ matrix.arch }}' \
-            -e @'${{ github.workspace }}/ansible/secrets.yml' \
-            ansible/ci-build-builder.yml
-
-      - name: Build s390x images
-        if: |
-          (github.event_name != 'pull_request' && matrix.arch == 's390x') ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
-        timeout-minutes: 480
-        run: |
           ansible-playbook \
             -i ansible/ci \
             -e build_hosts='job_id_${{ env.JOB_ID }}' \
@@ -160,21 +195,24 @@ jobs:
             ansible/ci-build-builder.yml
 
       - name: Destroy VMs
-        if: always() && matrix.arch == 's390x'
+        if: always()
         run: |
           make -C ansible destroy-vms
 
   create-multiarch-manifest:
     needs:
+    - builder-needs-rebuilding
     - build-builder-image
+    - build-builder-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-24.04
     if: |
-      github.event_name != 'pull_request' ||
-      (needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
+      github.event_name != 'pull_request' || (
+        needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
+        contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      )
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
       ARCHS: amd64 ppc64le s390x arm64
 
     steps:
@@ -208,15 +246,16 @@ jobs:
 
   retag-x86-image:
     needs:
+    - builder-needs-rebuilding
     - build-builder-image
     name: Retag x86 builder image
     runs-on: ubuntu-24.04
     if: |
       github.event_name == 'pull_request' &&
-      needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
+      needs.builder-needs-rebuilding.outputs.collector-builder-tag != 'master' &&
       !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
     steps:
       - name: Pull image to retag
         run: |

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -22,7 +22,7 @@
         version: "{{ local_branch }}"
         refspec: "+{{ collector_git_ref | replace('refs/', '') }}:{{ local_branch }}"
         recursive: true
-      when: arch == "s390x"
+      when: clone_repository
 
     - name: Build the collector builder image
       community.general.make:

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -29,51 +29,29 @@
         chdir: "{{ ansible_env.GITHUB_WORKSPACE | default(collector_root) }}"
         target: builder
 
-    - name: Retag collector builder image to arch specific
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        repository: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        source: local
-
-    - name: Untag collector builder image to prevent issues with multiarch
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
-        state: absent
-
-    - name: Login to quay.io
-      community.docker.docker_login:
-        registry_url: quay.io
+    - name: Retag and push to stackrox-io
+      ansible.builtin.include_role:
+        name: push-image
+      vars:
+        original_image: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}"
+        target_image: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        untag_original: true
         username: "{{ stackrox_io_username }}"
         password: "{{ stackrox_io_password }}"
 
-    - name: Push builder image to quay.io/stackrox-io
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        push: true
-        source: local
-
-    - name: Login to quay.io
-      community.docker.docker_login:
-        registry_url: quay.io
+    - name: Retag and push to rhacs-eng
+      ansible.builtin.include_role:
+        name: push-image
+      vars:
+        original_image: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        target_image: "quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
+        untag_original: false
         username: "{{ rhacs_eng_username }}"
         password: "{{ rhacs_eng_password }}"
 
-    - name: Push builder image to quay.io/rhacs-eng
-      community.docker.docker_image:
-        name: "quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        repository: "quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-        push: true
-        source: local
-
     - name: Print builder images pushed
-      debug:
+      ansible.builtin.debug:
         msg:
           - "Pushed the following builder images:"
           - "  quay.io/stackrox-io/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
           - "  quay.io/rhacs-eng/collector-builder:{{ ansible_env.COLLECTOR_BUILDER_TAG }}-{{ arch }}"
-
-    - name: Logout of quay.io
-      community.docker.docker_login:
-        registry_url: quay.io
-        state: absent
-      when: true

--- a/ansible/ci-build-builder.yml
+++ b/ansible/ci-build-builder.yml
@@ -28,6 +28,8 @@
       community.general.make:
         chdir: "{{ ansible_env.GITHUB_WORKSPACE | default(collector_root) }}"
         target: builder
+      environment:
+        BUILDAH_FORMAT: 'docker'
 
     - name: Retag and push to stackrox-io
       ansible.builtin.include_role:

--- a/ansible/ci-create-build-vms.yml
+++ b/ansible/ci-create-build-vms.yml
@@ -8,9 +8,11 @@
       include_role:
         name: create-all-vms
       vars:
-        vm_list:
-          # s390x
-          rhel-s390x: "{{ virtual_machines['rhel-s390x'] }}"
+        vm_list: "{{ virtual_machines }}"
+  post_tasks:
+    # We have all the VMs created now, so refresh the inventory - this allows
+    # us to use the provisioning role on the VMs we just created
+    - meta: refresh_inventory
 
 - name: Provision Build VMs
   hosts: "job_id_{{ job_id }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -95,10 +95,6 @@ virtual_machines:
   sles:
     project: suse-cloud
     families:
-      # Disable SLES-12 as it currently relies on kernel-modules
-      # that are no longer built.
-      # See https://github.com/stackrox/collector/issues/1141 for details.
-      #- sles-12
       - sles-15
     container_engine: podman
 

--- a/ansible/roles/provision-vm/tasks/redhat.yml
+++ b/ansible/roles/provision-vm/tasks/redhat.yml
@@ -32,6 +32,7 @@
     name:
       - git
       - make
+      - python3-requests
 
 - name: Add docker repos
   ansible.builtin.shell: |

--- a/ansible/roles/push-image/tasks/docker.yml
+++ b/ansible/roles/push-image/tasks/docker.yml
@@ -1,0 +1,30 @@
+---
+- name: Retag image to arch specific
+  community.docker.docker_image:
+    name: "{{ original_image }}"
+    repository: "{{ target_image }}"
+    source: local
+
+- name: Untag collector builder image to prevent issues with multiarch
+  community.docker.docker_image:
+    name: "{{ original_image }}"
+    state: absent
+  when: untag_original
+
+- name: Login to quay.io
+  community.docker.docker_login:
+    registry_url: quay.io
+    username: "{{ username }}"
+    password: "{{ password }}"
+
+- name: Push builder image to quay.io/stackrox-io
+  community.docker.docker_image:
+    name: "{{ target_image }}"
+    push: true
+    source: local
+
+- name: Logout of quay.io
+  community.docker.docker_login:
+    registry_url: quay.io
+    state: absent
+  when: true

--- a/ansible/roles/push-image/tasks/main.yml
+++ b/ansible/roles/push-image/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Tag an push image with docker
+  ansible.builtin.include_tasks: docker.yml
+  when: runtime_command == 'docker'
+
+- name: Tag an push image with podman
+  ansible.builtin.include_tasks: podman.yml
+  when: runtime_command == 'podman'

--- a/ansible/roles/push-image/tasks/podman.yml
+++ b/ansible/roles/push-image/tasks/podman.yml
@@ -1,0 +1,20 @@
+---
+- name: Retag image to arch specific
+  containers.podman.podman_tag:
+    image: "{{ original_image }}"
+    target_names:
+      - "{{ target_image }}"
+
+- name: Untag original image to prevent issues with multiarch
+  containers.podman.podman_image:
+    name: "{{ original_image }}"
+    state: absent
+  when: untag_original
+
+- name: Push target image
+  containers.podman.podman_image:
+    name: "{{ target_image }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    pull: false
+    push: true


### PR DESCRIPTION
## Description

In order to cut down on the time taken to build the builder image, which is currently very long due to QEMU being used on small GHA VMs, we can move the non x86 images to be built on remote VMs hosted on GCP and IBM cloud. We already use these VMs for integration tests and for building s390x images, this is just extending the functionality for ppc64le and arm64.

The changes are based on the ones from #1593.
These changes will break #1838, will look into fixing that after we merge this, since the builder is now taking over 5 hours and I would like us to fix this situation as fast as possible.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
- [x] Run with no labels. ([CI run](https://github.com/stackrox/collector/actions/runs/11893815535/job/33139751318?pr=1960))
- [ ] Run with the `run-multiarch-builds` label. ([CI run](https://github.com/stackrox/collector/actions/runs/11895098561))
- [ ] Run on a test tag. ([CI run](https://github.com/stackrox/collector/actions/runs/11895108355))