### PR TITLE
ROX-29602: Use updated `determine-image-tag` task

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       - name: name
         value: post-bigquery-metrics
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -201,7 +201,7 @@ spec:
       - name: name
         value: determine-image-expiration
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles
@@ -217,7 +217,7 @@ spec:
       - name: name
         value: determine-image-tag
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:f25156593a965451b5e21dd337ae0ffe68cd3b30dacfc76997c1e161788cf7c9
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:8f95f656875314a5c10e5da5f9a35352c3cd59a96e9da1648199686dccde6da2
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Description

From https://github.com/stackrox/konflux-tasks/pull/66.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Only CI here.