### PR TITLE
Use std::filesystem::path in GetHostPath

### DIFF
--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -418,7 +418,7 @@ std::string CollectorConfig::Hostname() const {
   return hostname_;
 }
 
-std::string CollectorConfig::HostProc() const {
+const std::filesystem::path& CollectorConfig::HostProc() const {
   return host_proc_;
 }
 

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -80,7 +80,7 @@ class CollectorConfig {
   bool ScrapeListenEndpoints() const { return scrape_listen_endpoints_; }
   int ScrapeInterval() const;
   std::string Hostname() const;
-  std::string HostProc() const;
+  const std::filesystem::path& HostProc() const;
   CollectionMethod GetCollectionMethod() const;
   std::vector<std::string> Syscalls() const;
   int64_t AfterglowPeriod() const;
@@ -201,7 +201,7 @@ class CollectorConfig {
   bool turn_off_scrape_;
   std::vector<std::string> syscalls_;
   std::string hostname_;
-  std::string host_proc_;
+  std::filesystem::path host_proc_;
   bool disable_network_flows_ = false;
   bool scrape_listen_endpoints_ = false;
   UnorderedSet<L4ProtoPortPair> ignored_l4proto_port_pairs_;

--- a/collector/lib/ProcfsScraper.h
+++ b/collector/lib/ProcfsScraper.h
@@ -2,6 +2,7 @@
 #define COLLECTOR_PROCFSSCRAPER_H
 
 #include <cstring>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -19,7 +20,7 @@ class IConnScraper {
 // ConnScraper is a class that allows scraping a `/proc`-like directory structure for active network connections.
 class ConnScraper : public IConnScraper {
  public:
-  explicit ConnScraper(std::string proc_path, std::shared_ptr<ProcessStore> process_store = 0)
+  explicit ConnScraper(std::filesystem::path proc_path, std::shared_ptr<ProcessStore> process_store = 0)
       : proc_path_(std::move(proc_path)),
         process_store_(process_store) {}
 
@@ -27,7 +28,7 @@ class ConnScraper : public IConnScraper {
   bool Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints);
 
  private:
-  std::string proc_path_;
+  std::filesystem::path proc_path_;
   std::shared_ptr<ProcessStore> process_store_;
 };
 

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -133,19 +133,13 @@ std::string Base64Decode(std::string const& encoded_string) {
   return ret;
 }
 
-std::string GetHostPath(const std::string& file) {
+std::filesystem::path GetHostPath(std::string_view file) {
   const char* host_root = std::getenv("COLLECTOR_HOST_ROOT");
-  if (!host_root) {
+  if (host_root == nullptr) {
     host_root = "";
   }
-  std::string host_file(host_root);
-  // Check if we are joining paths without a seperator,
-  if (host_file.length() && file.length() &&
-      host_file.back() != '/' && file.front() != '/') {
-    host_file += '/';
-  }
-  host_file += file;
-  return host_file;
+  std::filesystem::path host_path(host_root);
+  return host_path / file;
 }
 
 const char* GetSNIHostname() {

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -133,13 +133,13 @@ std::string Base64Decode(std::string const& encoded_string) {
   return ret;
 }
 
-std::filesystem::path GetHostPath(std::string_view file) {
+std::filesystem::path GetHostPath(const std::filesystem::path& file) {
   const char* host_root = std::getenv("COLLECTOR_HOST_ROOT");
   if (host_root == nullptr) {
     host_root = "";
   }
   std::filesystem::path host_path(host_root);
-  return host_path / file;
+  return host_path / (file.is_absolute() ? file.relative_path() : file);
 }
 
 const char* GetSNIHostname() {

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -3,11 +3,8 @@
 #define _UTILITY_H_
 
 #include <cerrno>
-#include <chrono>
-#include <cinttypes>
-#include <functional>
+#include <filesystem>
 #include <iostream>
-#include <memory>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -31,7 +28,7 @@ const char* SignalName(int signum);
 std::string Base64Decode(std::string const& encoded_string);
 
 // Get path using host prefix from COLLECTOR_HOST_ROOT env var
-std::string GetHostPath(const std::string& file);
+std::filesystem::path GetHostPath(std::string_view file);
 
 // Get SNI hostname from SNI_HOSTNAME env var
 const char* GetSNIHostname();

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -28,7 +28,7 @@ const char* SignalName(int signum);
 std::string Base64Decode(std::string const& encoded_string);
 
 // Get path using host prefix from COLLECTOR_HOST_ROOT env var
-std::filesystem::path GetHostPath(std::string_view file);
+std::filesystem::path GetHostPath(const std::filesystem::path& file);
 
 // Get SNI hostname from SNI_HOSTNAME env var
 const char* GetSNIHostname();


### PR DESCRIPTION
## Description

This change simplifies the logic for GetHostPath, since std::filesystem::path provides a dedicated operator/ which is guaranteed to have the correct separator and use it properly when concatenating paths.

On top of this, some C-like operations have been changed to use their std::filesystem equivalent.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
