### PR TITLE
Move the collector tests image to its own registry

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -23,7 +23,7 @@ on:
     outputs:
       collector-tests-tag:
         description: The tag used for the integration test image
-        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'collector-tests-master' }}
+        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'master' }}
 
 jobs:
   should-build-test-image:
@@ -63,7 +63,7 @@ jobs:
       collector-tests-tag: ${{ steps.tests-tag.outputs.collector-tests-tag }}
 
     env:
-      DEFAULT_TESTS_TAG: collector-tests-master
+      DEFAULT_TESTS_TAG: master
 
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'pull_request' || \
                 "${{ github.ref_type }}" == 'tag' || \
                 "${{ github.ref_name }}" =~ ^release- ]]; then
-            COLLECTOR_TESTS_TAG="collector-tests-${{ inputs.collector-tag }}"
+            COLLECTOR_TESTS_TAG="${{ inputs.collector-tag }}"
           fi
 
           echo "COLLECTOR_TESTS_TAG=${COLLECTOR_TESTS_TAG}" >> "$GITHUB_ENV"
@@ -130,7 +130,7 @@ jobs:
           # build_multi_arch passed in as json to ensure boolean type
           ansible-playbook \
             --connection local -i localhost, --limit localhost \
-            -e test_image="quay.io/rhacs-eng/qa-multi-arch:${COLLECTOR_TESTS_TAG}" \
+            -e test_image="quay.io/rhacs-eng/collector-tests:${COLLECTOR_TESTS_TAG}" \
             -e "{\"build_multi_arch\": $BUILD_MULTI_ARCH}" \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-tests.yml

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       COLLECTOR_IMAGE: ${{ inputs.collector-repo }}:${{ inputs.collector-tag }}
       COLLECTOR_QA_TAG: ${{ inputs.collector-qa-tag }}
-      TEST_IMAGE: quay.io/rhacs-eng/qa-multi-arch:${{ inputs.collector-tests-tag }}
+      TEST_IMAGE: quay.io/rhacs-eng/collector-tests:${{ inputs.collector-tests-tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
-  COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/qa-multi-arch:${{ inputs.collector-tests-tag }}
+  COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/collector-tests:${{ inputs.collector-tests-tag }}
   COLLECTOR_IMAGE: ${{ inputs.collector-repo }}:${{ inputs.collector-tag }}
 
 jobs:

--- a/ansible/roles/run-test-target/tasks/test-cri.yml
+++ b/ansible/roles/run-test-target/tasks/test-cri.yml
@@ -33,7 +33,7 @@
   ansible.builtin.set_fact:
     logs_root: "{{ collector_root }}/integration-tests/container-logs"
     collector_image: "{{ lookup('env', 'COLLECTOR_IMAGE', default='quay.io/rhacs-eng/collector:' +  collector_tag_result.stdout) }}"
-    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/qa-multi-arch:collector-tests-' + collector_tag_result.stdout) }}"
+    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/collector-tests:' + collector_tag_result.stdout) }}"
 
 - name: Default args
   ansible.builtin.set_fact:

--- a/ansible/roles/run-test-target/tasks/test-docker.yml
+++ b/ansible/roles/run-test-target/tasks/test-docker.yml
@@ -20,7 +20,7 @@
 
 - set_fact:
     collector_image: "{{ lookup('env', 'COLLECTOR_IMAGE', default='quay.io/rhacs-eng/collector:' +  collector_tag_result.stdout) }}"
-    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/qa-multi-arch:collector-tests-' + collector_tag_result.stdout) }}"
+    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/collector-tests:' + collector_tag_result.stdout) }}"
 
 - set_fact:
     run_args: -test.run {{ collector_test }} -test.timeout 60m -test.count=1

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -14,11 +14,11 @@ COLLECTOR_QA_TAG=$(shell cat container/QA_TAG | tr -d '\n')
 endif
 
 ifeq ($(COLLECTOR_TESTS_REPO),)
-COLLECTOR_TESTS_REPO=quay.io/rhacs-eng/qa-multi-arch
+COLLECTOR_TESTS_REPO=quay.io/rhacs-eng/collector-tests
 endif
 
 ifeq ($(COLLECTOR_TESTS_IMAGE),)
-COLLECTOR_TESTS_IMAGE=$(COLLECTOR_TESTS_REPO):collector-tests-$(COLLECTOR_TAG)
+COLLECTOR_TESTS_IMAGE=$(COLLECTOR_TESTS_REPO):$(COLLECTOR_TAG)
 endif
 
 SHELL=/bin/bash


### PR DESCRIPTION
## Description

We have been pushing our integration tests to a generic qa registry that is meant to have (mostly) static images. This somewhat pollutes the registry and might make it harder for people to find the tags they want, so we are moving this image to a new registry.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.