### PR TITLE
Remove stale description of 'if-konflux'

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,8 +32,6 @@ on:
       is-konflux:
         description: |
           Marker for workflows triggered for a konflux build.
-          These builds don't support multiarch, so it should only run x86
-          tests
         type: boolean
         default: false
       large-box:


### PR DESCRIPTION
## Description

The effect of `is-klonflux` has been changed by https://github.com/stackrox/collector/pull/1768 and https://github.com/stackrox/collector/pull/1930 from its original purpose.

The existing description is misleading, remove it.
