### PR TITLE
ROX-18384: removes slim and latest images from konflux build

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -416,12 +416,9 @@ spec:
       values: [ "true" ]
 
   - name: build-image-index-extra
-    matrix:
-      params:
-      - name: IMAGE
-        value:
-        - $(params.output-image-repo):konflux-$(params.revision)
     params:
+    - name: IMAGE
+      value: $(params.output-image-repo):konflux-$(params.revision)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
     - name: IMAGES

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -420,8 +420,6 @@ spec:
       params:
       - name: IMAGE
         value:
-        - $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-latest
-        - $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-slim
         - $(params.output-image-repo):konflux-$(params.revision)
     params:
     - name: COMMIT_SHA


### PR DESCRIPTION
## Description

Following #1963 and https://github.com/stackrox/stackrox/pull/13350 we no longer require -latest or -slim images for Collector