### PR TITLE
Fix two address sanitizer bugs

### DIFF
--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -1,5 +1,6 @@
 #include "NetworkSignalHandler.h"
 
+#include <cstring>
 #include <optional>
 
 #include <libsinsp/sinsp.h>
@@ -89,7 +90,14 @@ std::optional<Connection> NetworkSignalHandler::GetConnection(sinsp_evt* evt) {
   }
 
   const int64_t* res = event_extractor_->get_event_rawres(evt);
-  if (!res || *res < 0) {
+  if (res == nullptr) {
+    return std::nullopt;
+  }
+
+  // Read the value into aligned memory
+  int64_t res_value = 0;
+  std::memcpy(&res_value, res, sizeof(int64_t));
+  if (res_value < 0) {
     // ignore unsuccessful events for now.
     return std::nullopt;
   }

--- a/collector/lib/NetworkSignalHandler.cpp
+++ b/collector/lib/NetworkSignalHandler.cpp
@@ -89,15 +89,8 @@ std::optional<Connection> NetworkSignalHandler::GetConnection(sinsp_evt* evt) {
     }
   }
 
-  const int64_t* res = event_extractor_->get_event_rawres(evt);
-  if (res == nullptr) {
-    return std::nullopt;
-  }
-
-  // Read the value into aligned memory
-  int64_t res_value = 0;
-  std::memcpy(&res_value, res, sizeof(int64_t));
-  if (res_value < 0) {
+  auto res = event_extractor_->get_event_rawres(evt);
+  if (!res.has_value() || res.value() < 0) {
     // ignore unsuccessful events for now.
     return std::nullopt;
   }

--- a/collector/lib/NetworkSignalHandler.h
+++ b/collector/lib/NetworkSignalHandler.h
@@ -20,7 +20,7 @@ class EventExtractor;
 class NetworkSignalHandler final : public SignalHandler {
  public:
   explicit NetworkSignalHandler(sinsp* inspector, std::shared_ptr<ConnectionTracker> conn_tracker, system_inspector::Stats* stats);
-  ~NetworkSignalHandler();
+  ~NetworkSignalHandler() override;
 
   std::string GetName() override { return "NetworkSignalHandler"; }
   Result HandleSignal(sinsp_evt* evt) override;

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -30,6 +30,12 @@ class ProcessSignalHandler : public SignalHandler {
         stats_(stats),
         config_(config) {}
 
+  ProcessSignalHandler(const ProcessSignalHandler&) = delete;
+  ProcessSignalHandler(ProcessSignalHandler&&) = delete;
+  ProcessSignalHandler& operator=(const ProcessSignalHandler&) = delete;
+  ProcessSignalHandler& operator=(ProcessSignalHandler&&) = delete;
+  ~ProcessSignalHandler() override = default;
+
   bool Start() override;
   bool Stop() override;
   Result HandleSignal(sinsp_evt* evt) override;

--- a/collector/lib/SelfCheckHandler.cpp
+++ b/collector/lib/SelfCheckHandler.cpp
@@ -56,10 +56,10 @@ SignalHandler::Result SelfCheckNetworkHandler::HandleSignal(sinsp_evt* evt) {
     return IGNORED;
   }
 
-  const uint16_t* server_port = event_extractor_->get_server_port(evt);
-  const uint16_t* client_port = event_extractor_->get_client_port(evt);
+  auto server_port = event_extractor_->get_server_port(evt);
+  auto client_port = event_extractor_->get_client_port(evt);
 
-  if (server_port == nullptr || client_port == nullptr) {
+  if (!server_port.has_value() | !client_port.has_value()) {
     return IGNORED;
   }
 

--- a/collector/lib/SignalHandler.h
+++ b/collector/lib/SignalHandler.h
@@ -25,6 +25,13 @@ class SignalHandler {
     FINISHED,
   };
 
+  SignalHandler() = default;
+  SignalHandler(const SignalHandler&) = default;
+  SignalHandler(SignalHandler&&) = delete;
+  SignalHandler& operator=(const SignalHandler&) = default;
+  SignalHandler& operator=(SignalHandler&&) = delete;
+  virtual ~SignalHandler() = default;
+
   virtual std::string GetName() = 0;
   virtual bool Start() { return true; }
   virtual bool Stop() { return true; }


### PR DESCRIPTION


## Description

<details>
<summary>NetworkSignalHandler attempts to read int64_t from unaligned memory.</summary>

```
/go/src/github.com/stackrox/collector/collector/lib/NetworkSignalHandler.cpp:92:15: runtime error: load of misaligned address 0x7f181b9dcb7c for type 'const int64_t', which requires 8 byte alignment
0x7f181b9dcb7c: note: pointer points here
  00 00 08 00 00 00 00 00  00 00 00 00 00 00 00 00  24 00 00 00 03 00 00 00  96 75 63 5c c4 ff 33 18
              ^
```

</details>

<details>
<summary>Wrong destructor being called for SignalHandlers.</summary>

```
==10821==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x604000011a90 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   40 bytes;
  size of the deallocated type: 8 bytes.
    #0 0x7f182948d3cf in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xb73cf)
    #1 0xc4f939 in std::default_delete<collector::SignalHandler>::operator()(collector::SignalHandler*) const /usr/include/c++/11/bits/unique_ptr.h:85
    #2 0x1040f8c in std::__uniq_ptr_impl<collector::SignalHandler, std::default_delete<collector::SignalHandler> >::reset(collector::SignalHandler*) /usr/include/c++/11/bits/unique_ptr.h:182
    #3 0x1040bdc in std::__uniq_ptr_impl<collector::SignalHandler, std::default_delete<collector::SignalHandler> >::operator=(std::__uniq_ptr_impl<collector::SignalHandler, std::default_delete<collector::SignalHandler> >&&) /usr/include/c++/11/bits/unique_ptr.h:167
    #4 0x103fedd in std::__uniq_ptr_data<collector::SignalHandler, std::default_delete<collector::SignalHandler>, true, true>::operator=(std::__uniq_ptr_data<collector::SignalHandler, std::default_delete<collector::SignalHandler>, true, true>&&) /usr/include/c++/11/bits/unique_ptr.h:212
    #5 0x103ffd3 in std::unique_ptr<collector::SignalHandler, std::default_delete<collector::SignalHandler> >::operator=(std::unique_ptr<collector::SignalHandler, std::default_delete<collector::SignalHandler> >&&) /usr/include/c++/11/bits/unique_ptr.h:371
    #6 0x10400c9 in collector::system_inspector::Service::SignalHandlerEntry::operator=(collector::system_inspector::Service::SignalHandlerEntry&&) /go/src/github.com/stackrox/collector/collector/lib/system-inspector/Service.h:57
    #7 0x10403a7 in collector::system_inspector::Service::SignalHandlerEntry* std::__copy_move<true, false, std::random_access_iterator_tag>::__copy_m<collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*>(collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*) /usr/include/c++/11/bits/stl_algobase.h:405
    #8 0x103e5c5 in collector::system_inspector::Service::SignalHandlerEntry* std::__copy_move_a2<true, collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*>(collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*) /usr/include/c++/11/bits/stl_algobase.h:495
    #9 0x103af21 in collector::system_inspector::Service::SignalHandlerEntry* std::__copy_move_a1<true, collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*>(collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*, collector::system_inspector::Service::SignalHandlerEntry*) /usr/include/c++/11/bits/stl_algobase.h:522
    #10 0x1037587 in __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > > std::__copy_move_a<true, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > > >(__gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >) /usr/include/c++/11/bits/stl_algobase.h:529
    #11 0x1031d84 in __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > > std::move<__gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > > >(__gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >, __gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >) /usr/include/c++/11/bits/stl_algobase.h:652
    #12 0x102b3c5 in std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> >::_M_erase(__gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >) /usr/include/c++/11/bits/vector.tcc:175
    #13 0x1023729 in std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> >::erase(__gnu_cxx::__normal_iterator<collector::system_inspector::Service::SignalHandlerEntry const*, std::vector<collector::system_inspector::Service::SignalHandlerEntry, std::allocator<collector::system_inspector::Service::SignalHandlerEntry> > >) /usr/include/c++/11/bits/stl_vector.h:1431
    #14 0x100f2b9 in collector::system_inspector::Service::Run(std::atomic<collector::ControlValue> const&) /go/src/github.com/stackrox/collector/collector/lib/system-inspector/Service.cpp:276
    #15 0xc3d512 in collector::CollectorService::RunForever() /go/src/github.com/stackrox/collector/collector/lib/CollectorService.cpp:123
    #16 0xbbbd6d in RunService(collector::CollectorConfig&) /go/src/github.com/stackrox/collector/collector/collector.cpp:137
    #17 0xbbdaf2 in main /go/src/github.com/stackrox/collector/collector/collector.cpp:194
    #18 0x7f1827e9a5cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf)
    #19 0x7f1827e9a67f in __libc_start_main_alias_2 (/lib64/libc.so.6+0x2967f)
    #20 0xbb90b4 in _start (/go/src/github.com/stackrox/collector/cmake-build/collector/collector+0xbb90b4)

0x604000011a90 is located 0 bytes inside of 40-byte region [0x604000011a90,0x604000011ab8)
allocated by thread T0 here:
    #0 0x7f182948c367 in operator new(unsigned long) (/lib64/libasan.so.6+0xb6367)
    #1 0x1020df0 in std::_MakeUniq<collector::SelfCheckNetworkHandler>::__single_object std::make_unique<collector::SelfCheckNetworkHandler, sinsp*>(sinsp*&&) /usr/include/c++/11/bits/unique_ptr.h:962
    #2 0x10085cd in collector::system_inspector::Service::Service(collector::CollectorConfig const&) /go/src/github.com/stackrox/collector/collector/lib/system-inspector/Service.cpp:96
    #3 0xc36f12 in collector::CollectorService::CollectorService(collector::CollectorConfig&, std::atomic<collector::ControlValue>*, std::atomic<int> const*) /go/src/github.com/stackrox/collector/collector/lib/CollectorService.cpp:30
    #4 0xbbb89f in RunService(collector::CollectorConfig&) /go/src/github.com/stackrox/collector/collector/collector.cpp:125
    #5 0xbbdaf2 in main /go/src/github.com/stackrox/collector/collector/collector.cpp:194
    #6 0x7f1827e9a5cf in __libc_start_call_main (/lib64/libc.so.6+0x295cf)

SUMMARY: AddressSanitizer: new-delete-type-mismatch (/lib64/libasan.so.6+0xb73cf) in operator delete(void*, unsigned long)
==10821==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
==10821==ABORTING
```

</details>

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run collector under address sanitizer with the proposed changes and checked the errors are gone.