### PR TITLE
ROX-27634: Improvements to CollectorConfig protobuf definitions

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -131,7 +131,8 @@ class CollectorConfig {
 
   int64_t PerContainerRateLimit() const {
     int64_t max_connections_per_minute = MaxConnectionsPerMinute();
-    return int64_t(float(max_connections_per_minute) * float(scrape_interval_) / 60.0 + 0.5);
+    // Converts from max connections per minute to connections per scrape interval.
+    return int64_t(std::round(float(max_connections_per_minute) * float(scrape_interval_) / 60.0));
   }
 
   std::string GetRuntimeConfigStr() {

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -120,6 +120,17 @@ class CollectorConfig {
 
   int64_t PerContainerRateLimit() const {
     auto lock = ReadLock();
+    int64_t max_connections_per_minute = max_connections_per_minute_;
+    if (runtime_config_.has_value()) {
+      max_connections_per_minute = runtime_config_.value()
+                                       .networking()
+                                       .max_connections_per_minute();
+    }
+    return int64_t(float(max_connections_per_minute) * float(scrape_interval_) / 60.0 + 0.5);
+  }
+
+  int64_t MaxConnectionsPerMinute() const {
+    auto lock = ReadLock();
     if (runtime_config_.has_value()) {
       return runtime_config_.value()
           .networking()
@@ -217,7 +228,7 @@ class CollectorConfig {
   std::vector<double> connection_stats_quantiles_;
   double connection_stats_error_;
   unsigned int connection_stats_window_;
-  int64_t max_connections_per_minute_ = 1024;
+  int64_t max_connections_per_minute_ = 2048;
 
   // URL to the GRPC server
   std::optional<std::string> grpc_server_;

--- a/collector/lib/CollectorRuntimeConfigInspector.cpp
+++ b/collector/lib/CollectorRuntimeConfigInspector.cpp
@@ -22,7 +22,9 @@ std::string CollectorConfigInspector::configToJson(bool& isError) {
 
   std::string jsonString;
   const auto& config = runtime_config.value();
-  absl::Status status = google::protobuf::util::MessageToJsonString(config, &jsonString);
+  google::protobuf::util::JsonPrintOptions options;
+  options.always_print_fields_with_no_presence = true;
+  absl::Status status = google::protobuf::util::MessageToJsonString(config, &jsonString, options);
 
   if (!status.ok()) {
     isError = true;

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -74,8 +74,7 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
 
   sensor::ExternalIpsEnabled enable_external_ips;
   const std::string enabled_value = external_ips_node["enabled"] ? external_ips_node["enabled"].as<std::string>() : "";
-  std::string enabled_value_lower = enabled_value;
-  std::transform(enabled_value_lower.begin(), enabled_value_lower.end(), enabled_value_lower.begin(), ::tolower);
+  std::transform(enabled_value.begin(), enabled_value.end(), enabled_value.begin(), std::tolower);
 
   if (enabled_value_lower == "enabled") {
     enable_external_ips = sensor::ExternalIpsEnabled::ENABLED;

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -72,16 +72,28 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
     return true;
   }
 
-  bool enable_external_ips = external_ips_node["enable"].as<bool>(false);
-  int64_t per_container_rate_limit = networking_node["perContainerRateLimit"].as<int64_t>(1024);
+  sensor::ExternalIpsEnabled enable_external_ips;
+  const std::string enabled_value = external_ips_node["enabled"] ? external_ips_node["enabled"].as<std::string>() : "";
+  std::string enabled_value_lower = enabled_value;
+  std::transform(enabled_value_lower.begin(), enabled_value_lower.end(), enabled_value_lower.begin(), ::tolower);
+
+  if (enabled_value_lower == "enabled") {
+    enable_external_ips = sensor::ExternalIpsEnabled::ENABLED;
+  } else if (enabled_value_lower == "disabled") {
+    enable_external_ips = sensor::ExternalIpsEnabled::DISABLED;
+  } else {
+    CLOG(ERROR) << "Unknown value for for networking.externalIps.enabled. Setting it to DISABLED";
+    enable_external_ips = sensor::ExternalIpsEnabled::DISABLED;
+  }
+  int64_t max_connections_per_minute = networking_node["maxConnectionsPerMinute"].as<int64_t>(1024);
 
   sensor::CollectorConfig runtime_config;
   auto* networking = runtime_config.mutable_networking();
   networking
       ->mutable_external_ips()
-      ->set_enable(enable_external_ips);
+      ->set_enabled(enable_external_ips);
   networking
-      ->set_per_container_rate_limit(per_container_rate_limit);
+      ->set_max_connections_per_minute(max_connections_per_minute);
 
   config.SetRuntimeConfig(std::move(runtime_config));
 

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -74,17 +74,18 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
 
   sensor::ExternalIpsEnabled enable_external_ips;
   const std::string enabled_value = external_ips_node["enabled"] ? external_ips_node["enabled"].as<std::string>() : "";
-  std::transform(enabled_value.begin(), enabled_value.end(), enabled_value.begin(), std::tolower);
+  std::string enabled_value_lower = enabled_value;
+  std::transform(enabled_value_lower.begin(), enabled_value_lower.end(), enabled_value_lower.begin(), ::tolower);
 
   if (enabled_value_lower == "enabled") {
     enable_external_ips = sensor::ExternalIpsEnabled::ENABLED;
   } else if (enabled_value_lower == "disabled") {
     enable_external_ips = sensor::ExternalIpsEnabled::DISABLED;
   } else {
-    CLOG(ERROR) << "Unknown value for for networking.externalIps.enabled. Setting it to DISABLED";
+    CLOG(WARNING) << "Unknown value for for networking.externalIps.enabled. Setting it to DISABLED";
     enable_external_ips = sensor::ExternalIpsEnabled::DISABLED;
   }
-  int64_t max_connections_per_minute = networking_node["maxConnectionsPerMinute"].as<int64_t>(1024);
+  int64_t max_connections_per_minute = networking_node["maxConnectionsPerMinute"].as<int64_t>(CollectorConfig::kMaxConnectionsPerMinute);
 
   sensor::CollectorConfig runtime_config;
   auto* networking = runtime_config.mutable_networking();

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -73,13 +73,12 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
   }
 
   sensor::ExternalIpsEnabled enable_external_ips;
-  const std::string enabled_value = external_ips_node["enabled"] ? external_ips_node["enabled"].as<std::string>() : "";
-  std::string enabled_value_lower = enabled_value;
-  std::transform(enabled_value_lower.begin(), enabled_value_lower.end(), enabled_value_lower.begin(), ::tolower);
+  std::string enabled_value = external_ips_node["enabled"] ? external_ips_node["enabled"].as<std::string>() : "";
+  std::transform(enabled_value.begin(), enabled_value.end(), enabled_value.begin(), ::tolower);
 
-  if (enabled_value_lower == "enabled") {
+  if (enabled_value == "enabled") {
     enable_external_ips = sensor::ExternalIpsEnabled::ENABLED;
-  } else if (enabled_value_lower == "disabled") {
+  } else if (enabled_value == "disabled") {
     enable_external_ips = sensor::ExternalIpsEnabled::DISABLED;
   } else {
     CLOG(WARNING) << "Unknown value for for networking.externalIps.enabled. Setting it to DISABLED";

--- a/collector/test/CollectorConfigTest.cpp
+++ b/collector/test/CollectorConfigTest.cpp
@@ -134,7 +134,7 @@ TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig) {
   auto* networking_config = runtime_config.mutable_networking();
   auto* external_ips_config = networking_config->mutable_external_ips();
 
-  external_ips_config->set_enable(false);
+  external_ips_config->set_enabled(sensor::ExternalIpsEnabled::DISABLED);
 
   config.SetRuntimeConfig(runtime_config);
 
@@ -142,7 +142,7 @@ TEST(CollectorConfigTest, TestEnableExternalIpsRuntimeConfig) {
 
   config.MockSetEnableExternalIPs(false);
 
-  external_ips_config->set_enable(true);
+  external_ips_config->set_enabled(sensor::ExternalIpsEnabled::ENABLED);
   config.SetRuntimeConfig(runtime_config);
 
   EXPECT_TRUE(config.EnableExternalIPs());

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -71,12 +71,6 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmptyOrMalformed) {
       R"(
                   asdf
                )",
-      R"(
-                  networking:
-                    externalIps:
-                      enabled: DISABLED
-                    maxConnectionsPerMinute: invalid
-               )",
       R"()"};
 
   for (const auto& yamlStr : tests) {
@@ -109,8 +103,8 @@ TEST(CollectorConfigTest, TestPerContainerRateLimit) {
       {R"(
                   networking:
                     externalIps:
-                      enabled: false
-                    perContainerRateLimit: invalid
+                      enabled: DISABLED
+                    maxConnectionsPerMinute: invalid
                )",
        1024},
   };

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -106,7 +106,7 @@ TEST(CollectorConfigTest, TestMaxConnectionsPerMinute) {
                       enabled: DISABLED
                     maxConnectionsPerMinute: invalid
                )",
-       1024},
+       2048},
   };
 
   for (const auto& [yamlStr, expected] : tests) {

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -84,7 +84,7 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmptyOrMalformed) {
   }
 }
 
-TEST(CollectorConfigTest, TestPerContainerRateLimit) {
+TEST(CollectorConfigTest, TestMaxConnectionsPerMinute) {
   std::vector<std::pair<std::string, int>> tests = {
       {R"(
                   networking:
@@ -122,7 +122,7 @@ TEST(CollectorConfigTest, TestPerContainerRateLimit) {
                    .networking()
                    .max_connections_per_minute();
     EXPECT_EQ(rate, expected);
-    EXPECT_EQ(config.PerContainerRateLimit(), expected);
+    EXPECT_EQ(config.MaxConnectionsPerMinute(), expected);
   }
 }
 }  // namespace collector

--- a/collector/test/ConfigLoaderTest.cpp
+++ b/collector/test/ConfigLoaderTest.cpp
@@ -8,13 +8,13 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
       {R"(
                   networking:
                     externalIps:
-                      enable: true
+                      enabled: ENABLED
                )",
        true},
       {R"(
                   networking:
                     externalIps:
-                      enable: false
+                      enabled: DISABLED
                )",
        false},
       {R"(
@@ -36,7 +36,7 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigMultiple) {
     bool enabled = runtime_config.value()
                        .networking()
                        .external_ips()
-                       .enable();
+                       .enabled() == sensor::ExternalIpsEnabled::ENABLED;
     EXPECT_EQ(enabled, expected);
     EXPECT_EQ(config.EnableExternalIPs(), expected);
   }
@@ -71,6 +71,12 @@ TEST(CollectorConfigTest, TestYamlConfigToConfigEmptyOrMalformed) {
       R"(
                   asdf
                )",
+      R"(
+                  networking:
+                    externalIps:
+                      enabled: DISABLED
+                    maxConnectionsPerMinute: invalid
+               )",
       R"()"};
 
   for (const auto& yamlStr : tests) {
@@ -89,15 +95,15 @@ TEST(CollectorConfigTest, TestPerContainerRateLimit) {
       {R"(
                   networking:
                     externalIps:
-                      enabled: false
-                    perContainerRateLimit: 1234
+                      enabled: DISABLED
+                    maxConnectionsPerMinute: 1234
                )",
        1234},
       {R"(
                   networking:
                     externalIps:
-                      enabled: false
-                    perContainerRateLimit: 1337
+                      enabled: DISABLED
+                    maxConnectionsPerMinute: 1337
                )",
        1337},
       {R"(
@@ -120,7 +126,7 @@ TEST(CollectorConfigTest, TestPerContainerRateLimit) {
 
     int rate = runtime_config.value()
                    .networking()
-                   .per_container_rate_limit();
+                   .max_connections_per_minute();
     EXPECT_EQ(rate, expected);
     EXPECT_EQ(config.PerContainerRateLimit(), expected);
   }

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -77,7 +77,7 @@ class MockCollectorConfig : public collector::CollectorConfig {
     enable_afterglow_ = false;
   }
 
-  void SetPerContainerRateLimit(int64_t limit) {
+  void SetMaxConnectionsPerMinute(int64_t limit) {
     max_connections_per_minute_ = limit;
   }
 };
@@ -353,7 +353,9 @@ TEST(NetworkStatusNotifier, RateLimitedConnections) {
   // maximum of 2 connections per scrape interval
   // if we throw four connections from the same container into the conn
   // tracker delta, we expect only two to be returned
-  config.SetPerContainerRateLimit(2);
+  // The scrape interval is 30 seconds so max_connections_per_minute_
+  // should be 4 to make per_container_rate_limit 2
+  config.SetMaxConnectionsPerMinute(4);
 
   NetworkStatusNotifier netStatusNotifier(conn_scraper, conn_tracker, comm, config);
 

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -78,7 +78,7 @@ class MockCollectorConfig : public collector::CollectorConfig {
   }
 
   void SetPerContainerRateLimit(int64_t limit) {
-    per_container_rate_limit_ = limit;
+    max_connections_per_minute_ = limit;
   }
 };
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -114,15 +114,14 @@ seconds. The default value is 30 seconds.
 ### File mount or ConfigMap
 
 The external IPs feature can be enabled or disabled using a file or ConfigMap. This is an optional
-method and does not have to be used. This file overwites the ENABLE_EXTERNAL_IPS feature flag.
-When using collector by itself a file can be mounted to it at /etc/stackrox/runtime_config.yaml. The
-following is an example of the contents
+method and does not have to be used. When using collector by itself a file can be mounted to it at
+/etc/stackrox/runtime_config.yaml. The following is an example of the contents
 
 ```
 networking:
   externalIps:
-    enable: true
-  perContainerRateLimit: 1234
+    enabled: ENABLED
+  maxConnectionsPerMinute: 1234
 ```
 
 Alternatively, if collector is used as a part of Stackrox, the configuration can be set
@@ -138,8 +137,8 @@ data:
   runtime_config.yaml: |
     networking:
       externalIps:
-        enable: true
-      perContainerRateLimit: 1234
+        enabled: ENABLED
+      maxConnectionsPerMinute: 1234
 ```
 
 The file path can be set using the `ROX_COLLECTOR_CONFIG_PATH` environment variable.

--- a/integration-tests/pkg/assert/assert.go
+++ b/integration-tests/pkg/assert/assert.go
@@ -19,7 +19,7 @@ var (
 	runtimeConfigErrorMsg = "Runtime configuration was not updated"
 )
 
-func AssertExternalIps(t *testing.T, enabled bool, collectorIP string) {
+func AssertExternalIps(t *testing.T, enabled string, collectorIP string) {
 	tickTime := 1 * time.Second
 	timeout := 3 * time.Minute
 	AssertRepeated(t, tickTime, timeout, runtimeConfigErrorMsg, func() bool {
@@ -29,7 +29,7 @@ func AssertExternalIps(t *testing.T, enabled bool, collectorIP string) {
 		err = json.Unmarshal(body, &response)
 		assert.NoError(t, err)
 
-		return response.Networking.ExternalIps.Enable == enabled
+		return response.Networking.ExternalIps.Enabled == enabled
 	})
 }
 

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -4,13 +4,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type RuntimeConfig struct {
-	Networking struct {
-		ExternalIps struct {
-			Enabled string `yaml:"enabled"`
-		} `yaml:"externalIps"`
-	} `yaml:"networking"`
+type ExternalIpsConfig struct {
+	Enabled string `yaml:"enabled"`
 }
+
+type NetworkConfig struct {
+	ExternalIps ExternalIpsConfig `yaml:"externalIps"`
+}
+
+type RuntimeConfig struct {
+	Networking NetworkConfig `yaml:"networking"`
+}
+
+// e.g.
+//    runtimeConfig := types.RuntimeConfig {
+//        Networking: types.NetworkConfig {
+//            ExternalIps: types.ExternalIpsConfig {
+//                Enabled: "ENABLED"
+//            },
+//        },
+//    }
 
 func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
 	return n.Networking.ExternalIps.Enabled == other.Networking.ExternalIps.Enabled
@@ -24,11 +37,4 @@ func (n *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
 	}
 
 	return string(yamlBytes), err
-}
-
-func GetRuntimeConfigEnabledStr(enabled string) (string, error) {
-	var runtimeConfig RuntimeConfig
-	runtimeConfig.Networking.ExternalIps.Enabled = enabled
-
-	return runtimeConfig.GetRuntimeConfigStr()
 }

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -7,13 +7,13 @@ import (
 type RuntimeConfig struct {
 	Networking struct {
 		ExternalIps struct {
-			Enable bool `yaml:"enable"`
+			Enabled string `yaml:"enabled"`
 		} `yaml:"externalIps"`
 	} `yaml:"networking"`
 }
 
 func (n *RuntimeConfig) Equal(other RuntimeConfig) bool {
-	return n.Networking.ExternalIps.Enable == other.Networking.ExternalIps.Enable
+	return n.Networking.ExternalIps.Enabled == other.Networking.ExternalIps.Enabled
 }
 
 func (n *RuntimeConfig) GetRuntimeConfigStr() (string, error) {

--- a/integration-tests/pkg/types/runtime_config.go
+++ b/integration-tests/pkg/types/runtime_config.go
@@ -25,3 +25,10 @@ func (n *RuntimeConfig) GetRuntimeConfigStr() (string, error) {
 
 	return string(yamlBytes), err
 }
+
+func GetRuntimeConfigEnabledStr(enabled string) (string, error) {
+	var runtimeConfig RuntimeConfig
+	runtimeConfig.Networking.ExternalIps.Enabled = enabled
+
+	return runtimeConfig.GetRuntimeConfigStr()
+}

--- a/integration-tests/suites/k8s/config_reload.go
+++ b/integration-tests/suites/k8s/config_reload.go
@@ -99,7 +99,7 @@ func (k *K8sConfigReloadTestSuite) TestConfigurationReload() {
 			"ROX_COLLECTOR_INTROSPECTION_ENABLE": "true",
 		},
 	})
-	assert.AssertExternalIps(k.T(), true, k.Collector().IP())
+	assert.AssertExternalIps(k.T(), "ENABLED", k.Collector().IP())
 
 	log.Info("Checking external IPs is disabled")
 	configMap.Data["runtime_config.yaml"] = EXT_IP_DISABLE

--- a/integration-tests/suites/k8s/config_reload.go
+++ b/integration-tests/suites/k8s/config_reload.go
@@ -13,13 +13,13 @@ const (
 	EXT_IP_ENABLE = `
 networking:
   externalIps:
-    enable: true
+    enable: ENABLED
 `
 
 	EXT_IP_DISABLE = `
 networking:
   externalIps:
-    enable: false
+    enable: DISABLED
 `
 
 	CONFIG_MAP_NAME = "collector-config"
@@ -64,12 +64,12 @@ func (k *K8sConfigReloadTestSuite) TestCreateConfigurationAfterStart() {
 		},
 	}
 	k.createConfigMap(&configMap)
-	assert.AssertExternalIps(k.T(), true, k.Collector().IP())
+	assert.AssertExternalIps(k.T(), "ENABLED", k.Collector().IP())
 
 	log.Info("Checking external IPs is disabled")
 	configMap.Data["runtime_config.yaml"] = EXT_IP_DISABLE
 	k.updateConfigMap(&configMap)
-	assert.AssertExternalIps(k.T(), false, k.Collector().IP())
+	assert.AssertExternalIps(k.T(), "DISABLED", k.Collector().IP())
 
 	log.Info("Checking runtime configuration is not in use")
 	k.deleteConfigMap(CONFIG_MAP_NAME)
@@ -78,7 +78,7 @@ func (k *K8sConfigReloadTestSuite) TestCreateConfigurationAfterStart() {
 	log.Info("Checking external IPs is enabled again")
 	configMap.Data["runtime_config.yaml"] = EXT_IP_ENABLE
 	k.createConfigMap(&configMap)
-	assert.AssertExternalIps(k.T(), true, k.Collector().IP())
+	assert.AssertExternalIps(k.T(), "ENABLED", k.Collector().IP())
 }
 
 func (k *K8sConfigReloadTestSuite) TestConfigurationReload() {
@@ -104,5 +104,5 @@ func (k *K8sConfigReloadTestSuite) TestConfigurationReload() {
 	log.Info("Checking external IPs is disabled")
 	configMap.Data["runtime_config.yaml"] = EXT_IP_DISABLE
 	k.updateConfigMap(&configMap)
-	assert.AssertExternalIps(k.T(), false, k.Collector().IP())
+	assert.AssertExternalIps(k.T(), "DISABLED", k.Collector().IP())
 }

--- a/integration-tests/suites/k8s/config_reload.go
+++ b/integration-tests/suites/k8s/config_reload.go
@@ -4,26 +4,23 @@ import (
 	"github.com/stackrox/collector/integration-tests/pkg/assert"
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
 	"github.com/stackrox/collector/integration-tests/pkg/log"
+	"github.com/stackrox/collector/integration-tests/pkg/types"
 
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	EXT_IP_ENABLE = `
-networking:
-  externalIps:
-    enable: ENABLED
-`
-
-	EXT_IP_DISABLE = `
-networking:
-  externalIps:
-    enable: DISABLED
-`
+var (
+	EXT_IP_ENABLE  string
+	EXT_IP_DISABLE string
 
 	CONFIG_MAP_NAME = "collector-config"
 )
+
+func init() {
+	EXT_IP_ENABLE, _ = types.GetRuntimeConfigEnabledStr("ENABLED")
+	EXT_IP_DISABLE, _ = types.GetRuntimeConfigEnabledStr("DISABLED")
+}
 
 type K8sConfigReloadTestSuite struct {
 	K8sTestSuiteBase

--- a/integration-tests/suites/k8s/config_reload.go
+++ b/integration-tests/suites/k8s/config_reload.go
@@ -17,19 +17,28 @@ var (
 	CONFIG_MAP_NAME = "collector-config"
 )
 
+func init() {
+	var err error
+	var runtimeConfig types.RuntimeConfig
+	runtimeConfig.Networking.ExternalIps.Enabled = "ENABLED"
+
+	EXT_IP_ENABLE, err = runtimeConfig.GetRuntimeConfigStr()
+	if err != nil {
+		panic(err)
+	}
+
+	runtimeConfig.Networking.ExternalIps.Enabled = "DISABLED"
+	EXT_IP_DISABLE, err = runtimeConfig.GetRuntimeConfigStr()
+	if err != nil {
+		panic(err)
+	}
+}
+
 type K8sConfigReloadTestSuite struct {
 	K8sTestSuiteBase
 }
 
 func (k *K8sConfigReloadTestSuite) SetupSuite() {
-	var err error
-
-	EXT_IP_ENABLE, err = types.GetRuntimeConfigEnabledStr("ENABLED")
-	k.Require().NoError(err, "Failed to get runtime config for ENABLED")
-
-	EXT_IP_DISABLE, err = types.GetRuntimeConfigEnabledStr("DISABLED")
-	k.Require().NoError(err, "Failed to get runtime config for DISABLED")
-
 	k.T().Cleanup(func() {
 		k.Sensor().Stop()
 		k.teardownTargetNamespace()

--- a/integration-tests/suites/k8s/config_reload.go
+++ b/integration-tests/suites/k8s/config_reload.go
@@ -17,16 +17,19 @@ var (
 	CONFIG_MAP_NAME = "collector-config"
 )
 
-func init() {
-	EXT_IP_ENABLE, _ = types.GetRuntimeConfigEnabledStr("ENABLED")
-	EXT_IP_DISABLE, _ = types.GetRuntimeConfigEnabledStr("DISABLED")
-}
-
 type K8sConfigReloadTestSuite struct {
 	K8sTestSuiteBase
 }
 
 func (k *K8sConfigReloadTestSuite) SetupSuite() {
+	var err error
+
+	EXT_IP_ENABLE, err = types.GetRuntimeConfigEnabledStr("ENABLED")
+	k.Require().NoError(err, "Failed to get runtime config for ENABLED")
+
+	EXT_IP_DISABLE, err = types.GetRuntimeConfigEnabledStr("DISABLED")
+	k.Require().NoError(err, "Failed to get runtime config for DISABLED")
+
 	k.T().Cleanup(func() {
 		k.Sensor().Stop()
 		k.teardownTargetNamespace()

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -130,7 +130,7 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {
 	// External IPs enabled.
 	// Normalized connection must be reported as inactive
 	// Unnormalized connection will now be reported.
-	s.setExternalIpsEnabled(runtimeConfigFile, "ENABLED")
+	s.setExternalIpsEnabled(runtimeConfigFile, "enabled")
 	assert.AssertExternalIps(s.T(), "ENABLED", collectorIP)
 	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -121,7 +121,7 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {
 	// External IPs enabled.
 	// Normalized connection must be reported as inactive
 	// Unnormalized connection will now be reported.
-	s.setExternalIpsEnabled(runtimeConfigFile, "enabled")
+	s.setExternalIpsEnabled(runtimeConfigFile, "ENABLED")
 	assert.AssertExternalIps(s.T(), "ENABLED", collectorIP)
 	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -66,18 +66,9 @@ func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, 
 	s.Require().NoError(err)
 }
 
-func (s *RuntimeConfigFileTestSuite) getRuntimeConfigEnabledStr(enabled string) string {
-	var runtimeConfig types.RuntimeConfig
-	runtimeConfig.Networking.ExternalIps.Enabled = enabled
-
-	configStr, err := runtimeConfig.GetRuntimeConfigStr()
-	s.Require().NoError(err)
-
-	return configStr
-}
-
 func (s *RuntimeConfigFileTestSuite) setExternalIpsEnabled(runtimeConfigFile string, enabled string) {
-	runtimeConfigStr := s.getRuntimeConfigEnabledStr(enabled)
+	runtimeConfigStr, err := types.GetRuntimeConfigEnabledStr(enabled)
+	s.Require().NoError(err)
 	s.setRuntimeConfig(runtimeConfigFile, runtimeConfigStr)
 }
 

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -66,9 +66,9 @@ func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, 
 	s.Require().NoError(err)
 }
 
-func (s *RuntimeConfigFileTestSuite) getRuntimeConfigEnabledStr(enabled bool) string {
+func (s *RuntimeConfigFileTestSuite) getRuntimeConfigEnabledStr(enabled string) string {
 	var runtimeConfig types.RuntimeConfig
-	runtimeConfig.Networking.ExternalIps.Enable = enabled
+	runtimeConfig.Networking.ExternalIps.Enabled = enabled
 
 	configStr, err := runtimeConfig.GetRuntimeConfigStr()
 	s.Require().NoError(err)
@@ -76,7 +76,7 @@ func (s *RuntimeConfigFileTestSuite) getRuntimeConfigEnabledStr(enabled bool) st
 	return configStr
 }
 
-func (s *RuntimeConfigFileTestSuite) setExternalIpsEnabled(runtimeConfigFile string, enabled bool) {
+func (s *RuntimeConfigFileTestSuite) setExternalIpsEnabled(runtimeConfigFile string, enabled string) {
 	runtimeConfigStr := s.getRuntimeConfigEnabledStr(enabled)
 	s.setRuntimeConfig(runtimeConfigFile, runtimeConfigStr)
 }
@@ -130,8 +130,8 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {
 	// External IPs enabled.
 	// Normalized connection must be reported as inactive
 	// Unnormalized connection will now be reported.
-	s.setExternalIpsEnabled(runtimeConfigFile, true)
-	assert.AssertExternalIps(s.T(), true, collectorIP)
+	s.setExternalIpsEnabled(runtimeConfigFile, "ENABLED")
+	assert.AssertExternalIps(s.T(), "ENABLED", collectorIP)
 	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
 	s.Require().True(connectionSuccess)
@@ -145,8 +145,8 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileEnable() {
 	s.Require().True(connectionSuccess)
 
 	// Back to having external IPs enabled.
-	s.setExternalIpsEnabled(runtimeConfigFile, true)
-	assert.AssertExternalIps(s.T(), true, collectorIP)
+	s.setExternalIpsEnabled(runtimeConfigFile, "ENABLED")
+	assert.AssertExternalIps(s.T(), "ENABLED", collectorIP)
 	expectedConnections = append(expectedConnections, activeUnnormalizedConnection, inactiveNormalizedConnection)
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
 	s.Require().True(connectionSuccess)
@@ -163,8 +163,8 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileDisable() {
 
 	// The runtime config file is created, but external IPs is disables.
 	// There is no change in the state, so there are no changes to the connections
-	s.setExternalIpsEnabled(runtimeConfigFile, false)
-	assert.AssertExternalIps(s.T(), false, collectorIP)
+	s.setExternalIpsEnabled(runtimeConfigFile, "DISABLED")
+	assert.AssertExternalIps(s.T(), "DISABLED", collectorIP)
 	common.Sleep(3 * time.Second) // Sleep so that collector has a chance to report connections
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
 	s.Require().True(connectionSuccess)
@@ -189,7 +189,7 @@ func (s *RuntimeConfigFileTestSuite) TestRuntimeConfigFileInvalid() {
 	// Testing an invalid configuration. There should not be a change in the configuration or reported connections
 	invalidConfig := "asdf"
 	s.setRuntimeConfig(runtimeConfigFile, invalidConfig)
-	assert.AssertExternalIps(s.T(), false, collectorIP)
+	assert.AssertNoRuntimeConfig(s.T(), collectorIP)
 	common.Sleep(3 * time.Second) // Sleep so that collector has a chance to report connections
 	connectionSuccess = s.Sensor().ExpectSameElementsConnections(s.T(), s.ClientContainer, 10*time.Second, expectedConnections...)
 	s.Require().True(connectionSuccess)

--- a/integration-tests/suites/runtime_config_file.go
+++ b/integration-tests/suites/runtime_config_file.go
@@ -67,7 +67,9 @@ func (s *RuntimeConfigFileTestSuite) setRuntimeConfig(runtimeConfigFile string, 
 }
 
 func (s *RuntimeConfigFileTestSuite) setExternalIpsEnabled(runtimeConfigFile string, enabled string) {
-	runtimeConfigStr, err := types.GetRuntimeConfigEnabledStr(enabled)
+	var runtimeConfig types.RuntimeConfig
+	runtimeConfig.Networking.ExternalIps.Enabled = enabled
+	runtimeConfigStr, err := runtimeConfig.GetRuntimeConfigStr()
 	s.Require().NoError(err)
 	s.setRuntimeConfig(runtimeConfigFile, runtimeConfigStr)
 }


### PR DESCRIPTION
## Description

It was suggested in the [PR](https://github.com/stackrox/stackrox/pull/13419) to set collector runtime config via helm charts that `networking.external_ips.enable` should be changed to `networking.external_ips.enabled`. The protobuf definitions tend to use enabled rather than enable. The same is true for the helm charts. The boolean datatype should be changed to an enum. per_container_rate_limit should be changed to max_connections_per_minute.

Even if these are never set using helm or operator, it is still good to make these changes.

These protobufs are internal and the feature that uses them is in technical preview. The collector expects the field to be `enable` rather than `enabled` in the collector-config ConfigMap. Some customers may have this setting, but as stated earlier this is in technical preview, use in production is not recommended, and customers should not expect this to be stable.

The PR that updated the protobuf definitions in stackrox/stackrox is here https://github.com/stackrox/stackrox/pull/13608

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
