### PR TITLE
Register SLES VMs before installing podman

### DIFF
--- a/ansible/roles/provision-vm/tasks/sles.yml
+++ b/ansible/roles/provision-vm/tasks/sles.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Register VM
+  command: registercloudguest --force-new
+
 - name: Install podman
   community.general.zypper:
     name: podman

--- a/ansible/roles/provision-vm/tasks/sles.yml
+++ b/ansible/roles/provision-vm/tasks/sles.yml
@@ -2,6 +2,10 @@
 
 - name: Register VM
   command: registercloudguest --force-new
+  register: register_result
+  until: register_result is not failed
+  retries: 5
+  delay: 10
 
 - name: Install podman
   community.general.zypper:


### PR DESCRIPTION
## Description

This fixes the SUSE fix, but first registering the VM which allows us access to the repo in which podman lives.