### PR TITLE
ROX-22250: Switch to sanitizing `determine-image-tag` task

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -186,7 +186,8 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:433e2a1bacbbbdccb2fc7d935d8f801a8d876340567f9de3d57fd56e1856bcf0
+        # TODO(ROX-22250): switch to latest
+        value: quay.io/rhacs-eng/konflux-tasks:pr-30@sha256:3dfb865398b12d2c0671daabc3a5af0e2353050e1a2abf2286f998a7309ad516
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

In order to make sure there are no changes in tags for this repo, i.e. `.x` remains `.x`.

Coupled with https://github.com/stackrox/konflux-tasks/pull/30

I'm not going to merge this PR because there's no change in tags and the updated task bundle will eventually come to `master` via Renovate. I.e. this PR is only for testing.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
No change.

## Testing Performed

- [x] Konflux CI is happy.
- [x] Image tag contains `.x`, not `.0`.