### PR TITLE
Pin shfmt version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install shfmt
         run: |
-          GOBIN="${HOME}/bin/" go install mvdan.cc/sh/v3/cmd/shfmt@latest
+          GOBIN="${HOME}/bin/" go install mvdan.cc/sh/v3/cmd/shfmt@v3.10.0
 
       - name: Install actionlint
         run: |


### PR DESCRIPTION

## Description

The lint CI job has started failing because the go version required by the latest release of shfmt is higher than the one being installed on the fedora:40 image. We could bump the image, but for now I think pinning the shfmt version would lead to the least pain in the future.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
