### PR TITLE
Fix image build segfaults on QEMU

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

Collector build randomly started failing on ppc64le and arm64 with the following segfault message:
```
gmake[2]: *** [driver/modern_bpf/CMakeFiles/ProbeSkeleton.dir/build.make:673: driver/modern_bpf/copy_file_range.bpf.o] Segmentation fault (core dumped)
gmake[1]: *** [CMakeFiles/Makefile2:2035: driver/modern_bpf/CMakeFiles/ProbeSkeleton.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

The error itself seems to coincide with an update to the GHA runner which updates the kernel:
- Last successful build: https://github.com/stackrox/collector/actions/runs/12890846039/job/36009468005
  - Runner version: 20250105.1.0
- First failing build: https://github.com/stackrox/collector/actions/runs/12939264126/job/36091246392
  - Runner version: 20250120.5.0
  - Release notes for this runner: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250120.5

Because the errors are specific to ppc64le and arm64 builds, the best guess is that there is an incompatibility between QEMU and this newer kernel. The proposed fix is to update the image used for setting up QEMU.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run all affected jobs on CI.
