### PR TITLE
ROX-27947: Disable scraper for repeated network test

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -38,6 +38,7 @@ func TestRepeatedNetworkFlow(t *testing.T) {
 	repeatedNetworkFlowTestSuite := &suites.RepeatedNetworkFlowTestSuite{
 		AfterglowPeriod:        10,
 		ScrapeInterval:         4,
+		TurnOffScrape:          false,
 		EnableAfterglow:        true,
 		NumMetaIter:            1,
 		NumIter:                11,
@@ -55,6 +56,7 @@ func TestRepeatedNetworkFlowWithZeroAfterglowPeriod(t *testing.T) {
 	repeatedNetworkFlowTestSuite := &suites.RepeatedNetworkFlowTestSuite{
 		AfterglowPeriod:        0,
 		ScrapeInterval:         2,
+		TurnOffScrape:          false,
 		EnableAfterglow:        true,
 		NumMetaIter:            1,
 		NumIter:                3,
@@ -71,6 +73,7 @@ func TestRepeatedNetworkFlowThreeCurlsNoAfterglow(t *testing.T) {
 	repeatedNetworkFlowTestSuite := &suites.RepeatedNetworkFlowTestSuite{
 		AfterglowPeriod:        0,
 		ScrapeInterval:         4,
+		TurnOffScrape:          true,
 		EnableAfterglow:        false,
 		NumMetaIter:            1,
 		NumIter:                3,

--- a/integration-tests/suites/repeated_network_flow.go
+++ b/integration-tests/suites/repeated_network_flow.go
@@ -24,6 +24,7 @@ type RepeatedNetworkFlowTestSuite struct {
 	EnableAfterglow        bool
 	AfterglowPeriod        int
 	ScrapeInterval         int
+	TurnOffScrape          bool
 	NumMetaIter            int
 	NumIter                int
 	SleepBetweenCurlTime   int
@@ -44,6 +45,7 @@ func (s *RepeatedNetworkFlowTestSuite) SetupSuite() {
 			// turnOffScrape will be true, but the scrapeInterval
 			// also controls the reporting interval for network events
 			"scrapeInterval": s.ScrapeInterval,
+			"turnOffScrape":  s.TurnOffScrape,
 		},
 		Env: map[string]string{
 			"ROX_AFTERGLOW_PERIOD": strconv.Itoa(s.AfterglowPeriod),


### PR DESCRIPTION
## Description

Test.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Manual tests.

## Summary by Sourcery

Add configuration to disable scraping in repeated network flow tests

Enhancements:
- Introduced a new configuration parameter 'TurnOffScrape' to control scraping behavior in network flow test suites

Tests:
- Modified integration tests to support optional scraping disablement
- Updated test suite configuration to include new scraping control parameter