### PR TITLE
ROX-29116: (fix) Use ARM GH action workflow runners for ARM builds

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -73,8 +73,7 @@ jobs:
       - name: Check arches for local build
         if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
-        run: |
-          echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"
+        run: echo "local-exclude=[{\"arch\":\"ppc64le\"}]" >> "$GITHUB_OUTPUT"
 
   build-builder-image:
     name: Local builder image

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       build-image: ${{ steps.builder-tag.outputs.build-image || false }}
       collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag || 'master'}}
+      local-exclude: ${{ steps.builder-tag.outputs.local-exclude || ''}}
 
     env:
       DEFAULT_BUILDER_TAG: master
@@ -69,6 +70,12 @@ jobs:
           echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
           echo "build-image=true" >> "$GITHUB_OUTPUT"
 
+      - name: Check arches for local build
+        if: ! contains(inputs.architectures, 'ppc64le')
+        id: arch
+        run: |
+          echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"
+
   build-builder-image:
     name: Local builder image
     # Multiarch builds sometimes take for eeeeeeeeeever
@@ -80,8 +87,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le]
-        exclude:
-          - arch: ${{ contains(inputs.architectures, 'ppc64le') && '' || 'ppc64le' }}
+        exclude: ${{ fromJSON(needs.builder-needs-rebuilding.outputs.local-exclude) }}
     runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
 
     env:

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Check arches for local build
         if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
-        run: echo "local-exclude=[{\"arch\":\"ppc64le\"}]" >> "$GITHUB_OUTPUT"
+        run: echo 'local-exclude=[{"arch":"ppc64le"}]' >> "$GITHUB_OUTPUT"
 
   build-builder-image:
     name: Local builder image

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -12,7 +12,7 @@ on:
         type: string
         required: true
         description: |
-          Space-seperated list of architectures to build
+          Space-separated list of architectures to build
 
     outputs:
       collector-builder-tag:

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -71,7 +71,7 @@ jobs:
           echo "build-image=true" >> "$GITHUB_OUTPUT"
 
       - name: Check arches for local build
-        if: ! contains(inputs.architectures, 'ppc64le')
+        if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
         run: |
           echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -8,10 +8,16 @@ on:
         required: true
         description: |
           The tag used to build the collector image
+      architectures:
+        type: string
+        required: true
+        description: |
+          Space-seperated list of architectures to build
+
     outputs:
       collector-builder-tag:
         description: The builder tag used by the build
-        value: ${{ jobs.build-builder-image.outputs.collector-builder-tag || 'master' }}
+        value: ${{ jobs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -23,7 +29,11 @@ jobs:
     name: Determine if builder image needs to be built
     runs-on: ubuntu-24.04
     outputs:
-      build-image: ${{ steps.changed.outputs.builder-changed }}
+      build-image: ${{ steps.builder-tag.outputs.build-image || false }}
+      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag || 'master'}}
+
+    env:
+      DEFAULT_BUILDER_TAG: master
 
     steps:
       - uses: actions/checkout@v4
@@ -38,30 +48,46 @@ jobs:
               - builder/Dockerfile
               - .github/workflows/collector-builder.yml
 
+      - name: Check labels and define builder tag
+        id: builder-tag
+        if: |
+          steps.changed.outputs.builder-changed == 'true' ||
+          (github.event_name == 'push' && (
+            github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
+          )) ||
+          contains(github.event.pull_request.labels.*.name, 'build-builder-image') ||
+          github.event_name == 'schedule'
+        run: |
+          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
+          if [[ "${{ github.event_name }}" == 'pull_request' || \
+                "${{ github.ref_type }}" == 'tag' || \
+                "${{ github.ref_name }}" =~ ^release- ]]; then
+            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
+          fi
+
+          echo "Rebuild builder image with tag ${COLLECTOR_BUILDER_TAG}"
+          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
+          echo "build-image=true" >> "$GITHUB_OUTPUT"
+
   build-builder-image:
-    name: Build the builder image
-    runs-on: ubuntu-24.04
+    name: Local builder image
     # Multiarch builds sometimes take for eeeeeeeeeever
     timeout-minutes: 480
     needs:
     - builder-needs-rebuilding
     if: |
-      needs.builder-needs-rebuilding.outputs.build-image == 'true' ||
-      (github.event_name == 'push' && (
-        github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
-      )) ||
-      contains(github.event.pull_request.labels.*.name, 'build-builder-image') ||
-      github.event_name == 'schedule'
-    outputs:
-      collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag }}
+      needs.builder-needs-rebuilding.outputs.build-image == 'true'
     strategy:
-      fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, s390x, arm64]
+        arch: [amd64, arm64, ppc64le]
+        exclude:
+          - arch: ${{ contains(inputs.architectures, 'ppc64le') && '' || 'ppc64le' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
       BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +101,54 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Create ansible vars
+        run: |
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
+          EOF
+
+      - name: Build images
+        timeout-minutes: 480
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml
+          ansible-playbook \
+            --connection local \
+            -i localhost, \
+            --limit localhost \
+            -e arch='${{ matrix.arch }}' \
+            -e @'${{ github.workspace }}/ansible/secrets.yml' \
+            ansible/ci-build-builder.yml
+
+  build-builder-image-remote-vm:
+    name: Remote builder image
+    # Multiarch builds sometimes take for eeeeeeeeeever
+    timeout-minutes: 480
+    needs:
+    - builder-needs-rebuilding
+    if: |
+      needs.builder-needs-rebuilding.outputs.build-image == 'true' &&
+      contains(inputs.architectures, 's390x')
+    strategy:
+      matrix:
+        arch: [s390x]
+    runs-on: ubuntu-24.04
+
+    env:
+      PLATFORM: linux/${{ matrix.arch }}
+      BUILD_TYPE: ci
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/setup-python@v5
         with:
@@ -101,57 +175,22 @@ jobs:
           job-tag: builder
 
       - name: Create Build VMs
-        if: |
-          matrix.arch == 's390x' &&
-          (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
         run: |
           make -C "${{ github.workspace }}/ansible" create-build-vms
 
-      - name: Define builder tag
-        id: builder-tag
-        run: |
-          COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
-          if [[ "${{ github.event_name }}" == 'pull_request' || \
-                "${{ github.ref_type }}" == 'tag' || \
-                "${{ github.ref_name }}" =~ ^release- ]]; then
-            COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
-          fi
-
-          echo "COLLECTOR_BUILDER_TAG=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_ENV"
-          echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Create ansible vars
         run: |
-          {
-            echo "---"
-            echo "stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}"
-            echo "stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}"
-            echo "rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}"
-            echo "rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}"
-            echo "collector_git_ref: ${{ github.ref }}"
-            echo "collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}"
-          } > ${{ github.workspace }}/ansible/secrets.yml
+          cat << EOF > ${{ github.workspace }}/ansible/secrets.yml
+          ---
+          stackrox_io_username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          stackrox_io_password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+          rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+          collector_git_ref: ${{ github.ref }}
+          collector_builder_tag: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
+          EOF
 
       - name: Build images
-        if: |
-          (github.event_name != 'pull_request' && matrix.arch != 's390x') ||
-          matrix.arch == 'amd64' ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch != 's390x')
-        timeout-minutes: 480
-        run: |
-          ansible-galaxy install -r ansible/requirements.yml
-          ansible-playbook \
-            --connection local \
-            -i localhost, \
-            --limit localhost \
-            -e arch='${{ matrix.arch }}' \
-            -e @'${{ github.workspace }}/ansible/secrets.yml' \
-            ansible/ci-build-builder.yml
-
-      - name: Build s390x images
-        if: |
-          (github.event_name != 'pull_request' && matrix.arch == 's390x') ||
-          (contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds') && matrix.arch == 's390x')
         timeout-minutes: 480
         run: |
           ansible-playbook \
@@ -162,22 +201,23 @@ jobs:
             ansible/ci-build-builder.yml
 
       - name: Destroy VMs
-        if: always() && matrix.arch == 's390x'
+        if: always()
         run: |
           make -C ansible destroy-vms
 
   create-multiarch-manifest:
     needs:
+    - builder-needs-rebuilding
     - build-builder-image
+    - build-builder-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-24.04
     if: |
-      github.event_name != 'pull_request' ||
-      (needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-       contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds'))
+      always() && !contains(join(needs.*.result, ','), 'failure') &&
+      needs.builder-needs-rebuilding.outputs.build-image == 'true'
     env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
-      ARCHS: amd64 ppc64le s390x arm64
+      COLLECTOR_BUILDER_TAG: ${{ needs.builder-needs-rebuilding.outputs.collector-builder-tag }}
+      ARCHS: ${{ inputs.architectures }}
 
     steps:
       - uses: actions/checkout@v4
@@ -208,45 +248,13 @@ jobs:
           base-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
           archs: ${{ env.ARCHS }}
 
-  retag-x86-image:
-    needs:
-    - build-builder-image
-    name: Retag x86 builder image
-    runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.build-builder-image.outputs.collector-builder-tag != 'cache' &&
-      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-    env:
-      COLLECTOR_BUILDER_TAG: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
-    steps:
-      - name: Pull image to retag
-        run: |
-          docker pull "quay.io/stackrox-io/collector-builder:${COLLECTOR_BUILDER_TAG}-amd64"
-
-      - name: Retag and push stackrox-io
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: quay.io/stackrox-io/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}-amd64
-          dst-image: quay.io/rhacs-eng/collector-builder:${{ env.COLLECTOR_BUILDER_TAG }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
   notify:
     runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
     needs:
       - build-builder-image
+      - build-builder-image-remote-vm
       - create-multiarch-manifest
-      - retag-x86-image
     steps:
       - name: Slack notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       build-image: ${{ steps.builder-tag.outputs.build-image || false }}
       collector-builder-tag: ${{ steps.builder-tag.outputs.collector-builder-tag || 'master'}}
-      local-exclude: ${{ steps.builder-tag.outputs.local-exclude || ''}}
+      local-exclude: ${{ steps.arch.outputs.local-exclude || '[]'}}
 
     env:
       DEFAULT_BUILDER_TAG: master

--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -66,7 +66,7 @@ jobs:
             COLLECTOR_BUILDER_TAG="${{ inputs.collector-tag }}"
           fi
 
-          echo "Rebuild builder image with tag ${COLLECTOR_BUILDER_TAG}"
+          echo "::notice::Rebuild builder image with tag ${COLLECTOR_BUILDER_TAG}"
           echo "collector-builder-tag=${COLLECTOR_BUILDER_TAG}" >> "$GITHUB_OUTPUT"
           echo "build-image=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check arches for local build
         if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
-        run: echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"
+        run: echo "local-exclude=[{\"arch\":\"ppc64le\"}]" >> "$GITHUB_OUTPUT"
 
   build-collector-image:
     name: Local collector image ${{ matrix.arch }}

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -22,7 +22,7 @@ on:
         type: string
         required: true
         description: |
-          Space-seperated list of architectures to build
+          Space-separated list of architectures to build
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check arches for local build
-        if: ! contains(inputs.architectures, 'ppc64le')
+        if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
         run: echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check arches for local build
         if: ${{ ! contains(inputs.architectures, 'ppc64le') }}
         id: arch
-        run: echo "local-exclude=[{\"arch\":\"ppc64le\"}]" >> "$GITHUB_OUTPUT"
+        run: echo 'local-exclude=[{"arch":"ppc64le"}]' >> "$GITHUB_OUTPUT"
 
   build-collector-image:
     name: Local collector image ${{ matrix.arch }}

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -18,6 +18,11 @@ on:
         required: true
         description: |
           The builder tag to use in the build
+      architectures:
+        type: string
+        required: true
+        description: |
+          Space-seperated list of architectures to build
 
 env:
   COLLECTOR_TAG: ${{ inputs.collector-tag }}
@@ -29,12 +34,13 @@ env:
 
 jobs:
   build-collector-image:
-    name: Build Collector
-    runs-on: ubuntu-24.04
+    name: Local collector image ${{ matrix.arch }}
     strategy:
-      fail-fast: false
       matrix:
-        arch: [amd64, ppc64le, arm64]
+        arch: [amd64, arm64, ppc64le]
+        exclude:
+          - arch: ${{ contains(inputs.architectures, 'ppc64le') && '' || 'ppc64le' }}
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
 
     env:
       PLATFORM: linux/${{ matrix.arch }}
@@ -62,6 +68,7 @@ jobs:
           rhacs_eng_username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           rhacs_eng_password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
           collector_git_ref: ${{ github.ref }}
+          collector_git_sha: ${{ github.sha }}
           collector_builder_tag: ${{ env.COLLECTOR_BUILDER_TAG }}
           disable_profiling: ${{ matrix.arch != 'amd64' && matrix.arch != 'arm64' }}
           rhacs_eng_image: ${{ env.RHACS_ENG_IMAGE }}
@@ -71,11 +78,7 @@ jobs:
           driver_version: ${DRIVER_VERSION}
           EOF
 
-      - name: Build images
-        if: |
-          github.event_name != 'pull_request' ||
-          matrix.arch == 'amd64' ||
-          contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+      - name: Build ${{ matrix.arch }} image locally
         timeout-minutes: 480
         run: |
           ansible-playbook \
@@ -87,11 +90,10 @@ jobs:
             ansible/ci-build-collector.yml
 
   build-collector-image-remote-vm:
-    name: Build Collector on a remote VM
+    name: Remote collector image
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+    if: contains(inputs.architectures, 's390x')
     strategy:
-      fail-fast: false
       matrix:
         arch: [s390x]
 
@@ -168,11 +170,9 @@ jobs:
     - build-collector-image-remote-vm
     name: Create Multiarch manifest
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
+    if: always() && !contains(join(needs.*.result, ','), 'failure')
     env:
-      ARCHS: amd64 ppc64le s390x arm64
+      ARCHS: ${{ inputs.architectures }}
 
     steps:
       - uses: actions/checkout@v4
@@ -203,35 +203,6 @@ jobs:
           base-image: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
           archs: ${{ env.ARCHS }}
 
-  retag-x86-image:
-    needs:
-    - build-collector-image
-    name: Retag x86 image
-    runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
-    steps:
-      - name: Pull image to retag
-        run: |
-          docker pull ${{ inputs.collector-image }}-amd64
-
-      - name: Retag and push stackrox-io
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ inputs.collector-image }}
-          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-
-      - name: Retag and push rhacs-eng
-        uses: stackrox/actions/images/retag-and-push@v1
-        with:
-          src-image: ${{ inputs.collector-image }}-amd64
-          dst-image: ${{ env.RHACS_ENG_IMAGE }}
-          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
   notify:
     runs-on: ubuntu-24.04
     if: always() && contains(join(needs.*.result, ','), 'failure') && github.event_name != 'pull_request'
@@ -239,7 +210,6 @@ jobs:
       - build-collector-image
       - build-collector-image-remote-vm
       - create-multiarch-manifest
-      - retag-x86-image
     steps:
       - name: Slack notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -33,13 +33,25 @@ env:
   ADDRESS_SANITIZER: ${{ contains(github.event.pull_request.labels.*.name, 'address-sanitizer') }}
 
 jobs:
+  prepare-build-collector:
+    name: Prepare builders for collector
+    runs-on: ubuntu-24.04
+    outputs:
+      local-exclude: ${{ steps.arch.outputs.local-exclude || '' }}
+
+    steps:
+      - name: Check arches for local build
+        if: ! contains(inputs.architectures, 'ppc64le')
+        id: arch
+        run: echo "local-exclude=[{arch:ppc64le}]" >> "$GITHUB_OUTPUT"
+
   build-collector-image:
     name: Local collector image ${{ matrix.arch }}
+    needs: prepare-build-collector
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le]
-        exclude:
-          - arch: ${{ contains(inputs.architectures, 'ppc64le') && '' || 'ppc64le' }}
+        exclude: ${{ fromJSON(needs.prepare-build-collector.outputs.local-exclude) }}
     runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
 
     env:

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -37,7 +37,7 @@ jobs:
     name: Prepare builders for collector
     runs-on: ubuntu-24.04
     outputs:
-      local-exclude: ${{ steps.arch.outputs.local-exclude || '' }}
+      local-exclude: ${{ steps.arch.outputs.local-exclude || '[]' }}
 
     steps:
       - name: Check arches for local build

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -60,7 +60,7 @@ on:
         value: ${{ jobs.common-variables.outputs.rebuild-qa-containers }}
       architectures:
         description: |
-          Space-seperated list of architectures to build
+          Space-separated list of architectures to build
         value: |
           ${{ ((github.event_name != 'pull_request' ||
             contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')) &&

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -58,6 +58,13 @@ on:
         description: |
           Trigger rebuild of QA containers
         value: ${{ jobs.common-variables.outputs.rebuild-qa-containers }}
+      architectures:
+        description: |
+          Space-seperated list of architectures to build
+        value: |
+          ${{ ((github.event_name != 'pull_request' ||
+            contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')) &&
+            'amd64 arm64 ppc64le s390x') || 'amd64 arm64' }}
 
 jobs:
   common-variables:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,6 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         vm_type:
+          - cos-arm64
           - rhel-arm64
           - ubuntu-arm
           - sles-arm64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,9 +91,6 @@ jobs:
 
   arm64-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
-    if: |
-      github.event_name != 'pull_request' || inputs.is-konflux ||
-      contains(github.event.pull_request.labels.*.name, 'run-multiarch-builds')
     strategy:
       # ensure that if one part of the matrix fails, the
       # rest will continue

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
     needs: init
     with:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
+      architectures: ${{ needs.init.outputs.architectures }}
     secrets: inherit
 
   build-collector:
@@ -51,6 +52,7 @@ jobs:
       collector-tag: ${{ needs.init.outputs.collector-tag }}
       collector-image: ${{ needs.init.outputs.collector-image }}
       collector-builder-tag: ${{ needs.build-builder-image.outputs.collector-builder-tag }}
+      architectures: ${{ needs.init.outputs.architectures }}
     secrets: inherit
 
   build-test-containers:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,16 +11,18 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-24.04
     container:
       image: quay.io/stackrox-io/collector-builder:${{ inputs.collector-builder-tag }}
     strategy:
       fail-fast: false
       matrix:
+        arch: [amd64, arm64]
         cmake-flags:
         - -DCMAKE_BUILD_TYPE=Release
         - -DADDRESS_SANITIZER=ON -DCMAKE_BUILD_TYPE=Debug
         - -DUSE_VALGRIND=ON -DCMAKE_BUILD_TYPE=Debug
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -92,6 +92,15 @@ virtual_machines:
       - cos-beta
       - cos-dev
 
+  cos-arm64:
+    arch: arm64
+    machine_type: t2a-standard-2
+    project: cos-cloud
+    families:
+      - cos-arm64-stable
+      - cos-arm64-beta
+      - cos-arm64-dev
+
   sles:
     project: suse-cloud
     families:


### PR DESCRIPTION
## Description
**Undo the revert with a fix for error of using a runtime computed value within a job matrix.**

Re-enable changes from https://github.com/stackrox/collector/pull/2084 which was reverted. Now with fixes to github actions on these [commits](https://github.com/stackrox/collector/pull/2106/files/aa714121e95a525f5cde83e4b849ad80549124eb..baddaf52b967c30d66eb1965a22eae1e5ea941c2 )

**Original Description:**
Utilize newly added [arm64 runners](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ ) for github actions.

* Build arm64 images natively instead of using QEMU in all workflows
* Make arm64 builds, unit-tests, and integration tests run alongside x86_64 **by default** on PR workflows. Build time performance is slightly faster on ARM so it shouldn't increase total time to finish PR steps.
* Split and refactored the builder image job into a local and remote version 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
