### PR TITLE
Use newest clang and llvm

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,8 +11,8 @@ RUN dnf -y update \
         binutils-devel \
         bison \
         ca-certificates \
-        clang-17.0.6 \
-        llvm-17.0.6 \
+        clang-19.1.5 \
+        llvm-19.1.5 \
         cmake \
         cracklib-dicts \
         diffutils \


### PR DESCRIPTION
## Description

We pin clang and llvm versions due to bugs in certain versions, which we would like to skip (see [1], [2]). Bump them to 19.1.5 .

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2209635
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2211472

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

## Testing Performed

Multi-arch CI pass is sufficient.