### PR TITLE
build(fix): Bump TA steps memory from 4 to 6Gi

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -125,6 +125,10 @@ spec:
     stepSpecs:
     - name: use-trusted-artifact
       computeResources: *ta-resources
+  - pipelineTaskName: push-dockerfile
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-collector

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -71,9 +71,9 @@ spec:
       # use-/create-trusted-artifact gets OOM-killed when a cluster is loaded. Bigger mem limits==request should help.
       computeResources: &ta-resources
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
 
   - pipelineTaskName: clone-repository
     stepSpecs:

--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -71,9 +71,9 @@ spec:
       # use-/create-trusted-artifact gets OOM-killed when a cluster is loaded. Bigger mem limits==request should help.
       computeResources: &ta-resources
         limits:
-          memory: 4Gi
+          memory: 5Gi
         requests:
-          memory: 4Gi
+          memory: 5Gi
 
   - pipelineTaskName: clone-repository
     stepSpecs:


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/collector/pull/2129. In that PR I bumped the memory from 3 to 4Gi, but that wasn't enough as I saw `sast-unicode-check` failing [here](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/collector-on-push-4cnxr) with OOMKill.

```
$ kubectl describe pod collector-on-push-4cnxr-sast-unicode-check-pod
[...]
Containers:
  step-use-trusted-artifact:
[...]
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Wed, 21 May 2025 04:43:24 +0200
      Finished:     Wed, 21 May 2025 04:45:25 +0200
    Ready:          False
    Restart Count:  0
    Limits:
      memory:  4Gi
    Requests:
      cpu:     33m
      memory:  4Gi
[...]
```

Again, I don't know if the current value is enough but we'll see if failures keep happening.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
No change.

## Testing Performed

None. Will only check that CI feels ok.