### PR TITLE
Use newer QEMU on test containers builds

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -171,6 +173,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Description

We recently had to change the image being used by the setup-qemu action in order to fix some segmentation faults while building collector and builder images on ppc64le and arm64 architectures (#2018). Now we are seeing similar segfaults when trying to build the integration test containers, so we are bumping the version there as well in hopes that it will solve the issue.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run CI with the `run-multiarch-builds` label.
