### PR TITLE
Stop running the unit tests as part of the image build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ on:
           The builder tag to use in the build
 
 jobs:
-  memory-checked:
+  unit-tests:
     runs-on: ubuntu-24.04
     container:
       image: quay.io/stackrox-io/collector-builder:${{ inputs.collector-builder-tag }}
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake-flags:
+        - -DCMAKE_BUILD_TYPE=Release
         - -DADDRESS_SANITIZER=ON -DCMAKE_BUILD_TYPE=Debug
         - -DUSE_VALGRIND=ON -DCMAKE_BUILD_TYPE=Debug
     steps:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ connscrape:
 unittest:
 	make -C collector unittest
 
-image: collector unittest
+image: collector
 	make -C collector txt-files
 	docker buildx build --load --platform ${PLATFORM} \
 		--build-arg COLLECTOR_VERSION="$(COLLECTOR_TAG)" \
@@ -53,7 +53,7 @@ image: collector unittest
 		-t quay.io/stackrox-io/collector:$(COLLECTOR_TAG) \
 		$(COLLECTOR_BUILD_CONTEXT)
 
-image-dev: collector unittest container-dockerfile-dev
+image-dev: collector container-dockerfile-dev
 	make -C collector txt-files
 	docker buildx build --load --platform ${PLATFORM} \
 		--build-arg COLLECTOR_VERSION="$(COLLECTOR_TAG)" \

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -90,7 +90,7 @@ RUN if [[ "$(uname -m)" == "x86_64" ]];   \
            -DADDRESS_SANITIZER="${ADDRESS_SANITIZER}" \
            -DCOLLECTOR_VERSION="${COLLECTOR_TAG}" \
            -DTRACE_SINSP_EVENTS="${TRACE_SINSP_EVENTS}"
-RUN cmake --build "${CMAKE_BUILD_DIR}" --target collector -- -j "${NPROCS:-4}"
+RUN cmake --build "${CMAKE_BUILD_DIR}" --target collector self-checks -- -j "${NPROCS:-4}"
 RUN strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector"
 
 

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -90,8 +90,7 @@ RUN if [[ "$(uname -m)" == "x86_64" ]];   \
            -DADDRESS_SANITIZER="${ADDRESS_SANITIZER}" \
            -DCOLLECTOR_VERSION="${COLLECTOR_TAG}" \
            -DTRACE_SINSP_EVENTS="${TRACE_SINSP_EVENTS}"
-RUN cmake --build "${CMAKE_BUILD_DIR}" --target all -- -j "${NPROCS:-4}"
-RUN ctest --no-tests=error -V --test-dir "${CMAKE_BUILD_DIR}"
+RUN cmake --build "${CMAKE_BUILD_DIR}" --target collector -- -j "${NPROCS:-4}"
 RUN strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector"
 
 

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -90,7 +90,8 @@ RUN if [[ "$(uname -m)" == "x86_64" ]];   \
            -DADDRESS_SANITIZER="${ADDRESS_SANITIZER}" \
            -DCOLLECTOR_VERSION="${COLLECTOR_TAG}" \
            -DTRACE_SINSP_EVENTS="${TRACE_SINSP_EVENTS}"
-RUN cmake --build "${CMAKE_BUILD_DIR}" --target collector self-checks -- -j "${NPROCS:-4}"
+RUN cmake --build "${CMAKE_BUILD_DIR}" --target all -- -j "${NPROCS:-4}"
+RUN ctest --no-tests=error -V --test-dir "${CMAKE_BUILD_DIR}"
 RUN strip -v --strip-unneeded "${CMAKE_BUILD_DIR}/collector/collector"
 
 


### PR DESCRIPTION
## Description

When iterating on collector changes, waiting for the image build takes some time because we build the binary, then run the unit tests which also attempt to build the binary again and run the tests themselves. If we ask for the image to be built, we should only do the steps required to build the collector binary and creating the image, if we want to run unit tests, we have a separate target for it.

On CI, the unit tests are already being run as a separate step, so removing it from the image build should be a net win with no losses there.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.