### PR TITLE
Stop copying hostname

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     container:
-      image: fedora:40
+      image: fedora:41
     steps:
       - name: dnf install dependencies
         run: |

--- a/collector/lib/CollectorConfig.cpp
+++ b/collector/lib/CollectorConfig.cpp
@@ -124,12 +124,6 @@ void CollectorConfig::InitCollectorConfig(CollectorArgs* args) {
     }
   }
 
-  // Get hostname
-  hostname_ = GetHostname();
-  if (hostname_.empty()) {
-    CLOG(FATAL) << "Unable to determine the hostname. Consider setting the environment variable NODE_HOSTNAME";
-  }
-
   // Get path to host proc dir
   host_proc_ = GetHostPath("/proc");
 
@@ -414,10 +408,6 @@ CollectionMethod CollectorConfig::GetCollectionMethod() const {
   return collection_method_;
 }
 
-std::string CollectorConfig::Hostname() const {
-  return hostname_;
-}
-
 const std::filesystem::path& CollectorConfig::HostProc() const {
   return host_proc_;
 }
@@ -443,7 +433,7 @@ std::ostream& operator<<(std::ostream& os, const CollectorConfig& c) {
          << "collection_method:" << c.GetCollectionMethod()
          << ", scrape_interval:" << c.ScrapeInterval()
          << ", turn_off_scrape:" << c.TurnOffScrape()
-         << ", hostname:" << c.Hostname()
+         << ", hostname:" << HostInfo::GetHostname()
          << ", processesListeningOnPorts:" << c.IsProcessesListeningOnPortsEnabled()
          << ", logLevel:" << c.LogLevel()
          << ", set_import_users:" << c.ImportUsers()

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -79,7 +79,6 @@ class CollectorConfig {
   bool TurnOffScrape() const;
   bool ScrapeListenEndpoints() const { return scrape_listen_endpoints_; }
   int ScrapeInterval() const;
-  std::string Hostname() const;
   const std::filesystem::path& HostProc() const;
   CollectionMethod GetCollectionMethod() const;
   std::vector<std::string> Syscalls() const;
@@ -200,7 +199,6 @@ class CollectorConfig {
   CollectionMethod collection_method_;
   bool turn_off_scrape_;
   std::vector<std::string> syscalls_;
-  std::string hostname_;
   std::filesystem::path host_proc_;
   bool disable_network_flows_ = false;
   bool scrape_listen_endpoints_ = false;

--- a/collector/lib/CollectorService.cpp
+++ b/collector/lib/CollectorService.cpp
@@ -52,7 +52,7 @@ CollectorService::CollectorService(CollectorConfig& config, std::atomic<ControlV
     conn_tracker_->UpdateIgnoredNetworks(config_.IgnoredNetworks());
     conn_tracker_->UpdateNonAggregatedNetworks(config_.NonAggregatedNetworks());
 
-    network_connection_info_service_comm_ = std::make_shared<NetworkConnectionInfoServiceComm>(config_.Hostname(), config_.grpc_channel);
+    network_connection_info_service_comm_ = std::make_shared<NetworkConnectionInfoServiceComm>(config_.grpc_channel);
 
     auto total_reporter = config_.EnableConnectionStats() ? exporter_.GetConnectionsTotalReporter() : nullptr;
     auto rate_reporter = config_.EnableConnectionStats() ? exporter_.GetConnectionsRateReporter() : nullptr;
@@ -72,7 +72,7 @@ CollectorService::CollectorService(CollectorConfig& config, std::atomic<ControlV
   }
 
   // Initialize civetweb server handlers
-  civet_endpoints_.emplace_back(std::make_unique<GetStatus>(config_.Hostname(), &system_inspector_));
+  civet_endpoints_.emplace_back(std::make_unique<GetStatus>(&system_inspector_));
   civet_endpoints_.emplace_back(std::make_unique<LogLevelHandler>());
   civet_endpoints_.emplace_back(std::make_unique<ProfilerHandler>());
 

--- a/collector/lib/GetStatus.cpp
+++ b/collector/lib/GetStatus.cpp
@@ -4,6 +4,8 @@
 
 #include <json/json.h>
 
+#include "HostInfo.h"
+
 namespace collector {
 
 const std::string GetStatus::kBaseRoute = "/ready";
@@ -24,7 +26,7 @@ bool GetStatus::handleGet(CivetServer* server, struct mg_connection* conn) {
 
     status["status"] = "ok";
     status["collector"] = Json::Value(Json::objectValue);
-    status["collector"]["node"] = node_name_;
+    status["collector"]["node"] = HostInfo::GetHostname();
     status["collector"]["events"] = Json::UInt64(stats.nEvents);
     status["collector"]["drops"] = drops;
     status["collector"]["preemptions"] = Json::UInt64(stats.nPreemptions);

--- a/collector/lib/GetStatus.h
+++ b/collector/lib/GetStatus.h
@@ -10,8 +10,8 @@ namespace collector {
 
 class GetStatus : public CivetWrapper {
  public:
-  GetStatus(std::string node_name, const system_inspector::SystemInspector* si)
-      : node_name_(std::move(node_name)), system_inspector_(si) {}
+  GetStatus(const system_inspector::SystemInspector* si)
+      : system_inspector_(si) {}
   bool handleGet(CivetServer* server, struct mg_connection* conn) override;
 
   const std::string& GetBaseRoute() override {
@@ -21,7 +21,6 @@ class GetStatus : public CivetWrapper {
  private:
   static const std::string kBaseRoute;
 
-  std::string node_name_;
   const system_inspector::SystemInspector* system_inspector_;
 };
 

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -32,7 +32,6 @@ extern "C" {
 #include <regex>
 #include <string>
 
-#include "FileSystem.h"
 #include "Logging.h"
 #include "Utility.h"
 
@@ -92,7 +91,7 @@ struct KernelVersion {
       release = kernel_version_env;
     }
 
-    struct utsname uts_buffer {};
+    struct utsname uts_buffer{};
     if (uname(&uts_buffer) == 0) {
       if (release.empty()) {
         release = uts_buffer.release;
@@ -178,7 +177,9 @@ class HostInfo {
   virtual KernelVersion GetKernelVersion();
 
   // Get the host's hostname
-  const std::string& GetHostname();
+  static const std::string& GetHostname() {
+    return HostInfo::Instance().GetHostnameInner();
+  }
 
   // Get the Linux distribution, if possible.
   // If not, default to "Linux"
@@ -273,6 +274,8 @@ class HostInfo {
   HostInfo() = default;
 
  private:
+  const std::string& GetHostnameInner();
+
   // the kernel version of the host
   KernelVersion kernel_version_;
   // the Linux distribution of the host (defaults to Linux)

--- a/collector/lib/NetworkConnectionInfoServiceComm.cpp
+++ b/collector/lib/NetworkConnectionInfoServiceComm.cpp
@@ -1,6 +1,7 @@
 #include "NetworkConnectionInfoServiceComm.h"
 
 #include "GRPCUtil.h"
+#include "HostInfo.h"
 #include "Utility.h"
 
 namespace collector {
@@ -11,12 +12,12 @@ constexpr char NetworkConnectionInfoServiceComm::kSupportedCaps[];
 
 std::unique_ptr<grpc::ClientContext> NetworkConnectionInfoServiceComm::CreateClientContext() const {
   auto ctx = std::make_unique<grpc::ClientContext>();
-  ctx->AddMetadata(kHostnameMetadataKey, hostname_);
+  ctx->AddMetadata(kHostnameMetadataKey, HostInfo::GetHostname());
   ctx->AddMetadata(kCapsMetadataKey, kSupportedCaps);
   return ctx;
 }
 
-NetworkConnectionInfoServiceComm::NetworkConnectionInfoServiceComm(std::string hostname, std::shared_ptr<grpc::Channel> channel) : hostname_(std::move(hostname)), channel_(std::move(channel)) {
+NetworkConnectionInfoServiceComm::NetworkConnectionInfoServiceComm(std::shared_ptr<grpc::Channel> channel) : channel_(std::move(channel)) {
   if (channel_) {
     stub_ = sensor::NetworkConnectionInfoService::NewStub(channel_);
   }

--- a/collector/lib/NetworkConnectionInfoServiceComm.h
+++ b/collector/lib/NetworkConnectionInfoServiceComm.h
@@ -33,7 +33,7 @@ class INetworkConnectionInfoServiceComm {
 
 class NetworkConnectionInfoServiceComm : public INetworkConnectionInfoServiceComm {
  public:
-  NetworkConnectionInfoServiceComm(std::string hostname, std::shared_ptr<grpc::Channel> channel);
+  NetworkConnectionInfoServiceComm(std::shared_ptr<grpc::Channel> channel);
 
   void ResetClientContext() override;
   bool WaitForConnectionReady(const std::function<bool()>& check_interrupted) override;
@@ -54,7 +54,6 @@ class NetworkConnectionInfoServiceComm : public INetworkConnectionInfoServiceCom
 
   std::unique_ptr<grpc::ClientContext> CreateClientContext() const;
 
-  std::string hostname_;
   std::shared_ptr<grpc::Channel> channel_;
   std::unique_ptr<sensor::NetworkConnectionInfoService::Stub> stub_;
 

--- a/collector/lib/Utility.cpp
+++ b/collector/lib/Utility.cpp
@@ -153,11 +153,6 @@ const char* GetSNIHostname() {
   return "sensor.stackrox";
 }
 
-std::string GetHostname() {
-  HostInfo& info = HostInfo::Instance();
-  return info.GetHostname();
-}
-
 std::vector<std::string> SplitStringView(const std::string_view sv, char delim) {
   std::vector<std::string> parts;
   std::string_view::size_type offset = 0;

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -33,9 +33,6 @@ std::filesystem::path GetHostPath(const std::filesystem::path& file);
 // Get SNI hostname from SNI_HOSTNAME env var
 const char* GetSNIHostname();
 
-// Get hostname from NODE_HOSTNAME env var
-std::string GetHostname();
-
 // Allows Splitting a std::string_view into a vector of strings
 std::vector<std::string> SplitStringView(const std::string_view sv, char delim = ' ');
 


### PR DESCRIPTION

## Description

The hostname for a given node is lazily loaded in the HostInfo and will outlast any other object attempting to use it. As such, we should try to avoid unnecessary copies and just call the GetHostname method of the HostInfo class.

The GetHostname function from our utilities has been turned into a static method of HostInfo so we can directly access it calling HostInfo::GetHostname(), otherwise we would need HostInfo::Instance().GetHostname() which is a bit too verbose.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check CI logs to validate the hostname is properly being captured.
