### PR TITLE
Replace all include guards with #pragma once

### DIFF
--- a/collector/lib/AbortHandler.h
+++ b/collector/lib/AbortHandler.h
@@ -1,6 +1,4 @@
-
-#ifndef _ABORT_HANDLER_H_
-#define _ABORT_HANDLER_H_
+#pragma once
 
 #include <csignal>
 #include <cstdio>
@@ -26,5 +24,3 @@ extern "C" {
 //
 // [1]: https://en.cppreference.com/w/cpp/utility/program/signal
 extern "C" void AbortHandler(int signum);
-
-#endif  // _ABORT_H_

--- a/collector/lib/CivetWrapper.h
+++ b/collector/lib/CivetWrapper.h
@@ -1,5 +1,4 @@
-#ifndef CIVET_WRAPPER_H
-#define CIVET_WRAPPER_H
+#pragma once
 
 #include <CivetServer.h>
 #include <optional>
@@ -24,5 +23,3 @@ class CivetWrapper : public CivetHandler {
   }
 };
 }  // namespace collector
-
-#endif

--- a/collector/lib/CollectionMethod.h
+++ b/collector/lib/CollectionMethod.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTION_METHOD_H
-#define COLLECTION_METHOD_H
+#pragma once
 
 #include <cstdint>
 #include <ostream>
@@ -17,5 +16,3 @@ const char* CollectionMethodName(CollectionMethod method);
 CollectionMethod ParseCollectionMethod(std::string_view method);
 
 }  // namespace collector
-
-#endif  // COLLECTION_METHOD_H

--- a/collector/lib/CollectorArgs.h
+++ b/collector/lib/CollectorArgs.h
@@ -1,5 +1,4 @@
-#ifndef _COLLECTOR_ARGS_H_
-#define _COLLECTOR_ARGS_H_
+#pragma once
 
 #include <optional>
 #include <string>
@@ -41,5 +40,3 @@ class CollectorArgs {
 };
 
 } /* namespace collector */
-
-#endif /* _COLLECTOR_ARGS_H_ */

--- a/collector/lib/CollectorConfig.h
+++ b/collector/lib/CollectorConfig.h
@@ -1,5 +1,4 @@
-#ifndef _COLLECTOR_CONFIG_H_
-#define _COLLECTOR_CONFIG_H_
+#pragma once
 
 #include <filesystem>
 #include <optional>
@@ -269,5 +268,3 @@ class CollectorConfig {
 std::ostream& operator<<(std::ostream& os, const CollectorConfig& c);
 
 }  // end namespace collector
-
-#endif  // _COLLECTOR_CONFIG_H_

--- a/collector/lib/CollectorException.h
+++ b/collector/lib/CollectorException.h
@@ -1,5 +1,4 @@
-#ifndef _COLLECTOR_EXCEPTION_H_
-#define _COLLECTOR_EXCEPTION_H_
+#pragma once
 
 #include <exception>
 #include <string>
@@ -19,5 +18,3 @@ class CollectorException : public std::exception {
 };
 
 }  // namespace collector
-
-#endif  // _COLLECTOR_EXCEPTION_H_

--- a/collector/lib/CollectorRuntimeConfigInspector.h
+++ b/collector/lib/CollectorRuntimeConfigInspector.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_RUNTIME_CONFIG_INSPECTOR_H
-#define COLLECTOR_RUNTIME_CONFIG_INSPECTOR_H
+#pragma once
 
 #include <json/writer.h>
 
@@ -27,5 +26,3 @@ class CollectorConfigInspector : public CivetWrapper {
 };
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/CollectorService.h
+++ b/collector/lib/CollectorService.h
@@ -1,5 +1,4 @@
-#ifndef _COLLECTOR_SERVICE_H_
-#define _COLLECTOR_SERVICE_H_
+#pragma once
 
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
@@ -58,5 +57,3 @@ class CollectorService {
 };
 
 }  // namespace collector
-
-#endif  // _COLLECTOR_SERVICE_H_

--- a/collector/lib/CollectorStats.h
+++ b/collector/lib/CollectorStats.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_COLLECTORSTATS_H
-#define COLLECTOR_COLLECTORSTATS_H
+#pragma once
 
 #include <array>
 #include <atomic>
@@ -141,5 +140,3 @@ ScopedTimer<T> scoped_timer(T* timer_array, size_t index) {
 #define COUNTER_ZERO(i) COUNTER_SET(i, 0)
 
 }  // namespace collector
-
-#endif  // COLLECTOR_COLLECTORSTATS_H

--- a/collector/lib/CollectorStatsExporter.h
+++ b/collector/lib/CollectorStatsExporter.h
@@ -1,5 +1,4 @@
-#ifndef _COLLECTOR_STATS_EXPORTER_H_
-#define _COLLECTOR_STATS_EXPORTER_H_
+#pragma once
 
 #include <memory>
 
@@ -32,5 +31,3 @@ class CollectorStatsExporter {
 };
 
 }  // namespace collector
-
-#endif  // _COLLECTOR_STATS_EXPORTER_H_

--- a/collector/lib/CollectorVersion.h.in
+++ b/collector/lib/CollectorVersion.h.in
@@ -1,10 +1,7 @@
-#ifndef _COLLECTOR_VERSION_H_
-#define _COLLECTOR_VERSION_H_
+#pragma once
 
 #define COLLECTOR_VERSION "${COLLECTOR_VERSION}"
 
 inline const char* GetCollectorVersion() {
   return COLLECTOR_VERSION;
 }
-
-#endif  // _COLLECTOR_VERSION_H_

--- a/collector/lib/ConfigLoader.h
+++ b/collector/lib/ConfigLoader.h
@@ -1,5 +1,4 @@
-#ifndef _CONFIG_LOADER_H_
-#define _CONFIG_LOADER_H_
+#pragma once
 
 #include <optional>
 
@@ -267,5 +266,3 @@ class ConfigLoader {
 };
 
 }  // namespace collector
-
-#endif  // _CONFIG_LOADER_H_

--- a/collector/lib/ConnTracker.h
+++ b/collector/lib/ConnTracker.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_CONNTRACKER_H
-#define COLLECTOR_CONNTRACKER_H
+#pragma once
 
 #include <mutex>
 #include <vector>
@@ -394,5 +393,3 @@ bool ConnectionTracker::CheckIfOldConnShouldBeInactiveInDelta(const T& conn_key,
 }
 
 }  // namespace collector
-
-#endif  // COLLECTOR_CONNTRACKER_H

--- a/collector/lib/ContainerEngine.h
+++ b/collector/lib/ContainerEngine.h
@@ -1,5 +1,4 @@
-#ifndef _CONTAINER_ENGINE_H_
-#define _CONTAINER_ENGINE_H_
+#pragma once
 
 #include "container_engine/container_cache_interface.h"
 #include "container_engine/container_engine_base.h"
@@ -24,5 +23,3 @@ class ContainerEngine : public libsinsp::container_engine::container_engine_base
   }
 };
 }  // namespace collector
-
-#endif  // _CONTAINER_ENGINE_H_

--- a/collector/lib/ContainerInfoInspector.h
+++ b/collector/lib/ContainerInfoInspector.h
@@ -1,5 +1,4 @@
-#ifndef _CONTAINER_INFO_INSPECTOR_
-#define _CONTAINER_INFO_INSPECTOR_
+#pragma once
 
 #include <CivetServer.h>
 #include <civetweb.h>
@@ -34,5 +33,3 @@ class ContainerInfoInspector : public CivetWrapper {
 };
 
 }  // namespace collector
-
-#endif  //_CONTAINER_INFO_INSPECTOR_

--- a/collector/lib/ContainerMetadata.h
+++ b/collector/lib/ContainerMetadata.h
@@ -1,5 +1,4 @@
-#ifndef _CONTAINER_METADATA_H_
-#define _CONTAINER_METADATA_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -31,5 +30,3 @@ class ContainerMetadata {
 };
 
 }  // namespace collector
-
-#endif  // _CONTAINER_METADATA_H_

--- a/collector/lib/Containers.h
+++ b/collector/lib/Containers.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_CONTAINERS_H
-#define COLLECTOR_CONTAINERS_H
+#pragma once
 
 // Utility methods for working with STL containers.
 
@@ -46,5 +45,3 @@ MappedType<M>* Lookup(M& map, const typename M::key_type& key) {
 }
 
 }  // namespace collector
-
-#endif  // COLLECTOR_CONTAINERS_H

--- a/collector/lib/Control.h
+++ b/collector/lib/Control.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_CONTROL_H
-#define COLLECTOR_CONTROL_H
+#pragma once
 
 namespace collector {
 
@@ -9,5 +8,3 @@ enum ControlValue {
 };
 
 }
-
-#endif

--- a/collector/lib/Diagnostics.h
+++ b/collector/lib/Diagnostics.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_DIAGNOSTICS_H
-#define COLLECTOR_DIAGNOSTICS_H
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -66,5 +65,3 @@ class StartupDiagnostics : public IDiagnostics {
 };
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/DuplexGRPC.h
+++ b/collector/lib/DuplexGRPC.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_DUPLEXGRPC_H
-#define COLLECTOR_DUPLEXGRPC_H
+#pragma once
 
 #include <chrono>
 #include <cstdint>
@@ -804,5 +803,3 @@ template <typename W, typename R>
 using DuplexClientReaderWriter = grpc_duplex_impl::DuplexClientReaderWriter<W, R>;
 
 }  // namespace collector
-
-#endif  // COLLECTOR_DUPLEXGRPC_H

--- a/collector/lib/EnvVar.h
+++ b/collector/lib/EnvVar.h
@@ -2,8 +2,7 @@
 // Created by Malte Isberner on 8/12/20.
 //
 
-#ifndef COLLECTOR_ENVVAR_H
-#define COLLECTOR_ENVVAR_H
+#pragma once
 
 #include <algorithm>
 #include <cctype>
@@ -127,5 +126,3 @@ using PathEnvVar = EnvVar<std::filesystem::path, internal::ParsePath>;
 using FloatEnvVar = EnvVar<float, internal::ParseFloat>;
 
 }  // namespace collector
-
-#endif  // COLLECTOR_ENVVAR_H

--- a/collector/lib/EventMap.h
+++ b/collector/lib/EventMap.h
@@ -1,5 +1,4 @@
-#ifndef _EVENT_MAP_H_
-#define _EVENT_MAP_H_
+#pragma once
 
 #include <array>
 #include <string>
@@ -49,5 +48,3 @@ class EventMap {
 };
 
 }  // namespace collector
-
-#endif  // _EVENT_MAP_H_

--- a/collector/lib/EventNames.h
+++ b/collector/lib/EventNames.h
@@ -1,5 +1,4 @@
-#ifndef _EVENT_NAMES_H_
-#define _EVENT_NAMES_H_
+#pragma once
 
 #include <array>
 #include <string>
@@ -50,5 +49,3 @@ class EventNames {
 };
 
 }  // namespace collector
-
-#endif  // _EVENT_NAMES_H_

--- a/collector/lib/FileSystem.h
+++ b/collector/lib/FileSystem.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_FILESYSTEM_H
-#define COLLECTOR_FILESYSTEM_H
+#pragma once
 
 #include <array>
 #include <cstdio>
@@ -188,5 +187,3 @@ class GZFileHandle : public ResourceWrapper<gzFile, GZFileHandle> {
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_FILESYSTEM_H

--- a/collector/lib/GRPC.h
+++ b/collector/lib/GRPC.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_GRPC_H
-#define COLLECTOR_GRPC_H
+#pragma once
 
 #include <optional>
 #include <string_view>
@@ -20,5 +19,3 @@ std::pair<option::ArgStatus, std::string> CheckGrpcServer(std::string_view serve
 std::pair<option::ArgStatus, std::string> CheckGrpcServer(const char* server);
 
 }  // namespace collector
-
-#endif  // COLLECTOR_GRPC_H

--- a/collector/lib/GRPCUtil.h
+++ b/collector/lib/GRPCUtil.h
@@ -1,5 +1,4 @@
-#ifndef _GRPC_UTIL_H_
-#define _GRPC_UTIL_H_
+#pragma once
 
 #include <chrono>
 #include <functional>
@@ -18,5 +17,3 @@ bool WaitForChannelReady(
     const std::chrono::nanoseconds& poll_interval = std::chrono::seconds(1));
 
 }  // namespace collector
-
-#endif  // _GRPC_UTIL_H_

--- a/collector/lib/GetStatus.h
+++ b/collector/lib/GetStatus.h
@@ -1,5 +1,4 @@
-#ifndef _GET_STATUS_H_
-#define _GET_STATUS_H_
+#pragma once
 
 #include <string>
 
@@ -25,5 +24,3 @@ class GetStatus : public CivetWrapper {
 };
 
 } /* namespace collector */
-
-#endif /* _GET_STATUS_H_ */

--- a/collector/lib/Hash.h
+++ b/collector/lib/Hash.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_HASH_H
-#define COLLECTOR_HASH_H
+#pragma once
 
 #include <algorithm>
 #include <unordered_map>
@@ -101,5 +100,3 @@ template <typename K, typename V, typename E = std::equal_to<K>>
 using UnorderedMap = std::unordered_map<K, V, Hasher, E>;
 
 }  // namespace collector
-
-#endif  // COLLECTOR_HASH_H

--- a/collector/lib/HostConfig.h
+++ b/collector/lib/HostConfig.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_HOSTCONFIG_H
-#define COLLECTOR_HOSTCONFIG_H
+#pragma once
 
 #include <optional>
 #include <string>
@@ -29,5 +28,3 @@ class HostConfig {
   std::optional<collector::CollectionMethod> collection_method_;
   unsigned int num_possible_cpus_;
 };
-
-#endif  // COLLECTOR_HOSTCONFIG_H

--- a/collector/lib/HostHeuristics.h
+++ b/collector/lib/HostHeuristics.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_HOSTHEURISTICS_H
-#define COLLECTOR_HOSTHEURISTICS_H
+#pragma once
 
 #include "CollectorConfig.h"
 #include "HostConfig.h"
@@ -12,5 +11,3 @@ namespace collector {
 HostConfig ProcessHostHeuristics(const CollectorConfig& config);
 
 }  // namespace collector
-
-#endif  // COLLECTOR_HOSTHEURISTICS_H

--- a/collector/lib/HostInfo.h
+++ b/collector/lib/HostInfo.h
@@ -1,28 +1,4 @@
-/** collector
-
-A full notice with attributions is provided along with this source code.
-
-    This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
-
-                                 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-* In addition, as a special exception, the copyright holders give
-* permission to link the code of portions of this program with the
-* OpenSSL library under certain conditions as described in each
-* individual source file, and distribute linked combinations
-* including the two.
-* You must obey the GNU General Public License in all respects
-* for all of the code used other than OpenSSL.  If you modify
-* file(s) with this exception, you may extend this exception to your
-* version of the file(s), but you are not obligated to do so.  If you
-* do not wish to do so, delete this exception statement from your
-* version.
-*/
-
-#ifndef _HOSTINFO_H
-#define _HOSTINFO_H
+#pragma once
 
 extern "C" {
 #include <sys/stat.h>
@@ -291,5 +267,3 @@ class HostInfo {
 };
 
 }  // namespace collector
-
-#endif  // _HOSTINFO_H

--- a/collector/lib/Inotify.h
+++ b/collector/lib/Inotify.h
@@ -1,5 +1,4 @@
-#ifndef _INOTIFY_H_
-#define _INOTIFY_H_
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -288,5 +287,3 @@ class Inotify {
 };
 
 }  // namespace collector
-
-#endif  // _INOTIFY_H_

--- a/collector/lib/KernelDriver.h
+++ b/collector/lib/KernelDriver.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_KERNEL_DRIVER_H
-#define COLLECTOR_KERNEL_DRIVER_H
+#pragma once
 
 #include <string>
 
@@ -78,5 +77,3 @@ class KernelDriverCOREEBPF : public IKernelDriver {
   }
 };
 }  // namespace collector
-
-#endif

--- a/collector/lib/LogLevel.h
+++ b/collector/lib/LogLevel.h
@@ -1,5 +1,4 @@
-#ifndef _LOG_LEVEL_H_
-#define _LOG_LEVEL_H_
+#pragma once
 
 #include "CivetWrapper.h"
 
@@ -18,5 +17,3 @@ class LogLevelHandler : public CivetWrapper {
 };
 
 }  // namespace collector
-
-#endif  // _LOG_LEVEL_H_

--- a/collector/lib/Logging.h
+++ b/collector/lib/Logging.h
@@ -1,5 +1,4 @@
-#ifndef _LOGGING_H_
-#define _LOGGING_H_
+#pragma once
 
 #include <chrono>
 #include <cstdint>
@@ -246,5 +245,3 @@ class LogMessage {
   collector::logging::LogMessage(CLOG_VAR(_clog_stmt_))
 
 #define CLOG_THROTTLED(lvl, interval) CLOG_THROTTLED_IF(true, lvl, interval)
-
-#endif /* _LOG_LEVEL_H_ */

--- a/collector/lib/NRadix.h
+++ b/collector/lib/NRadix.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef COLLECTOR_NRADIX_H
-#define COLLECTOR_NRADIX_H
+#pragma once
 
 #include <mutex>
 
@@ -125,5 +124,3 @@ class NRadixTree {
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_NRADIX_H

--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_NETWORKCONNECTION_H
-#define COLLECTOR_NETWORKCONNECTION_H
+#pragma once
 
 #include <endian.h>
 
@@ -479,5 +478,3 @@ static inline const std::vector<IPNet>& PrivateNetworks() {
 }
 
 }  // namespace collector
-
-#endif  // COLLECTOR_NETWORKCONNECTION_H

--- a/collector/lib/NetworkConnectionInfoServiceComm.h
+++ b/collector/lib/NetworkConnectionInfoServiceComm.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_NETWORKCONNECTIONINFOSERVICECOMM_H
-#define COLLECTOR_NETWORKCONNECTIONINFOSERVICECOMM_H
+#pragma once
 
 #include <memory>
 
@@ -62,5 +61,3 @@ class NetworkConnectionInfoServiceComm : public INetworkConnectionInfoServiceCom
 };
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/NetworkSignalHandler.h
+++ b/collector/lib/NetworkSignalHandler.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_NETWORKSIGNALHANDLER_H
-#define COLLECTOR_NETWORKSIGNALHANDLER_H
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -42,5 +41,3 @@ class NetworkSignalHandler final : public SignalHandler {
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_NETWORKSIGNALHANDLER_H

--- a/collector/lib/NetworkStatusInspector.h
+++ b/collector/lib/NetworkStatusInspector.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_NETWORKSTATUSINSPECTOR_H
-#define COLLECTOR_NETWORKSTATUSINSPECTOR_H
+#pragma once
 
 #include <memory>
 
@@ -39,5 +38,3 @@ class NetworkStatusInspector : public CivetWrapper {
   bool handleGetConnections(struct mg_connection* conn, const QueryParams& queryParams);
 };
 }  // namespace collector
-
-#endif

--- a/collector/lib/NetworkStatusNotifier.h
+++ b/collector/lib/NetworkStatusNotifier.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_NETWORKSTATUSNOTIFIER_H
-#define COLLECTOR_NETWORKSTATUSNOTIFIER_H
+#pragma once
 
 #include <memory>
 
@@ -82,5 +81,3 @@ class NetworkStatusNotifier : protected ProtoAllocator<sensor::NetworkConnection
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_NETWORKSTATUSNOTIFIER_H

--- a/collector/lib/Process.h
+++ b/collector/lib/Process.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROCESS_H
-#define COLLECTOR_PROCESS_H
+#pragma once
 
 #include <condition_variable>
 #include <cstdint>
@@ -99,5 +98,3 @@ class Process : public IProcess {
 std::ostream& operator<<(std::ostream& os, const IProcess& process);
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/ProcessSignalFormatter.h
+++ b/collector/lib/ProcessSignalFormatter.h
@@ -1,5 +1,4 @@
-#ifndef _PROCESS_SIGNAL_FORMATTER_H_
-#define _PROCESS_SIGNAL_FORMATTER_H_
+#pragma once
 
 #include <memory>
 
@@ -63,5 +62,3 @@ class ProcessSignalFormatter : public ProtoSignalFormatter<sensor::SignalStreamM
 };
 
 }  // namespace collector
-
-#endif  // _PROCESS_SIGNAL_FORMATTER_H_

--- a/collector/lib/ProcessSignalHandler.h
+++ b/collector/lib/ProcessSignalHandler.h
@@ -1,5 +1,4 @@
-#ifndef __PROCESS_SIGNAL_HANDLER_H__
-#define __PROCESS_SIGNAL_HANDLER_H__
+#pragma once
 
 #include <memory>
 
@@ -53,5 +52,3 @@ class ProcessSignalHandler : public SignalHandler {
 };
 
 }  // namespace collector
-
-#endif  // __PROCESS_SIGNAL_HANDLER_H__

--- a/collector/lib/ProcfsScraper.h
+++ b/collector/lib/ProcfsScraper.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROCFSSCRAPER_H
-#define COLLECTOR_PROCFSSCRAPER_H
+#pragma once
 
 #include <cstring>
 #include <filesystem>
@@ -53,5 +52,3 @@ class ProcessScraper {
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_CONNSCRAPER_H

--- a/collector/lib/ProcfsScraper_internal.h
+++ b/collector/lib/ProcfsScraper_internal.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROCFSSCRAPER_INTERNAL_H
-#define COLLECTOR_PROCFSSCRAPER_INTERNAL_H
+#pragma once
 
 #include <optional>
 #include <string_view>
@@ -15,5 +14,3 @@ std::optional<std::string_view> ExtractContainerID(std::string_view cgroup_line)
 std::optional<char> ExtractProcessState(std::string_view proc_pid_stat_line);
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/Profiler.h
+++ b/collector/lib/Profiler.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROFILER_H
-#define COLLECTOR_PROFILER_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -62,5 +61,3 @@ class Profiler {
 };
 }  // namespace collector
 #endif
-
-#endif  // COLLECTOR_PROFILER_H

--- a/collector/lib/ProfilerHandler.h
+++ b/collector/lib/ProfilerHandler.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROFILERHANDLER_H
-#define COLLECTOR_PROFILERHANDLER_H
+#pragma once
 
 #include <memory>
 #include <mutex>
@@ -48,5 +47,3 @@ class ProfilerHandler : public CivetWrapper {
   std::mutex mutex_;
 };
 }  // namespace collector
-
-#endif  // COLLECTOR_PROFILERHANDLER_H

--- a/collector/lib/ProtoAllocator.h
+++ b/collector/lib/ProtoAllocator.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROTOALLOCATOR_H
-#define COLLECTOR_PROTOALLOCATOR_H
+#pragma once
 
 #ifdef USE_PROTO_ARENAS
 #  include <google/protobuf/arena.h>
@@ -96,5 +95,3 @@ using ProtoAllocator =
 #endif
 
 }  // namespace collector
-
-#endif  // COLLECTOR_PROTOALLOCATOR_H

--- a/collector/lib/ProtoSignalFormatter.h
+++ b/collector/lib/ProtoSignalFormatter.h
@@ -1,5 +1,4 @@
-#ifndef _PROTO_FORMATTER_H_
-#define _PROTO_FORMATTER_H_
+#pragma once
 
 #include <utility>
 
@@ -32,5 +31,3 @@ class ProtoSignalFormatter : public BaseProtoSignalFormatter, protected ProtoAll
 };
 
 }  // namespace collector
-
-#endif  // _PROTO_FORMATTER_H_

--- a/collector/lib/ProtoUtil.h
+++ b/collector/lib/ProtoUtil.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_PROTOUTIL_H
-#define COLLECTOR_PROTOUTIL_H
+#pragma once
 
 #include <google/protobuf/timestamp.pb.h>
 
@@ -11,5 +10,3 @@ namespace collector {
 google::protobuf::Timestamp CurrentTimeProto();
 
 }  // namespace collector
-
-#endif  // COLLECTOR_PROTOUTIL_H

--- a/collector/lib/RateLimit.h
+++ b/collector/lib/RateLimit.h
@@ -1,5 +1,4 @@
-#ifndef _RATE_LIMIT_H_
-#define _RATE_LIMIT_H_
+#pragma once
 
 #include <unordered_map>
 
@@ -53,5 +52,3 @@ class CountLimiter {
   std::unordered_map<std::string, TokenBucket> cache_;
 };
 }  // namespace collector
-
-#endif  // _RATE_LIMIT_H_

--- a/collector/lib/SelfCheckHandler.h
+++ b/collector/lib/SelfCheckHandler.h
@@ -1,6 +1,4 @@
-
-#ifndef COLLECTOR_SELF_CHECK_HANDLE_H
-#define COLLECTOR_SELF_CHECK_HANDLE_H
+#pragma once
 
 #include <chrono>
 #include <memory>
@@ -88,5 +86,3 @@ class SelfCheckNetworkHandler : public SelfCheckHandler {
 };
 
 }  // namespace collector
-
-#endif

--- a/collector/lib/SelfChecks.h
+++ b/collector/lib/SelfChecks.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace collector {

--- a/collector/lib/SignalHandler.h
+++ b/collector/lib/SignalHandler.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_SIGNALHANDLER_H
-#define COLLECTOR_SIGNALHANDLER_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -43,5 +42,3 @@ class SignalHandler {
 };
 
 }  // namespace collector
-
-#endif  // COLLECTOR_SIGNALHANDLER_H

--- a/collector/lib/SignalServiceClient.h
+++ b/collector/lib/SignalServiceClient.h
@@ -1,5 +1,4 @@
-#ifndef __SIGNAL_SERVICE_CLIENT_H
-#define __SIGNAL_SERVICE_CLIENT_H
+#pragma once
 
 // SIGNAL_SERVICE_CLIENT.h
 // This class defines our GRPC client abstraction
@@ -73,5 +72,3 @@ class StdoutSignalServiceClient : public ISignalServiceClient {
 };
 
 }  // namespace collector
-
-#endif  // __SIGNAL_SERVICE_CLIENT_H

--- a/collector/lib/StoppableThread.h
+++ b/collector/lib/StoppableThread.h
@@ -1,6 +1,4 @@
-
-#ifndef _STOPPABLE_THREAD_H_
-#define _STOPPABLE_THREAD_H_
+#pragma once
 
 #include <atomic>
 #include <chrono>
@@ -46,5 +44,3 @@ class StoppableThread {
 };
 
 }  // namespace collector
-
-#endif  // _STOPPABLE_THREAD_H_

--- a/collector/lib/TimeUtil.h
+++ b/collector/lib/TimeUtil.h
@@ -1,5 +1,4 @@
-#ifndef COLLECTOR_TIME_UTIL_H
-#define COLLECTOR_TIME_UTIL_H
+#pragma once
 
 #include <chrono>
 
@@ -11,5 +10,3 @@ inline int64_t NowMicros() {
 }
 
 }  // namespace collector
-
-#endif  // COLLECTOR_TIME_UTIL_H

--- a/collector/lib/TlsConfig.h
+++ b/collector/lib/TlsConfig.h
@@ -1,5 +1,4 @@
-#ifndef _TLS_H_
-#define _TLS_H_
+#pragma once
 
 #include <filesystem>
 #include <utility>
@@ -21,5 +20,3 @@ class TlsConfig {
   std::filesystem::path clientCert_;
   std::filesystem::path clientKey_;
 };
-
-#endif  // _TLS_H_

--- a/collector/lib/Utility.h
+++ b/collector/lib/Utility.h
@@ -1,5 +1,4 @@
-
-#ifndef _UTILITY_H_
+#pragma once
 #define _UTILITY_H_
 
 #include <cerrno>
@@ -108,5 +107,3 @@ std::optional<std::string> SanitizedUTF8(std::string_view str);
 
 void LogProtobufMessage(const google::protobuf::Message& msg);
 }  // namespace collector
-
-#endif  // _UTILITY_H_

--- a/collector/lib/system-inspector/EventExtractor.h
+++ b/collector/lib/system-inspector/EventExtractor.h
@@ -1,5 +1,4 @@
-#ifndef _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_
-#define _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -161,5 +160,3 @@ class EventExtractor {
 };
 
 }  // namespace collector::system_inspector
-
-#endif  // _SYSTEM_INSPECTOR_EVENT_EXTRACTOR_H_

--- a/collector/lib/system-inspector/Service.h
+++ b/collector/lib/system-inspector/Service.h
@@ -1,5 +1,4 @@
-#ifndef _SYSTEM_INSPECTOR_SERVICE_H_
-#define _SYSTEM_INSPECTOR_SERVICE_H_
+#pragma once
 
 #include <atomic>
 #include <bitset>
@@ -89,5 +88,3 @@ class Service : public SystemInspector {
 };
 
 }  // namespace collector::system_inspector
-
-#endif  // _SYSTEM_INSPECTOR_SERVICE_H_

--- a/collector/lib/system-inspector/SystemInspector.h
+++ b/collector/lib/system-inspector/SystemInspector.h
@@ -1,5 +1,4 @@
-#ifndef _SYSTEM_INSPECTOR_
-#define _SYSTEM_INSPECTOR_
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -56,5 +55,3 @@ class SystemInspector {
 };
 
 }  // namespace collector::system_inspector
-
-#endif /* _SYSTEM_INSPECTOR_ */


### PR DESCRIPTION

## Description

Since we don't have a common nomenclature for include guards, whenever a new header file is added to the project, it is up to the writer to come up with the name for the guard. This becomes a bit annoying when trying to figure out what the name should be and comes off a bit sloppy, since different files follow different guidelines. Using #pragma once solves both these problems.

The only header file that hasn't been changed is optionparser.h, since that is actually a third party header file that should not be modified manually.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough.
