### PR TITLE
Prevent serialization in LogProtobufMessage if log level is not met

### DIFF
--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -254,6 +254,11 @@ std::optional<std::string> SanitizedUTF8(std::string_view str) {
 
 void LogProtobufMessage(const google::protobuf::Message& msg) {
   using namespace google::protobuf::util;
+
+  if (!logging::CheckLogLevel(logging::LogLevel::DEBUG)) {
+    return;
+  }
+
   std::string output;
   absl::Status status = MessageToJsonString(msg, &output, JsonPrintOptions{});
   if (status.ok()) {


### PR DESCRIPTION
## Description

This is a small PR to prevent protobuf message serialization on the stdout clients when log level would discard the result.

This changed was triggered by this comment: https://github.com/stackrox/collector/pull/2063#discussion_r2030217477

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Was not able to test this locally, help would be appreciated.
