### PR TITLE
Adds accept4 to NetworkSignalHandler

### DIFF
--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -162,7 +162,11 @@ std::vector<std::string> NetworkSignalHandler::GetRelevantEvents() {
       "getsockopt<"};
 
   if (track_send_recv_) {
-    std::vector<std::string> extra = {
+    // disable clang-format here because it will massively
+    // indent the initializer list.
+    //
+    // clang-format off
+    base_events.insert(base_events.end(), {
         "sendto<",
         "sendto>",
         "sendmsg<",
@@ -175,10 +179,9 @@ std::vector<std::string> NetworkSignalHandler::GetRelevantEvents() {
         "recvmmsg<",
         "recvmmsg>",
         "recvmsg<",
-        "recvmsg>",
-    };
-
-    base_events.insert(base_events.end(), extra.begin(), extra.end());
+        "recvmsg>"
+    });
+    // clang-format on
   }
   return base_events;
 }

--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -23,6 +23,7 @@ EventMap<Modifier> modifiers = {
         {"shutdown<", Modifier::REMOVE},
         {"connect<", Modifier::ADD},
         {"accept<", Modifier::ADD},
+        {"accept4<", Modifier::ADD},
         {"getsockopt<", Modifier::ADD},
         {"sendto<", Modifier::ADD},
         {"sendto>", Modifier::ADD},
@@ -152,13 +153,16 @@ SignalHandler::Result NetworkSignalHandler::HandleSignal(sinsp_evt* evt) {
 }
 
 std::vector<std::string> NetworkSignalHandler::GetRelevantEvents() {
+  std::vector<std::string> base_events = {
+      "close<",
+      "shutdown<",
+      "connect<",
+      "accept<",
+      "accept4<",
+      "getsockopt<"};
+
   if (track_send_recv_) {
-    return {
-        "close<",
-        "shutdown<",
-        "connect<",
-        "accept<",
-        "getsockopt<",
+    std::vector<std::string> extra = {
         "sendto<",
         "sendto>",
         "sendmsg<",
@@ -173,8 +177,10 @@ std::vector<std::string> NetworkSignalHandler::GetRelevantEvents() {
         "recvmsg<",
         "recvmsg>",
     };
+
+    base_events.insert(base_events.end(), extra.begin(), extra.end());
   }
-  return {"close<", "shutdown<", "connect<", "accept<", "getsockopt<"};
+  return base_events;
 }
 
 bool NetworkSignalHandler::Stop() {


### PR DESCRIPTION
## Description

Accept4 was ignored by the signal handler, resulting in missing connection information, as shown with recent berserker network stress testing. This PR adds the missing syscall. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested on an openshift 4 cluster, using berserker. 
