### PR TITLE
ROX-28839 - Add RHCOS images to ARM integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,7 +95,6 @@ jobs:
       fail-fast: false
       matrix:
         vm_type:
-
           - rhcos-arm64
           - cos-arm64
           - rhel-arm64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,6 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         vm_type:
+          - rhcos-arm64
           - rhel-arm64
           - ubuntu-arm
           - sles-arm64

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -68,8 +68,8 @@ virtual_machines:
 
   rhcos:
     project: rhcos-cloud
-    # Test RHCOS images for RHEL version coverage (8.6, 9.2, 9.4, etc)
     images:
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.19') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.15') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12') }}"
@@ -89,6 +89,7 @@ virtual_machines:
     arch: arm64
     machine_type: t2a-standard-2
     images:
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.19 aarch64.images.gcp.name') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.15 aarch64.images.gcp.name') }}"
     username: core

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -91,7 +91,6 @@ virtual_machines:
     images:
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.15 aarch64.images.gcp.name') }}"
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12 aarch64.images.gcp.name') }}"
     username: core
     ignition:
       ignition:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -68,12 +68,30 @@ virtual_machines:
 
   rhcos:
     project: rhcos-cloud
+    # Test RHCOS images for RHEL version coverage (8.6, 9.2, 9.4, etc)
     images:
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.17') }}"
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.15') }}"
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.14') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12') }}"
+    username: core
+    ignition:
+      ignition:
+        version: 3.2.0
+      passwd:
+        users:
+          - name: core
+            sshAuthorizedKeys:
+              - "{{ lookup('file', gcp_ssh_key_file + '.pub', errors='ignore') }}"
+    container_engine: podman
+
+  rhcos-arm64:
+    project: rhcos-cloud
+    arch: arm64
+    machine_type: t2a-standard-2
+    images:
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.15 aarch64.images.gcp.name') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12 aarch64.images.gcp.name') }}"
     username: core
     ignition:
       ignition:

--- a/ansible/group_vars/platform_rhcos_arm64.yml
+++ b/ansible/group_vars/platform_rhcos_arm64.yml
@@ -1,0 +1,2 @@
+---
+ansible_user: core


### PR DESCRIPTION
## Description

Adds 4.12, 4.15, and 4.18 OCP versions of RHCOS to ARM integration tests.

(based on arm64 runners in https://github.com/stackrox/collector/pull/2084 for faster build)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

 ✅ CI tests of RHCOS arm64 pass 
