### PR TITLE
Use 'latest' tag for upstream image

### DIFF
--- a/collector/container/Dockerfile
+++ b/collector/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG BUILD_TYPE=rhel
 ARG ROOT_DIR=.


### PR DESCRIPTION
## Description

We are already using the 'stream9' tag for the builder image, which is essentially the same as the latest tag for ubi9, this will make them closer to each other.

As far as I can tell, the main repo is already using latest for its images.
See: https://github.com/stackrox/stackrox/blob/af2f4e3025c8a10eb3debeb8f960ef27c887806a/image/rhel/Dockerfile#L6

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.

## Summary by Sourcery

Enhancements:
- Switch from a specific version (9.3) to the 'latest' tag for the UBI minimal base image