### PR TITLE
Refactor NetworkStatusNotifier

### DIFF
--- a/collector/CMakeLists.txt
+++ b/collector/CMakeLists.txt
@@ -68,8 +68,6 @@ add_subdirectory(lib)
 add_executable(collector collector.cpp)
 target_link_libraries(collector collector_lib)
 
-target_link_libraries(collector prometheus-cpp::core prometheus-cpp::pull)
-
 add_executable(connscrape connscrape.cpp)
 target_link_libraries(connscrape collector_lib)
 

--- a/collector/lib/CMakeLists.txt
+++ b/collector/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(collector_lib uuid)
 target_link_libraries(collector_lib gRPC::grpc++)
 target_link_libraries(collector_lib civetweb::civetweb-cpp)
 target_link_libraries(collector_lib yaml-cpp::yaml-cpp)
+target_link_libraries(collector_lib prometheus-cpp::core prometheus-cpp::pull)
 
 target_link_libraries(collector_lib rox-proto)
 

--- a/collector/lib/CollectorConnectionStats.h
+++ b/collector/lib/CollectorConnectionStats.h
@@ -37,6 +37,12 @@ class CollectorConnectionStats {
   }
 
  private:
+  // prometheus::Registry owns all stats and only exposes references to
+  // them. However, storing references as members of a class invalidate
+  // copy and move constructors and assignment operators, making it
+  // harder to work with this type of class.
+  //
+  // To work around this, we store raw pointers instead.
   prometheus::Summary* inbound_private_summary_;
   prometheus::Summary* inbound_public_summary_;
   prometheus::Summary* outbound_private_summary_;

--- a/collector/lib/CollectorConnectionStats.h
+++ b/collector/lib/CollectorConnectionStats.h
@@ -1,0 +1,61 @@
+#ifndef _COLLECTOR_CONNECTION_STATS_
+#define _COLLECTOR_CONNECTION_STATS_
+
+#include <algorithm>
+
+#include "prometheus/gauge.h"
+#include "prometheus/registry.h"
+#include "prometheus/summary.h"
+
+namespace collector {
+template <typename T>
+class CollectorConnectionStats {
+ public:
+  CollectorConnectionStats(
+      prometheus::Registry* registry,
+      const std::string& name,
+      const std::string& help,
+      std::chrono::milliseconds max_age,
+      const std::vector<double>& quantiles,
+      double error) {
+    auto& family = prometheus::BuildSummary()
+                       .Name(name)
+                       .Help(help)
+                       .Register(*registry);
+    auto q = MakeQuantiles(quantiles, error);
+    inbound_private_summary_ = &family.Add({{"dir", "in"}, {"peer", "private"}}, q, max_age);
+    inbound_public_summary_ = &family.Add({{"dir", "in"}, {"peer", "public"}}, q, max_age);
+    outbound_private_summary_ = &family.Add({{"dir", "out"}, {"peer", "private"}}, q, max_age);
+    outbound_public_summary_ = &family.Add({{"dir", "out"}, {"peer", "public"}}, q, max_age);
+  }
+
+  void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) {
+    inbound_private_summary_->Observe(inbound_private);
+    inbound_public_summary_->Observe(inbound_public);
+    outbound_private_summary_->Observe(outbound_private);
+    outbound_public_summary_->Observe(outbound_public);
+  }
+
+ private:
+  prometheus::Summary* inbound_private_summary_;
+  prometheus::Summary* inbound_public_summary_;
+  prometheus::Summary* outbound_private_summary_;
+  prometheus::Summary* outbound_public_summary_;
+
+  prometheus::Summary::Quantiles MakeQuantiles(std::vector<double> quantiles, double error) {
+    prometheus::Summary::Quantiles result;
+
+    result.reserve(quantiles.size());
+
+    auto make_quantile = [error](double q) -> prometheus::detail::CKMSQuantiles::Quantile {
+      return {q, error};
+    };
+
+    std::transform(quantiles.begin(), quantiles.end(), std::back_inserter(result), make_quantile);
+
+    return result;
+  }
+};
+}  // namespace collector
+
+#endif

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -43,7 +43,6 @@ class CollectorService {
   std::vector<std::unique_ptr<CivetWrapper>> civet_endpoints_;
 
   // Prometheus
-  std::shared_ptr<prometheus::Registry> registry_;
   prometheus::Exposer exposer_;
   CollectorStatsExporter exporter_;
 
@@ -51,7 +50,6 @@ class CollectorService {
 
   // Network monitoring
   std::shared_ptr<ConnectionTracker> conn_tracker_;
-  std::shared_ptr<IConnScraper> conn_scraper_;
   std::unique_ptr<NetworkStatusNotifier> net_status_notifier_;
   std::shared_ptr<ProcessStore> process_store_;
   std::shared_ptr<NetworkConnectionInfoServiceComm> network_connection_info_service_comm_;

--- a/collector/lib/CollectorStats.h
+++ b/collector/lib/CollectorStats.h
@@ -96,14 +96,6 @@ class CollectorStats {
   CollectorStats() {};
 };
 
-template <typename T>
-class CollectorConnectionStats {
- public:
-  virtual void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) = 0;
-
-  virtual ~CollectorConnectionStats() {}
-};
-
 namespace internal {
 
 template <typename T>

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -9,73 +9,14 @@
 #include "Logging.h"
 #include "Utility.h"
 #include "prometheus/gauge.h"
-#include "prometheus/summary.h"
 #include "system-inspector/Service.h"
 
 namespace collector {
 
-template <typename T>
-class CollectorConnectionStatsPrometheus : public CollectorConnectionStats<T> {
- public:
-  CollectorConnectionStatsPrometheus(
-      std::shared_ptr<prometheus::Registry> registry,
-      std::string name,
-      std::string help,
-      std::chrono::milliseconds max_age,
-      const std::vector<double>& quantiles,
-      double error) : family_(prometheus::BuildSummary().Name(name).Help(help).Register(*registry)),
-                      inbound_private_summary_(family_.Add({{"dir", "in"}, {"peer", "private"}}, MakeQuantiles(quantiles, error), max_age)),
-                      inbound_public_summary_(family_.Add({{"dir", "in"}, {"peer", "public"}}, MakeQuantiles(quantiles, error), max_age)),
-                      outbound_private_summary_(family_.Add({{"dir", "out"}, {"peer", "private"}}, MakeQuantiles(quantiles, error), max_age)),
-                      outbound_public_summary_(family_.Add({{"dir", "out"}, {"peer", "public"}}, MakeQuantiles(quantiles, error), max_age)) {}
-
-  void Observe(T inbound_private, T inbound_public, T outbound_private, T outbound_public) override {
-    inbound_private_summary_.Observe(inbound_private);
-    inbound_public_summary_.Observe(inbound_public);
-    outbound_private_summary_.Observe(outbound_private);
-    outbound_public_summary_.Observe(outbound_public);
-  }
-
- private:
-  prometheus::Family<prometheus::Summary>& family_;
-  prometheus::Summary& inbound_private_summary_;
-  prometheus::Summary& inbound_public_summary_;
-  prometheus::Summary& outbound_private_summary_;
-  prometheus::Summary& outbound_public_summary_;
-
-  prometheus::Summary::Quantiles MakeQuantiles(std::vector<double> quantiles, double error) {
-    prometheus::Summary::Quantiles result;
-
-    result.reserve(quantiles.size());
-
-    auto make_quantile = [error](double q) -> prometheus::detail::CKMSQuantiles::Quantile {
-      return {q, error};
-    };
-
-    std::transform(quantiles.begin(), quantiles.end(), std::back_inserter(result), make_quantile);
-
-    return result;
-  }
-};
-
-CollectorStatsExporter::CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, system_inspector::Service* si)
-    : registry_(std::move(registry)),
+CollectorStatsExporter::CollectorStatsExporter(const CollectorConfig* config, system_inspector::Service* si)
+    : registry_(std::make_shared<prometheus::Registry>()),
       config_(config),
-      system_inspector_(si),
-      connections_total_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<unsigned int>>(
-          registry_,
-          "rox_connections_total",
-          "Amount of stored connections over time",
-          std::chrono::minutes{config->GetConnectionStatsWindow()},
-          config->GetConnectionStatsQuantiles(),
-          config->GetConnectionStatsError())),
-      connections_rate_reporter_(std::make_shared<CollectorConnectionStatsPrometheus<float>>(
-          registry_,
-          "rox_connections_rate",
-          "Rate of connections over time",
-          std::chrono::minutes{config->GetConnectionStatsWindow()},
-          config->GetConnectionStatsQuantiles(),
-          config->GetConnectionStatsError())) {}
+      system_inspector_(si) {}
 
 bool CollectorStatsExporter::start() {
   if (!thread_.Start(&CollectorStatsExporter::run, this)) {

--- a/collector/lib/CollectorStatsExporter.h
+++ b/collector/lib/CollectorStatsExporter.h
@@ -4,30 +4,27 @@
 #include <memory>
 
 #include "CollectorConfig.h"
+#include "CollectorConnectionStats.h"
 #include "CollectorStats.h"
 #include "StoppableThread.h"
 #include "prometheus/registry.h"
 #include "system-inspector/Service.h"
 
 namespace collector {
-
 class CollectorStatsExporter {
  public:
-  CollectorStatsExporter(std::shared_ptr<prometheus::Registry> registry, const CollectorConfig* config, system_inspector::Service* si);
+  CollectorStatsExporter(const CollectorConfig* config, system_inspector::Service* si);
 
   bool start();
   void run();
   void stop();
 
-  std::shared_ptr<CollectorConnectionStats<unsigned int>> GetConnectionsTotalReporter() { return connections_total_reporter_; }
-  std::shared_ptr<CollectorConnectionStats<float>> GetConnectionsRateReporter() { return connections_rate_reporter_; }
+  std::shared_ptr<prometheus::Registry>& GetRegistry() { return registry_; }
 
  private:
   std::shared_ptr<prometheus::Registry> registry_;
   const CollectorConfig* config_;
   system_inspector::Service* system_inspector_;
-  std::shared_ptr<CollectorConnectionStats<unsigned int>> connections_total_reporter_;
-  std::shared_ptr<CollectorConnectionStats<float>> connections_rate_reporter_;
   StoppableThread thread_;
 };
 

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -23,15 +23,10 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
                         system_inspector::Service* inspector,
                         prometheus::Registry* registry)
       : conn_scraper_(std::make_unique<ConnScraper>(config, inspector)),
-        scrape_interval_(config.ScrapeInterval()),
-        turn_off_scraping_(config.TurnOffScrape()),
-        scrape_listen_endpoints_(config.ScrapeListenEndpoints()),
         conn_tracker_(std::move(conn_tracker)),
-        afterglow_period_micros_(config.AfterglowPeriod()),
-        enable_afterglow_(config.EnableAfterglow()),
         config_(config),
         comm_(std::make_unique<NetworkConnectionInfoServiceComm>(config.grpc_channel)) {
-    if (config.EnableConnectionStats()) {
+    if (config_.EnableConnectionStats()) {
       connections_total_reporter_ = {{registry,
                                       "rox_connections_total",
                                       "Amount of stored connections over time",
@@ -99,13 +94,8 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
   StoppableThread thread_;
 
   std::unique_ptr<IConnScraper> conn_scraper_;
-  int scrape_interval_;
-  bool turn_off_scraping_;
-  bool scrape_listen_endpoints_;
   std::shared_ptr<ConnectionTracker> conn_tracker_;
 
-  int64_t afterglow_period_micros_;
-  bool enable_afterglow_;
   const CollectorConfig& config_;
   std::unique_ptr<INetworkConnectionInfoServiceComm> comm_;
 

--- a/collector/lib/ProcfsScraper.cpp
+++ b/collector/lib/ProcfsScraper.cpp
@@ -444,7 +444,7 @@ using SocketsByContainer = UnorderedMap<std::string, UnorderedMap<ino_t, Unorder
 // container id -> (netns -> socket) mapping, and synthesizes this to a list of (container id, connection info)
 // tuples.
 void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const ConnsByNS& conns_by_ns,
-                         std::shared_ptr<ProcessStore> process_store,
+                         ProcessStore* process_store,
                          std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) {
   for (const auto& container_sockets : sockets_by_container) {
     const auto& container_id = container_sockets.first;
@@ -483,7 +483,7 @@ void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const C
 // ReadContainerConnections reads all container connection info from the given `/proc`-like directory. All connections
 // from non-container processes are ignored.
 // process_store, when provided, is used to to link the originator process of a ContainerEndpoint.
-bool ReadContainerConnections(const char* proc_path, std::shared_ptr<ProcessStore> process_store,
+bool ReadContainerConnections(const char* proc_path, ProcessStore* process_store,
                               std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) {
   DirHandle procdir = opendir(proc_path);
   if (!procdir.valid()) {
@@ -655,7 +655,7 @@ std::optional<char> ExtractProcessState(std::string_view line) {
 }
 
 bool ConnScraper::Scrape(std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) {
-  return ReadContainerConnections(proc_path_.c_str(), process_store_, connections, listen_endpoints);
+  return ReadContainerConnections(proc_path_.c_str(), process_store_.get(), connections, listen_endpoints);
 }
 
 bool ProcessScraper::Scrape(uint64_t pid, ProcessInfo& process_info) {


### PR DESCRIPTION
## Description

This change started out from the effort to unify the services used to communicate with sensor. While attempting to add an output object to the notifier it became apparent this class has some issues with ownership of its members, which in turn makes it a bit odd to extend and modify.

In order to alleviate the problem the following changes are introduced:
- The connection scraper is now owned by NetworkStatusNotifier.
- The communication channel for network info is now owned by NetworkStatusNotifier.
- Connection stats are now owned by NetworkStatusNotifier.
- Move ownership of the prometheus registry into CollectorStatsExporter.
- The process store is now owned by ConnScrapper.
- Refactor CollectorConnectionStats into its own file.

When stating "X is now owned by Y" it stands for X now is part of Y and its lifecycle is fully handled by Y (i.e X is created with Y and destroyed with Y, preferably following RAII).

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check connection stats are still properly informed by the prometheus exporter.
