### PR TITLE
Fix CPU profiler

### DIFF
--- a/collector/lib/ProfilerHandler.cpp
+++ b/collector/lib/ProfilerHandler.cpp
@@ -13,6 +13,9 @@
 
 namespace collector {
 
+// The following route is used by the CPU profiler to dump information
+// into. When running in read only file systems, /var/profiles needs to
+// be writable, or the CPU profiler will not work.
 const std::string ProfilerHandler::kCPUProfileFilename = "/var/profiles/cpu_profile";
 const std::string ProfilerHandler::kBaseRoute = "/profile";
 const std::string ProfilerHandler::kCPURoute = kBaseRoute + "/cpu";

--- a/collector/lib/ProfilerHandler.cpp
+++ b/collector/lib/ProfilerHandler.cpp
@@ -13,7 +13,7 @@
 
 namespace collector {
 
-const std::string ProfilerHandler::kCPUProfileFilename = "/module/cpu_profile";
+const std::string ProfilerHandler::kCPUProfileFilename = "/var/profiles/cpu_profile";
 const std::string ProfilerHandler::kBaseRoute = "/profile";
 const std::string ProfilerHandler::kCPURoute = kBaseRoute + "/cpu";
 const std::string ProfilerHandler::kHeapRoute = kBaseRoute + "/heap";

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -453,6 +453,15 @@ $ curl collector:8080/profile/heap
 The resulting profile could be processed with `pprof` to get a human-readable
 output with debugging symbols.
 
+Collector also exposes a CPU profiler under `/profile/cpu`, which operates in
+a very similar manner to the heap profiler.
+
+---
+**_NOTE_**: If the CPU profiler fails to start, make sure /var/profiles exists
+in the collector container and is writable.
+
+---
+
 ## Benchmark CI step
 
 Whenever in doubt about performance implications of your changes, there is an

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stackrox/collector/integration-tests/pkg/collector"
+	"github.com/stackrox/collector/integration-tests/pkg/common"
 	"github.com/stackrox/collector/integration-tests/pkg/config"
 	"github.com/stackrox/collector/integration-tests/pkg/types"
 	"github.com/stackrox/collector/integration-tests/suites"
@@ -516,6 +517,9 @@ func TestPerfEvent(t *testing.T) {
 }
 
 func TestGperftools(t *testing.T) {
+	if ok, arch := common.ArchSupported("x86_64"); !ok {
+		t.Skip("[WARNING]: skip GperftoolsTestSuite on ", arch)
+	}
 	suite.Run(t, new(suites.GperftoolsTestSuite))
 }
 

--- a/integration-tests/pkg/collector/collector_docker.go
+++ b/integration-tests/pkg/collector/collector_docker.go
@@ -42,6 +42,7 @@ func NewDockerCollectorManager(e executor.Executor, name string) *DockerCollecto
 		"/host/usr/lib:ro":          "/usr/lib",
 		"/host/sys/kernel/debug:ro": "/sys/kernel/debug",
 		"/etc/stackrox:ro":          "/tmp/collector-test",
+		"/var/profiles":             "", // gperftools dump directory
 	}
 
 	return &DockerCollectorManager{

--- a/integration-tests/suites/gperftools.go
+++ b/integration-tests/suites/gperftools.go
@@ -1,6 +1,7 @@
 package suites
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -36,19 +37,18 @@ func (s *GperftoolsTestSuite) TearDownSuite() {
 // NOTE: The test will only be performed on supported architectures (only
 // x86_64 at the moment).
 func (s *GperftoolsTestSuite) TestFetchHeapProfile() {
-	if ok, arch := common.ArchSupported("x86_64"); !ok {
-		s.T().Skip("[WARNING]: skip GperftoolsTestSuite on ", arch)
-	}
+	s.runProfilerTest("heap")
+}
 
-	var (
-		response *http.Response
-		err      error
-	)
+func (s *GperftoolsTestSuite) TestFetchCpuProfile() {
+	s.runProfilerTest("cpu")
+}
 
-	heap_api_url := "http://localhost:8080/profile/heap"
+func (s *GperftoolsTestSuite) runProfilerTest(resource string) {
+	heap_api_url := fmt.Sprintf("http://localhost:8080/profile/%s", resource)
 	data_type := "application/x-www-form-urlencoded"
 
-	response, err = http.Post(heap_api_url, data_type, strings.NewReader("on"))
+	response, err := http.Post(heap_api_url, data_type, strings.NewReader("on"))
 	s.Require().NoError(err)
 	s.Assert().Equal(response.StatusCode, 200, "Failed to start heap profiling")
 

--- a/integration-tests/suites/gperftools.go
+++ b/integration-tests/suites/gperftools.go
@@ -50,16 +50,16 @@ func (s *GperftoolsTestSuite) runProfilerTest(resource string) {
 
 	response, err := http.Post(heap_api_url, data_type, strings.NewReader("on"))
 	s.Require().NoError(err)
-	s.Assert().Equal(response.StatusCode, 200, "Failed to start heap profiling")
+	s.Assert().Equalf(response.StatusCode, 200, "Failed to start %s profiling", resource)
 
 	// Wait a bit to collect something in the heap profile
 	common.Sleep(1 * time.Second)
 
 	response, err = http.Post(heap_api_url, data_type, strings.NewReader("off"))
 	s.Require().NoError(err)
-	s.Assert().Equal(response.StatusCode, 200, "Failed to stop heap profiling")
+	s.Assert().Equalf(response.StatusCode, 200, "Failed to stop %s profiling", resource)
 
 	response, err = http.Get(heap_api_url)
 	s.Require().NoError(err)
-	s.Assert().Equal(response.StatusCode, 200, "Failed to fetch heap profile")
+	s.Assert().Equalf(response.StatusCode, 200, "Failed to fetch %s profile", resource)
 }


### PR DESCRIPTION
## Description

When we removed the /module mount from the collector daemonset we inadvertedly broke the gperftool cpu profiler, since it was using that directory for dumping its output files. This patch moves the dump directory to /var/profiles, which will be a new emptydir mount on the collector daemonset.

A new test is also added to ensure the profiles still starts, stops and produces some output.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [x] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Manually tested the CPU profiler endpoint.
