### PR TITLE
Cap parallelism of dependency building

### DIFF
--- a/builder/install/install-dependencies.sh
+++ b/builder/install/install-dependencies.sh
@@ -7,7 +7,7 @@ export LICENSE_DIR="/THIRD_PARTY_NOTICES"
 mkdir -p "${LICENSE_DIR}"
 
 export NPROCS
-NPROCS="$(nproc)"
+NPROCS="${NPROCS:-$(nproc)}"
 
 # shellcheck source=SCRIPTDIR/versions.sh
 source builder/install/versions.sh


### PR DESCRIPTION

## Description

When building the third party dependencies, we use the nproc command to try and get as many parallel builds as possible running at once. This can bring problems on systems with large numbers of cores and not enough ram to come with them, so for those we provide the option of manually setting the number of parallel builds with an environment variable.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Test the downstream build works as expected on affected systems.
