### PR TITLE
Fix Garden Linux Bumper

### DIFF
--- a/utilities/gardenlinux-bumper/bumper.py
+++ b/utilities/gardenlinux-bumper/bumper.py
@@ -3,16 +3,24 @@
 import argparse
 import os
 import re
+from typing import NamedTuple
+
+from bs4 import BeautifulSoup
 
 # gfm stands for Github Flavoured Markdown
 from marko.ext.gfm import gfm
 
-from bs4 import BeautifulSoup
-
 import requests
 
-# Type alias for the garden version
-GardenVersion = tuple[str, int, int, str]
+
+class GardenVersion(NamedTuple):
+    """
+    Type alias for the garden version
+    """
+    checksum: str
+    major: int
+    minor: int
+    commit: str
 
 
 def get_latest_release() -> GardenVersion:
@@ -65,12 +73,8 @@ def get_latest_release() -> GardenVersion:
         raise RuntimeError(
             'Failed to find the GCP VM image: Version did not match')
 
-    checksum = match[1]
-    major = int(match[2])
-    minor = int(match[3])
-    commit = match[4]
-
-    return (checksum, major, minor, commit)
+    checksum, major, minor, commit = match.groups()
+    return GardenVersion(checksum, int(major), int(minor), commit)
 
 
 def get_current_version(image_file: str) -> GardenVersion:
@@ -88,7 +92,7 @@ def get_current_version(image_file: str) -> GardenVersion:
         minor = int(match[3])
         commit = match[4]
 
-        return (checksum, major, minor, commit)
+        return GardenVersion(checksum, major, minor, commit)
 
 
 def get_gardenlinux_image(version_data: GardenVersion) -> str:

--- a/utilities/gardenlinux-bumper/bumper.py
+++ b/utilities/gardenlinux-bumper/bumper.py
@@ -3,12 +3,44 @@
 import argparse
 import os
 import re
+
+# gfm stands for Github Flavoured Markdown
+from marko.ext.gfm import gfm
+
+from bs4 import BeautifulSoup
+
 import requests
 
+# Type alias for the garden version
+GardenVersion = tuple[str, int, int, str]
 
-def get_latest_release() -> (int, int, str):
-    gcp_vm_re = re.compile(r'^gcp-gardener_prod-amd64-([0-9]+)\.([0-9]+)-([0-9a-f]+)\.tar\.xz$')
-    url = "https://api.github.com/repos/gardenlinux/gardenlinux/releases/latest"
+
+def get_latest_release() -> GardenVersion:
+    """
+    Find the Garden Linux version in a GH release.
+
+    This method queries the GH API for the latest release of gardenlinux
+    and attempts to extract the version for the gcp image from it.
+
+    The block that holds the image name looks something like this in
+    markdown:
+    ### Google Cloud Platform (amd64)
+    ```
+    gcp_image_name: gardenlinux-gcp-8bd7b82716e90c634df25013-1592-9-2eaf0fc6
+    ```
+
+    marko parses the markdown string and translates it to equivalent
+    html that looks something like this:
+    <h3>Google Cloud Platform (amd64)</h3>
+    <pre><code>gcp_image_name: gardenlinux-gcp-8bd7b82716e90c634df25013-1592-9-2eaf0fc6</code></pre>
+
+    We can then use BeautifulSoup to parse the html and look for the
+    data we want. A bit convoluted, but it does not look like we can do
+    the same with marko directly.
+    """
+    gcp_vm_re = re.compile(
+        r'^gcp_image_name: gardenlinux-gcp-([0-9a-f]+)-([0-9]+)-([0-9]+)-([0-9a-f]+)$')
+    url = 'https://api.github.com/repos/gardenlinux/gardenlinux/releases/latest'
     headers = {
         'Accept': 'application/vnd.github+json',
         'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}',
@@ -18,19 +50,32 @@ def get_latest_release() -> (int, int, str):
     response.raise_for_status()
     latest_release = response.json()
 
-    for a in latest_release['assets']:
-        match = gcp_vm_re.match(a['name'])
-        if match:
-            major = int(match[1])
-            minor = int(match[2])
-            checksum = match[3]
+    body = gfm.convert(latest_release['body'])
+    body = BeautifulSoup(body, features='html.parser')
+    h = body.find(name='h3', string='Google Cloud Platform (amd64)')
+    if h is None:
+        raise RuntimeError('Failed to find the GCP VM image: Missed <h3>')
 
-            return (major, minor, checksum)
-    raise RuntimeError("Failed to find the GCP VM asset")
+    pre = h.find_next_sibling('pre')
+    if pre is None:
+        raise RuntimeError('Failed to find the GCP VM image: Missed <pre>')
+
+    match = gcp_vm_re.match(pre.code.string.strip())
+    if match is None:
+        raise RuntimeError(
+            'Failed to find the GCP VM image: Version did not match')
+
+    checksum = match[1]
+    major = int(match[2])
+    minor = int(match[3])
+    commit = match[4]
+
+    return (checksum, major, minor, commit)
 
 
-def get_current_version(image_file: str) -> (int, int, str):
-    gcp_vm_re = re.compile(r'^gardenlinux-gcp-gardener-prod-amd64-([0-9]+)-([0-9]+)-([0-9a-f]+)$')
+def get_current_version(image_file: str) -> GardenVersion:
+    gcp_vm_re = re.compile(
+        r'^gardenlinux-gcp-([-0-9a-z]+)-([0-9]+)-([0-9]+)-([0-9a-f]+)$')
 
     with open(image_file, 'r') as f:
         image = f.readline()
@@ -38,23 +83,22 @@ def get_current_version(image_file: str) -> (int, int, str):
         if match is None:
             raise RuntimeError('Configured image did not match')
 
-        major = int(match[1])
-        minor = int(match[2])
-        checksum = match[3]
+        checksum = match[1]
+        major = int(match[2])
+        minor = int(match[3])
+        commit = match[4]
 
-        return (major, minor, checksum)
-
-
-def get_gardenlinux_image(version_data: (int, int, str)) -> str:
-    major = version_data[0]
-    minor = version_data[1]
-    checksum = version_data[2]
-
-    return f'gardenlinux-gcp-gardener-prod-amd64-{major}-{minor}-{checksum}'
+        return (checksum, major, minor, commit)
 
 
-def image_is_outdated(latest: (int, int, str), current: (int, int, str)) -> bool:
-    return latest[:2] > current[:2]
+def get_gardenlinux_image(version_data: GardenVersion) -> str:
+    checksum, major, minor, commit = version_data
+
+    return f'gardenlinux-gcp-{checksum}-{major}-{minor}-{commit}'
+
+
+def image_is_outdated(latest: GardenVersion, current: GardenVersion) -> bool:
+    return latest[1:3] > current[1:3]
 
 
 def main(image_file: str):

--- a/utilities/gardenlinux-bumper/requirements.txt
+++ b/utilities/gardenlinux-bumper/requirements.txt
@@ -1,1 +1,3 @@
 requests==2.31.0
+marko==2.1.3
+beautifulsoup4==4.13.4


### PR DESCRIPTION
## Description

Garden Linux changed how it names its GCP images, so we cannot get that
from the assets of a release directly. Instead, we need to parse the
markdown text on the release itself and get it from there.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Run the bumper from this PR and it generated another PR with the correct image name: #2146
