### PR TITLE
Build arm64 test container by default

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -48,6 +48,7 @@ jobs:
               - integration-tests/images.yml
               - integration-tests/Dockerfile
               - .github/workflows/integration-test-containers.yml
+              - ansible/ci-build-tests.yml
 
   build-test-image:
     name: Build the integration test image

--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -10,7 +10,7 @@
       when: build_multi_arch
 
     - set_fact:
-        platforms: "linux/amd64"
+        platforms: "linux/amd64,linux/arm64"
       when: not build_multi_arch
 
     - set_fact:


### PR DESCRIPTION

## Description

After the changes introduced in #2106, we are building arm64 images by default and trying to test them. If a change is made to the integration tests, we are only building the amd64 version of the container and the arm64 tests fail when trying to pull the image for that architecture.

This patch makes it so the test container is built for amd64 and arm64 by default.

#2101 is currently affected by this bug.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Check the arm64 test container is built by default.
