### PR TITLE
ROX-18384: remove slim images from upstream

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -190,13 +190,6 @@ jobs:
           base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
           archs: ${{ env.ARCHS }}
 
-      - name: Create and push multiarch manifest for stackrox-io -slim
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -slim
-
       - name: Create and push multiarch manifest for stackrox-io -base
         uses: ./.github/actions/create-multiarch-manifest
         with:
@@ -223,13 +216,6 @@ jobs:
         with:
           base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
           archs: ${{ env.ARCHS }}
-
-      - name: Create and push multiarch manifest for rhacs-eng -slim
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -slim
 
       - name: Create and push multiarch manifest for rhacs-eng -base
         uses: ./.github/actions/create-multiarch-manifest
@@ -266,14 +252,6 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
-      - name: Retag and push stackrox-io -slim
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ inputs.collector-image }}-slim
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
       - name: Retag and push stackrox-io -base
         uses: stackrox/actions/images/retag-and-push@v1
         with:
@@ -295,14 +273,6 @@ jobs:
         with:
           src-image: ${{ inputs.collector-image }}-amd64
           dst-image: ${{ env.RHACS_ENG_IMAGE }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng -slim
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}-slim
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -190,20 +190,6 @@ jobs:
           base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
           archs: ${{ env.ARCHS }}
 
-      - name: Create and push multiarch manifest for stackrox-io -base
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -base
-
-      - name: Create and push multiarch manifest for stackrox-io -latest
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/stackrox-io/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -latest
-
       - name: Login to quay.io/rhacs-eng
         uses: docker/login-action@v3
         with:
@@ -217,24 +203,10 @@ jobs:
           base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
           archs: ${{ env.ARCHS }}
 
-      - name: Create and push multiarch manifest for rhacs-eng -base
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -base
-
-      - name: Create and push multiarch manifest for rhacs-eng -latest
-        uses: ./.github/actions/create-multiarch-manifest
-        with:
-          base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
-          archs: ${{ env.ARCHS }}
-          suffix: -latest
-
   retag-x86-image:
     needs:
     - build-collector-image
-    name: Retag x86 slim image
+    name: Retag x86 image
     runs-on: ubuntu-24.04
     if: |
       github.event_name == 'pull_request' &&
@@ -252,43 +224,11 @@ jobs:
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
-      - name: Retag and push stackrox-io -base
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ inputs.collector-image }}-base
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push stackrox-io -latest
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ inputs.collector-image }}-latest
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
       - name: Retag and push rhacs-eng
         uses: stackrox/actions/images/retag-and-push@v1
         with:
           src-image: ${{ inputs.collector-image }}-amd64
           dst-image: ${{ env.RHACS_ENG_IMAGE }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng -base
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}-base
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng -latest
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}-latest
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -51,9 +51,8 @@ quay.io.
 
 ### Collector image
 
-The `ci-build-collector.yml` playbook is meant to be used by CI, it handles the
-build process for the slim collector image, as well as retagging and pushing
-of these images to quay.io.
+The `ci-build-collector.yml` playbook is meant to be used by CI, it handles
+retagging and pushing of Collector images to quay.io.
 
 #### Environment variables used by the playbook
 

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -63,13 +63,6 @@
         push: true
         source: local
 
-    - name: Push slim to quay.io/stackrox-io
-      community.docker.docker_image:
-        name: "{{ collector_image }}-{{ arch }}"
-        repository: "{{ collector_image }}-{{ arch }}-slim"
-        push: true
-        source: local
-
     - name: Push base to quay.io/stackrox-io
       community.docker.docker_image:
         name: "{{ collector_image }}-{{ arch }}"
@@ -97,13 +90,6 @@
         push: true
         source: local
 
-    - name: Push slim to quay.io/rhacs-eng
-      community.docker.docker_image:
-        name: "{{ rhacs_eng_image }}-{{ arch }}"
-        repository: "{{ rhacs_eng_image }}-{{ arch }}-slim"
-        push: true
-        source: local
-
     - name: Push base to quay.io/rhacs-eng
       community.docker.docker_image:
         name: "{{ rhacs_eng_image }}-{{ arch }}"
@@ -123,11 +109,9 @@
         msg:
         - "Pushed the following images:"
         - "  {{ collector_image }}-{{ arch }}"
-        - "  {{ collector_image }}-{{ arch }}-slim"
         - "  {{ collector_image }}-{{ arch }}-base"
         - "  {{ collector_image }}-{{ arch }}-latest"
         - "  {{ rhacs_eng_image }}-{{ arch }}"
-        - "  {{ rhacs_eng_image }}-{{ arch }}-slim"
         - "  {{ rhacs_eng_image }}-{{ arch }}-base"
         - "  {{ rhacs_eng_image }}-{{ arch }}-latest"
       tags: [print_action]

--- a/ansible/ci-build-collector.yml
+++ b/ansible/ci-build-collector.yml
@@ -63,20 +63,6 @@
         push: true
         source: local
 
-    - name: Push base to quay.io/stackrox-io
-      community.docker.docker_image:
-        name: "{{ collector_image }}-{{ arch }}"
-        repository: "{{ collector_image }}-{{ arch }}-base"
-        push: true
-        source: local
-
-    - name: Push latest to quay.io/stackrox-io
-      community.docker.docker_image:
-        name: "{{ collector_image }}-{{ arch }}"
-        repository: "{{ collector_image }}-{{ arch }}-latest"
-        push: true
-        source: local
-
     - name: Login to quay.io
       community.docker.docker_login:
         registry_url: quay.io
@@ -90,30 +76,12 @@
         push: true
         source: local
 
-    - name: Push base to quay.io/rhacs-eng
-      community.docker.docker_image:
-        name: "{{ rhacs_eng_image }}-{{ arch }}"
-        repository: "{{ rhacs_eng_image }}-{{ arch }}-base"
-        push: true
-        source: local
-
-    - name: Push latest to quay.io/rhacs-eng
-      community.docker.docker_image:
-        name: "{{ rhacs_eng_image }}-{{ arch }}"
-        repository: "{{ rhacs_eng_image }}-{{ arch }}-latest"
-        push: true
-        source: local
-
     - name: Print images pushed
       debug:
         msg:
         - "Pushed the following images:"
         - "  {{ collector_image }}-{{ arch }}"
-        - "  {{ collector_image }}-{{ arch }}-base"
-        - "  {{ collector_image }}-{{ arch }}-latest"
         - "  {{ rhacs_eng_image }}-{{ arch }}"
-        - "  {{ rhacs_eng_image }}-{{ arch }}-base"
-        - "  {{ rhacs_eng_image }}-{{ arch }}-latest"
       tags: [print_action]
 
     - name: Logout of quay.io

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -25,7 +25,7 @@ $ make image
 
 This target will build necessary submodules (gRPC dependencies, Falco
 libraries), prepare a builder image, compile Collector using it, and wrap
-everything into a slim image with Collector binary inside.
+everything into an image with the Collector binary inside.
 
 *NOTE*: Using an intermediate image for compilation means that file paths are
 going to be different between your local project directory and the image. For


### PR DESCRIPTION
## Description

Since we have deprecated *full* images from Collector, we now want to drop the -slim tag for all images, since all image flavours are now inherently slim.

This PR removes upstream slim image tagging from Collector.

There are sibling PRs, which I will list here as they become available, that remove slim image use in other areas (downstream builds and the main repo)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
