### PR TITLE
Fix RuntimeConfigFileTestSuite cleanups

### DIFF
--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -466,6 +466,16 @@ func (s *IntegrationTestSuiteBase) createDirectory(dir string) {
 	s.Require().NoError(err)
 }
 
+func (s *IntegrationTestSuiteBase) deleteDirectory(dir string) {
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return
+	}
+
+	err = os.RemoveAll(dir)
+	s.Require().NoError(err)
+}
+
 func (s *IntegrationTestSuiteBase) deleteFile(file string) {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		return

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -104,15 +104,18 @@ func (s *RuntimeConfigFileTestSuite) SetupTest() {
 	}
 
 	s.createDirectory(runtimeConfigDir)
-	s.deleteFile(runtimeConfigFile)
 	s.StartCollector(false, &collectorOptions)
 }
 
-func (s *RuntimeConfigFileTestSuite) AfterTest() {
+func (s *RuntimeConfigFileTestSuite) AfterTest(suiteName, testName string) {
 	s.StopCollector()
 	s.cleanupContainers("external-connection")
 	s.WritePerfResults()
 	s.deleteFile(runtimeConfigFile)
+}
+
+func (s *RuntimeConfigFileTestSuite) TearDownSuite() {
+	s.deleteDirectory(runtimeConfigDir)
 }
 
 func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {


### PR DESCRIPTION


## Description

On top of fixing the `AfterTest` method signature, a suite teardown has been added for removing the /tmp/collector-test directory, this is not strictly needed, but it's good practise to cleanup completely after all tests.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run the `TestRuntimeConfigFile` locally and checked the directory and configuration files are properly cleaned up.