### PR TITLE
ROX-27695: Collector runtime configuration should be logged

### DIFF
--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -16,6 +16,7 @@
 
 #include "CollectionMethod.h"
 #include "HostConfig.h"
+#include "Logging.h"
 #include "NetworkConnection.h"
 #include "TlsConfig.h"
 #include "json/value.h"
@@ -146,6 +147,7 @@ class CollectorConfig {
 
   void ResetRuntimeConfig() {
     auto lock = WriteLock();
+    CLOG(INFO) << "Resetting runtime configuration";
     runtime_config_.reset();
   }
 

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -96,8 +96,8 @@ bool ConfigLoader::LoadConfiguration(CollectorConfig& config, const YAML::Node& 
 
   config.SetRuntimeConfig(std::move(runtime_config));
 
-  CLOG(DEBUG) << "Runtime configuration:\n"
-              << config.GetRuntimeConfigStr();
+  CLOG(INFO) << "Runtime configuration:\n"
+             << config.GetRuntimeConfigStr();
   return true;
 }
 

--- a/integration-tests/pkg/collector/collector.go
+++ b/integration-tests/pkg/collector/collector.go
@@ -19,6 +19,7 @@ type Manager interface {
 	ContainerID() string
 	TestName() string
 	SetTestName(string)
+	GetTestName() string
 }
 
 func New(e executor.Executor, name string) Manager {

--- a/integration-tests/pkg/collector/collector.go
+++ b/integration-tests/pkg/collector/collector.go
@@ -18,6 +18,7 @@ type Manager interface {
 	IsRunning() (bool, error)
 	ContainerID() string
 	TestName() string
+	SetTestName(string)
 }
 
 func New(e executor.Executor, name string) Manager {

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -188,3 +188,7 @@ func (c *DockerCollectorManager) ContainerID() string {
 func (c *DockerCollectorManager) TestName() string {
 	return c.testName
 }
+
+func (c *DockerCollectorManager) SetTestName(testName string) {
+	c.testName = testName
+}

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -192,3 +192,7 @@ func (c *DockerCollectorManager) TestName() string {
 func (c *DockerCollectorManager) SetTestName(testName string) {
 	c.testName = testName
 }
+
+func (c *DockerCollectorManager) GetTestName() string {
+	return c.testName
+}

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -128,6 +128,9 @@ func (s *IntegrationTestSuiteBase) StopCollector() {
 func (s *IntegrationTestSuiteBase) Collector() collector.Manager {
 	if s.collector == nil {
 		s.collector = collector.New(s.Executor(), s.T().Name())
+	} else {
+		// Otherwise the test name does not get set when subsequent tests are run
+		s.collector.SetTestName(s.T().Name())
 	}
 	return s.collector
 }

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -128,7 +128,7 @@ func (s *IntegrationTestSuiteBase) StopCollector() {
 func (s *IntegrationTestSuiteBase) Collector() collector.Manager {
 	if s.collector == nil {
 		s.collector = collector.New(s.Executor(), s.T().Name())
-	} else if collector.testName != s.T().Name() {
+	} else if s.collector.GetTestName() != s.T().Name() {
 		// Otherwise the test name does not get set when subsequent tests are run
 		s.collector.SetTestName(s.T().Name())
 	}

--- a/integration-tests/suites/base.go
+++ b/integration-tests/suites/base.go
@@ -128,7 +128,7 @@ func (s *IntegrationTestSuiteBase) StopCollector() {
 func (s *IntegrationTestSuiteBase) Collector() collector.Manager {
 	if s.collector == nil {
 		s.collector = collector.New(s.Executor(), s.T().Name())
-	} else {
+	} else if collector.testName != s.T().Name() {
 		// Otherwise the test name does not get set when subsequent tests are run
 		s.collector.SetTestName(s.T().Name())
 	}


### PR DESCRIPTION
## Description

It is important for customers to know what the current collector runtime configuration is. While this can be read from the ConfigMap, it is possible that some misconfiguration in the ConfigMap, will cause the actual runtime configuration to be something other than what the user expects. For this reason it is important to log the runtime configuration in collector. Also it may also be important to know the timestamp at which a certain runtime configuration was applied. A ConfigMap will not by itself preserve that history.

In addition to the change mentioned above, a bug is fixed, which made it so that for each test in  a group of tests in the same suite, separate collector log files are created. Currently in such cases each test overwrites the log file of the previous test. This change was needed to make the testing of this PR easier.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  ~~- [ ] Added unit tests~~
  ~~- [ ] Added integration tests~~
  ~~- [ ] Added regression tests~~

If any of these don't apply, please comment below.

This is just a change to the logging so no new testing is required.

## Testing Performed

Ran
```
make -C integration-tests TestRuntimeConfigFile
```

and checked the log files.

The log for `TestRuntimeConfigFileDisable` had the following

```
[INFO    2025/01/17 19:06:54] (ConfigLoader.cpp:99) Runtime configuration:
networking {
  external_ips {
  }
  max_connections_per_minute: 2048
}

```

and
```
[INFO    2025/01/17 19:06:58] (CollectorConfig.h:150) Resetting runtime configuration
[DEBUG   2025/01/17 19:06:58] (ConfigLoader.cpp:173) Got directory event for "/etc/stackrox/runtime_config.yaml" - mask: [ delete ]
[INFO    2025/01/17 19:06:58] (CollectorConfig.h:150) Resetting runtime configuration
```

The log for `TestRuntimeConfigFileEnable` had the following

```
[INFO    2025/01/17 19:07:15] (ConfigLoader.cpp:99) Runtime configuration:
networking {
  external_ips {
    enabled: ENABLED
  }
  max_connections_per_minute: 2048
}


```

and
```
[INFO    2025/01/17 19:07:19] (CollectorConfig.h:150) Resetting runtime configuration
[DEBUG   2025/01/17 19:07:19] (ConfigLoader.cpp:173) Got directory event for "/etc/stackrox/runtime_config.yaml" - mask: [ delete ]
[INFO    2025/01/17 19:07:19] (CollectorConfig.h:150) Resetting runtime configuration
```

and
```
[INFO    2025/01/17 19:07:25] (ConfigLoader.cpp:99) Runtime configuration:
networking {
  external_ips {
    enabled: ENABLED
  }
  max_connections_per_minute: 2048
}

```

The log for `TestRuntimeConfigFileInvalid` had the following

```
[ERROR   2025/01/17 19:07:45] (ConfigLoader.cpp:59) Unable to read config from "/etc/stackrox/runtime_config.yaml"
```