### PR TITLE
Add a label forcing a test container rebuild on PRs

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -56,7 +56,11 @@ jobs:
     needs:
       - should-build-test-image
     if: |
-      (github.event_name != 'pull_request' || needs.should-build-test-image.outputs.build-image == 'true') &&
+      (
+        github.event_name != 'pull_request' ||
+        needs.should-build-test-image.outputs.build-image == 'true' ||
+        contains(github.event.pull_request.labels.*.name, 'rebuild-test-container')
+      ) &&
       !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests')
 
     outputs:


### PR DESCRIPTION

## Description

Usually, the test container only needs rebuilding when a change to the tests or related files happen. However, when creating PRs that target old branches (like when backporting changes to a release branch), the rebuild may not trigger and an older image may be subject to newer tests it is not meant to pass.

In order to work around this, a label for triggering rebuilds of the test container manually is added, allowing PRs to rebuild the test container on demand.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
