### PR TITLE
Set GOMAXPROCS to a fixed value

### DIFF
--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -19,7 +19,12 @@ COPY integration_test.go "$TEST_ROOT"
 COPY benchmark_test.go "$TEST_ROOT"
 COPY k8s_test.go "$TEST_ROOT"
 
-RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go test -tags bench,k8s -c -o collector-tests
+RUN --mount=type=cache,target="/root/.cache/go-build" \
+    CGO_ENABLED=0\
+    GOOS=linux\
+    GOARCH=$TARGETARCH\
+    GOMAXPROCS=4\
+    go test -tags bench,k8s -c -o collector-tests
 
 FROM alpine:3.18
 


### PR DESCRIPTION
## Description

Currently building test images on arm64 is failing from time to time in a way, that resembles OOM cases during the build on nodes with large number of cores:

    /usr/local/go/pkg/tool/linux_arm64/compile: signal: segmentation fault (core dumped)

Experiments have shown that "go test -tags bench" does indeed spawns number of workers equal to the number of cores, and setting GOMAXPROCS allows to keep that number lower.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed

Manual testing with GOMAXPROCS set.