### PR TITLE
Downgrade ibm cloudcollection to 1.51.0 to workaround failures on ppc64le

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,5 +4,6 @@ collections:
 - community.general
 - community.docker
 - containers.podman
-- ibm.cloudcollection
 - kubernetes.core
+- name: ibm.cloudcollection
+  version: 1.51.0


### PR DESCRIPTION
## Description

Downgrades ansible `ibm cloudcollection` to `1.51.0` from the latest `1.71.2` since it introduces some breaking changes for ppc64le. This is a workaround till the automation is updated for the latest version.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed
Tested in CI.
