### PR TITLE
fix(ci): remove unsupported Ubuntu versions

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -140,7 +140,6 @@ virtual_machines:
   ubuntu-os:
     project: ubuntu-os-cloud
     families:
-      - ubuntu-2004-lts
       - ubuntu-2204-lts
       - ubuntu-2404-lts-amd64
 
@@ -149,7 +148,6 @@ virtual_machines:
     arch: arm64
     machine_type: t2a-standard-2
     families:
-      - ubuntu-2004-lts-arm64
       - ubuntu-2204-lts-arm64
       - ubuntu-2404-lts-arm64
 


### PR DESCRIPTION
## Description

Ubuntu images have been removed from GCP, so this PR simply removes them from our test matrix.
