### PR TITLE
Replace MakeUnique with std::make_unique

### DIFF
--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -97,12 +97,12 @@ void CollectorService::RunForever() {
 
     auto network_connection_info_service_comm = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
 
-    net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
-                                                            conn_tracker,
-                                                            network_connection_info_service_comm,
-                                                            config_,
-                                                            config_.EnableConnectionStats() ? exporter.GetConnectionsTotalReporter() : 0,
-                                                            config_.EnableConnectionStats() ? exporter.GetConnectionsRateReporter() : 0);
+    net_status_notifier = std::make_unique<NetworkStatusNotifier>(conn_scraper,
+                                                                  conn_tracker,
+                                                                  network_connection_info_service_comm,
+                                                                  config_,
+                                                                  config_.EnableConnectionStats() ? exporter.GetConnectionsTotalReporter() : 0,
+                                                                  config_.EnableConnectionStats() ? exporter.GetConnectionsRateReporter() : 0);
     net_status_notifier->Start();
   }
 

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -131,8 +131,8 @@ void CollectorStatsExporter::run() {
   std::array<std::unique_ptr<CollectorTimerGauge>, CollectorStats::timer_type_max> collector_timers;
   for (int i = 0; i < CollectorStats::timer_type_max; i++) {
     auto tt = (CollectorStats::TimerType)(i);
-    collector_timers[tt] = MakeUnique<CollectorTimerGauge>(collector_timers_gauge,
-                                                           CollectorStats::timer_type_to_name[tt]);
+    collector_timers[tt] = std::make_unique<CollectorTimerGauge>(collector_timers_gauge,
+                                                                 CollectorStats::timer_type_to_name[tt]);
   }
   auto& collector_counters_gauge = prometheus::BuildGauge()
                                        .Name("rox_collector_counters")

--- a/collector/lib/NetworkConnectionInfoServiceComm.cpp
+++ b/collector/lib/NetworkConnectionInfoServiceComm.cpp
@@ -10,7 +10,7 @@ constexpr char NetworkConnectionInfoServiceComm::kCapsMetadataKey[];
 constexpr char NetworkConnectionInfoServiceComm::kSupportedCaps[];
 
 std::unique_ptr<grpc::ClientContext> NetworkConnectionInfoServiceComm::CreateClientContext() const {
-  auto ctx = MakeUnique<grpc::ClientContext>();
+  auto ctx = std::make_unique<grpc::ClientContext>();
   ctx->AddMetadata(kHostnameMetadataKey, hostname_);
   ctx->AddMetadata(kCapsMetadataKey, kSupportedCaps);
   return ctx;
@@ -54,7 +54,7 @@ std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> Netwo
         &sensor::NetworkConnectionInfoService::Stub::AsyncPushNetworkConnectionInfo,
         channel_, context_.get(), std::move(receive_func));
   } else {
-    return MakeUnique<collector::grpc_duplex_impl::StdoutDuplexClientWriter<sensor::NetworkConnectionInfoMessage>>();
+    return std::make_unique<collector::grpc_duplex_impl::StdoutDuplexClientWriter<sensor::NetworkConnectionInfoMessage>>();
   }
 }
 

--- a/collector/lib/SignalServiceClient.cpp
+++ b/collector/lib/SignalServiceClient.cpp
@@ -27,7 +27,7 @@ bool SignalServiceClient::EstablishGRPCStreamSingle() {
   }
 
   // stream writer
-  context_ = MakeUnique<grpc::ClientContext>();
+  context_ = std::make_unique<grpc::ClientContext>();
   writer_ = DuplexClient::CreateWithReadsIgnored(&SignalService::Stub::AsyncPushSignals, channel_, context_.get());
   if (!writer_->WaitUntilStarted(std::chrono::seconds(30))) {
     CLOG(ERROR) << "Signal stream not ready after 30 seconds. Retrying ...";

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -27,11 +27,6 @@ const char* StrError(int errnum = errno);
 // Return the name of a signal. This function is reentrant.
 const char* SignalName(int signum);
 
-template <typename T, typename... Args>
-std::unique_ptr<T> MakeUnique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
 // Return string decoded from base 64
 std::string Base64Decode(std::string const& encoded_string);
 

--- a/collector/lib/system-inspector/Service.cpp
+++ b/collector/lib/system-inspector/Service.cpp
@@ -39,11 +39,11 @@ void Service::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTrac
   // so they are added to the handler list first, so they have access
   // to self-check events before the network and process handlers have
   // a chance to process them and send them to Sensor.
-  AddSignalHandler(MakeUnique<SelfCheckProcessHandler>(inspector_.get()));
-  AddSignalHandler(MakeUnique<SelfCheckNetworkHandler>(inspector_.get()));
+  AddSignalHandler(std::make_unique<SelfCheckProcessHandler>(inspector_.get()));
+  AddSignalHandler(std::make_unique<SelfCheckNetworkHandler>(inspector_.get()));
 
   if (conn_tracker) {
-    auto network_signal_handler_ = MakeUnique<NetworkSignalHandler>(inspector_.get(), conn_tracker, &userspace_stats_);
+    auto network_signal_handler_ = std::make_unique<NetworkSignalHandler>(inspector_.get(), conn_tracker, &userspace_stats_);
 
     network_signal_handler_->SetCollectConnectionStatus(config.CollectConnectionStatus());
     network_signal_handler_->SetTrackSendRecv(config.TrackingSendRecv());
@@ -56,10 +56,10 @@ void Service::Init(const CollectorConfig& config, std::shared_ptr<ConnectionTrac
   } else {
     signal_client_.reset(new StdoutSignalServiceClient());
   }
-  AddSignalHandler(MakeUnique<ProcessSignalHandler>(inspector_.get(),
-                                                    signal_client_.get(),
-                                                    &userspace_stats_,
-                                                    config));
+  AddSignalHandler(std::make_unique<ProcessSignalHandler>(inspector_.get(),
+                                                          signal_client_.get(),
+                                                          &userspace_stats_,
+                                                          config));
 
   if (signal_handlers_.size() == 2) {
     // self-check handlers do not count towards this check, because they

--- a/collector/test/NetworkStatusNotifierTest.cpp
+++ b/collector/test/NetworkStatusNotifierTest.cpp
@@ -209,7 +209,7 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
   EXPECT_CALL(*comm, PushNetworkConnectionInfoOpenStream)
       .Times(1)
       .WillOnce([&sem, &running](std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) -> std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> {
-        auto duplex_writer = MakeUnique<MockDuplexClientWriter>();
+        auto duplex_writer = std::make_unique<MockDuplexClientWriter>();
 
         // the service is sending Sensor a message
         EXPECT_CALL(*duplex_writer, Write).WillRepeatedly([&sem, &running](const sensor::NetworkConnectionInfoMessage& msg, const gpr_timespec& deadline) -> Result {
@@ -232,10 +232,10 @@ TEST(NetworkStatusNotifier, SimpleStartStop) {
     return true;
   });
 
-  auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
-                                                               conn_tracker,
-                                                               comm,
-                                                               config_);
+  auto net_status_notifier = std::make_unique<NetworkStatusNotifier>(conn_scraper,
+                                                                     conn_tracker,
+                                                                     comm,
+                                                                     config_);
 
   net_status_notifier->Start();
 
@@ -282,7 +282,7 @@ TEST(NetworkStatusNotifier, UpdateIPnoAfterglow) {
                  &conn2,
                  &conn3,
                  &network_flows_callback](std::function<void(const sensor::NetworkFlowsControlMessage*)> receive_func) -> std::unique_ptr<IDuplexClientWriter<sensor::NetworkConnectionInfoMessage>> {
-        auto duplex_writer = MakeUnique<MockDuplexClientWriter>();
+        auto duplex_writer = std::make_unique<MockDuplexClientWriter>();
         network_flows_callback = receive_func;
 
         // the service is sending Sensor a message
@@ -331,10 +331,10 @@ TEST(NetworkStatusNotifier, UpdateIPnoAfterglow) {
     return true;
   });
 
-  auto net_status_notifier = MakeUnique<NetworkStatusNotifier>(conn_scraper,
-                                                               conn_tracker,
-                                                               comm,
-                                                               config);
+  auto net_status_notifier = std::make_unique<NetworkStatusNotifier>(conn_scraper,
+                                                                     conn_tracker,
+                                                                     comm,
+                                                                     config);
 
   net_status_notifier->Start();
 


### PR DESCRIPTION
## Description

This is a small clean up, removing our home made implementation of MakeUnique (which was needed back when we were still on C++11) and replacing it with std::make_unique.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
