### PR TITLE
chore: Bump memory limit in TA download

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -89,6 +89,14 @@ spec:
       computeResources: *ta-resources
     - name: create-trusted-artifact
       computeResources: *ta-resources
+    - name: prefetch-dependencies
+      # We saw prefetch-dependencies _step_ also OOMKill-ed, therefore bumping its memory compared to default.
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: "1"
+          memory: 4Gi
   - pipelineTaskName: build-container-s390x
     stepSpecs:
     - name: use-trusted-artifact

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -105,6 +105,14 @@ spec:
     stepSpecs:
     - name: use-trusted-artifact
       computeResources: *ta-resources
+  - pipelineTaskName: sast-shell-check
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
   - pipelineTaskName: sast-snyk-check
     stepSpecs:
     - name: use-trusted-artifact

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -71,9 +71,9 @@ spec:
       # use-/create-trusted-artifact gets OOM-killed when a cluster is loaded. Bigger mem limits==request should help.
       computeResources: &ta-resources
         limits:
-          memory: 3Gi
+          memory: 4Gi
         requests:
-          memory: 3Gi
+          memory: 4Gi
 
   - pipelineTaskName: clone-repository
     stepSpecs:


### PR DESCRIPTION
## Description

Saw OOMKill again in prefetch-dependencies in this task (with a "call stack"):
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/collector-on-push-jpqj8-prefetch-dependencies/logs
- https://github.com/stackrox/collector/pull/2128/checks?check_run_id=42536648131
- https://github.com/stackrox/collector/pull/2128

From `kubectl describe pod collector-on-push-jpqj8-prefetch-dependencies-pod`:

```
[...]
  step-use-trusted-artifact:
[...]
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Tue, 20 May 2025 10:34:05 +0200
      Finished:     Tue, 20 May 2025 10:35:18 +0200
    Ready:          False
    Restart Count:  0
    Limits:
      memory:  3Gi
    Requests:
      cpu:     20m
      memory:  3Gi
[...]
```

Here I suggest giving it +1 more gigabyte to see if it helps. I don't have a more predictable way to determine resource needs.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Will try until the Konflux CI is green.