### PR TITLE
Make IsCanonicalExternalIp independent of system endianness

### DIFF
--- a/collector/lib/NetworkConnection.h
+++ b/collector/lib/NetworkConnection.h
@@ -139,7 +139,7 @@ class Address {
   static bool IsCanonicalExternalIp(const Address& addr) {
     switch (addr.family_) {
       case Family::IPV4:
-        return addr.data_[0] == 0xffffffffULL;
+        return (addr.data_[0] & htonll(0xffffffff00000000ULL)) == htonll(0xffffffff00000000ULL);
       case Family::IPV6:
         return addr.data_[0] == 0xffffffffffffffffULL && addr.data_[1] == 0xffffffffffffffffULL;
       default:

--- a/collector/test/NetworkConnectionTest.cpp
+++ b/collector/test/NetworkConnectionTest.cpp
@@ -172,7 +172,7 @@ TEST(TestIPNet, TestIsCanonicalExternalIp) {
   };
 
   for (const auto& [address, expected] : tests) {
-    EXPECT_EQ(Address::IsCanonicalExternalIp(address), expected);
+    EXPECT_EQ(Address::IsCanonicalExternalIp(address), expected) << "Address under test: " << address;
   }
 }
 


### PR DESCRIPTION


## Description

IsCanonicalExternalIp does not work on big endian systems like s390x. This change makes it so the check is always done in network endianness, effectively making it independent of the system. Change is only needed on IPv4 checks because IPv6 uses 64 bit integers filled with 1s, so endianness is irrelevant in that case.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Konflux run should pass.