### PR TITLE
Fix token used for pushing of tags and branches in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
+          token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 
       - name: Initialize mandatory git config
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: false
+          submodules: true
           fetch-depth: 0
           token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
       RELEASE: ${{ needs.determine-version.outputs.major }}.${{ needs.determine-version.outputs.minor }}
       RELEASE_TYPE: ${{ needs.determine-version.outputs.release-type }}
       PATCH: ${{ needs.determine-version.outputs.patch }}
+      GH_TOKEN: "${{ secrets.RHACS_BOT_GITHUB_TOKEN }}"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Our current configuration forbids GHA from pushing branches and tags to our repos. This change uses the rhacs-bot token, which should have the required permissions

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Create the release using the changes from this branch. ([CI run for 3.22.0](https://github.com/stackrox/collector/actions/runs/15343269483))
