### PR TITLE
ROX-27396: Collector configloader should not need to be modified when the protobuf is

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -108,6 +108,16 @@ class CollectorConfig {
     return enable_external_ips_;
   }
 
+  void RuntimeConfigHeuristics() {
+    auto lock = WriteLock();
+    if (runtime_config_.has_value()) {
+      auto* networking = runtime_config_.value().mutable_networking();
+      if (networking->per_container_rate_limit() == 0) {
+        networking->set_per_container_rate_limit(1024);
+      }
+    }
+  }
+
   int64_t PerContainerRateLimit() const {
     auto lock = ReadLock();
     if (runtime_config_.has_value()) {
@@ -118,7 +128,7 @@ class CollectorConfig {
     return per_container_rate_limit_;
   }
 
-  std::string GetRuntimeConfigStr() {
+  std::string GetRuntimeConfigStr() const {
     auto lock = ReadLock();
     if (runtime_config_.has_value()) {
       const auto& cfg = runtime_config_.value();

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -85,6 +85,11 @@ Json::Value yamlNodeToJson(const YAML::Node& yamlNode) {
 }
 
 bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& node) {
+  // We do multiple conversions here. First convert to JSON, then a JSON string, and then
+  // to the runtime config object. There are more direct ways to do the conversion.
+  // However, those methods make it difficult to handle the different data types.
+  // Here yamlNodeToJson converts everything to strings and JsonStringToMessage then
+  // correctly converts everything to the correct data type.
   const auto jsonConfig = yamlNodeToJson(node);
   Json::StreamWriterBuilder writer;
   std::string jsonStr = Json::writeString(writer, jsonConfig);
@@ -99,6 +104,9 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
   }
 
   config.SetRuntimeConfig(runtimeConfig);
+  config.RuntimeConfigHeuristics();
+  CLOG(INFO) << "Runtime configuration:\n"
+             << config.GetRuntimeConfigStr();
 
   return true;
 }

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -97,6 +97,7 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
   sensor::CollectorConfig runtimeConfig;
   google::protobuf::util::JsonParseOptions parseOptions;
   parseOptions.ignore_unknown_fields = true;
+  parseOptions.case_insensitive_enum_parsing = true;
   auto status = google::protobuf::util::JsonStringToMessage(jsonStr, &runtimeConfig, parseOptions);
   if (!status.ok()) {
     CLOG(ERROR) << "Failed to parse config: " << status.ToString();

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -42,34 +42,16 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
   }
 }
 
-TEST(CollectorConfigTest, TestYamlConfigToConfigInvalid) {
-  std::vector<std::string> tests = {
-      R"(
-                  networking:
-               )",
-      R"(
-                  networking:
-                    unknownFiled: asdf
-               )",
-      R"(
-                  unknownField: asdf
-               )"};
-
-  for (const auto& yamlStr : tests) {
-    YAML::Node yamlNode = YAML::Load(yamlStr);
-    CollectorConfig config;
-    ASSERT_TRUE(ConfigLoader::LoadConfiguration(config, yamlNode));
-
-    auto runtime_config = config.GetRuntimeConfig();
-
-    EXPECT_FALSE(runtime_config.has_value());
-  }
-}
-
 TEST(CollectorConfigTest, TestYamlConfigToConfigEmptyOrMalformed) {
   std::vector<std::string> tests = {
       R"(
                   asdf
+               )",
+      R"(
+                  networking:
+                    externalIps:
+                      enable: false
+                    perContainerRateLimit: invalid
                )",
       R"()"};
 
@@ -89,24 +71,17 @@ TEST(CollectorConfigTest, TestPerContainerRateLimit) {
       {R"(
                   networking:
                     externalIps:
-                      enabled: false
+                      enable: false
                     perContainerRateLimit: 1234
                )",
        1234},
       {R"(
                   networking:
                     externalIps:
-                      enabled: false
+                      enable: false
                     perContainerRateLimit: 1337
                )",
        1337},
-      {R"(
-                  networking:
-                    externalIps:
-                      enabled: false
-                    perContainerRateLimit: invalid
-               )",
-       1024},
   };
 
   for (const auto& [yamlStr, expected] : tests) {

--- a/integration-tests/pkg/collector/collector.go
+++ b/integration-tests/pkg/collector/collector.go
@@ -18,6 +18,7 @@ type Manager interface {
 	IsRunning() (bool, error)
 	ContainerID() string
 	TestName() string
+	SetTestName(string)
 }
 
 func New(e executor.Executor, name string) Manager {

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -188,3 +188,7 @@ func (c *DockerCollectorManager) ContainerID() string {
 func (c *DockerCollectorManager) TestName() string {
 	return c.testName
 }
+
+func (c *DockerCollectorManager) SetTestName(testName string) {
+	c.testName = testName
+}

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -128,6 +128,9 @@ func (s *IntegrationTestSuiteBase) StopCollector() {
 func (s *IntegrationTestSuiteBase) Collector() collector.Manager {
 	if s.collector == nil {
 		s.collector = collector.New(s.Executor(), s.T().Name())
+	} else {
+		// Otherwise the test name does not get set when subsequent tests are run
+		s.collector.SetTestName(s.T().Name())
 	}
 	return s.collector
 }


### PR DESCRIPTION
## Description

Currently every time that CollectorConfig protobuf definition is changed, we have to change the code for the ConfigLoader. The changes here make it so that is not necessary.

There are also changes here that make it so that collector logs are written to the correct location. Currently for tests that have sub-tests, collector logs are only written to the directory for the first sub-test. This PR fixes that.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Unit and integration tests are sufficient.
