### PR TITLE
Set selinux labels to share source directory with builder.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ start-builder: builder teardown-builder
 		--name $(COLLECTOR_BUILDER_NAME) \
 		--pull never \
 		--platform ${PLATFORM} \
-		-v $(CURDIR):$(CURDIR) \
+		-v $(CURDIR):$(CURDIR):Z \
 		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\
 		-w $(CURDIR) \
 		--cap-add sys_ptrace \

--- a/Makefile
+++ b/Makefile
@@ -8,23 +8,6 @@ BUILD_BUILDER_IMAGE ?= false
 
 export COLLECTOR_VERSION := $(COLLECTOR_TAG)
 
-PODMAN =
-# docker --version might not contain any traces of podman in the latest
-# version, search for more output
-ifneq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
-	PODMAN = yes
-endif
-ifneq (,$(findstring Podman,$(shell docker version 2>/dev/null)))
-	PODMAN = yes
-endif
-
-ifdef PODMAN
-# Disable selinux for local podman builds.
-BUILDER_OPTS=--security-opt label=disable
-else
-BUILDER_OPTS=
-endif
-
 .PHONY: tag
 tag:
 	@echo "$(COLLECTOR_TAG)"
@@ -101,7 +84,6 @@ endif
 .PHONY: start-builder
 start-builder: builder teardown-builder
 	docker run -d \
-		$(BUILDER_OPTS) \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		--pull never \
 		--platform ${PLATFORM} \


### PR DESCRIPTION
## Description

On systems where selinux is _enforcing_, docker/podman has to be told to set appropriate labels on the builder container to access the source tree from within the container.

## Testing Performed

It should be enough that the build succeeds.
