### PR TITLE
Add slack notifications for image build failures

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -237,3 +237,23 @@ jobs:
           dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+  notify:
+    runs-on: ubuntu-24.04
+    if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
+    needs:
+      - build-builder-image
+      - create-multiarch-manifest
+      - retag-x86-image
+    steps:
+      - name: Slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_COLLECTOR_ONCALL_WEBHOOK }}
+          SLACK_CHANNEL: team-acs-collector-oncall
+          SLACK_COLOR: failure
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: "Builder image build has failed"
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @acs-collector-oncall

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -319,3 +319,24 @@ jobs:
           dst-image: ${{ env.RHACS_ENG_IMAGE }}-latest
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+  notify:
+    runs-on: ubuntu-24.04
+    if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
+    needs:
+      - build-collector-image
+      - build-collector-image-remote-vm
+      - create-multiarch-manifest
+      - retag-x86-image
+    steps:
+      - name: Slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_COLLECTOR_ONCALL_WEBHOOK }}
+          SLACK_CHANNEL: team-acs-collector-oncall
+          SLACK_COLOR: failure
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: "Collector image build has failed"
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @acs-collector-oncall

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -185,3 +185,22 @@ jobs:
       - name: Build and Push containers
         run: |
           make -C "${{ matrix.directory }}" build-and-push
+
+  notify:
+    runs-on: ubuntu-24.04
+    if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
+    needs:
+      - build-test-image
+      - rebuild-containers
+    steps:
+      - name: Slack notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_COLLECTOR_ONCALL_WEBHOOK }}
+          SLACK_CHANNEL: team-acs-collector-oncall
+          SLACK_COLOR: failure
+          SLACK_LINK_NAMES: true
+          SLACK_TITLE: "Failed to rebuild test containers"
+          MSG_MINIMAL: actions url,commit
+          SLACK_MESSAGE: |
+            @acs-collector-oncall


### PR DESCRIPTION
## Description

The notifications should notify us when we fail to build the collector, builder, test or any of the QA images.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Test collector build failure notification.
- [x] Test builder build failure notification.
- [x] Test qa images failure notification.
