### PR TITLE
Move the collector tests image to its own registry (#2150)

### DIFF
--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -19,7 +19,7 @@ on:
     outputs:
       collector-tests-tag:
         description: The tag used for the integration test image
-        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'collector-tests-master' }}
+        value: ${{ jobs.build-test-image.outputs.collector-tests-tag || 'master' }}
 
 jobs:
   should-build-test-image:
@@ -58,7 +58,7 @@ jobs:
       collector-tests-tag: ${{ steps.tests-tag.outputs.collector-tests-tag }}
 
     env:
-      DEFAULT_TESTS_TAG: collector-tests-master
+      DEFAULT_TESTS_TAG: master
 
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
           if [[ "${{ github.event_name }}" == 'pull_request' || \
                 "${{ github.ref_type }}" == 'tag' || \
                 "${{ github.ref_name }}" =~ ^release- ]]; then
-            COLLECTOR_TESTS_TAG="collector-tests-${{ inputs.collector-tag }}"
+            COLLECTOR_TESTS_TAG="${{ inputs.collector-tag }}"
           fi
 
           echo "COLLECTOR_TESTS_TAG=${COLLECTOR_TESTS_TAG}" >> "$GITHUB_ENV"
@@ -103,7 +103,7 @@ jobs:
           # build_multi_arch passed in as json to ensure boolean type
           ansible-playbook \
             --connection local -i localhost, --limit localhost \
-            -e test_image="quay.io/rhacs-eng/qa-multi-arch:${COLLECTOR_TESTS_TAG}" \
+            -e test_image="quay.io/rhacs-eng/collector-tests:${COLLECTOR_TESTS_TAG}" \
             -e "{\"build_multi_arch\": $BUILD_MULTI_ARCH}" \
             -e @'${{ github.workspace }}/ansible/secrets.yml' \
             ansible/ci-build-tests.yml

--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       COLLECTOR_IMAGE: ${{ inputs.collector-repo }}:${{ inputs.collector-tag }}
       COLLECTOR_QA_TAG: ${{ inputs.collector-qa-tag }}
-      TEST_IMAGE: quay.io/rhacs-eng/qa-multi-arch:${{ inputs.collector-tests-tag }}
+      TEST_IMAGE: quay.io/rhacs-eng/collector-tests:${{ inputs.collector-tests-tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/k8s-integration-tests.yml
+++ b/.github/workflows/k8s-integration-tests.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
-  COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/qa-multi-arch:${{ inputs.collector-tests-tag }}
+  COLLECTOR_TESTS_IMAGE: quay.io/rhacs-eng/collector-tests:${{ inputs.collector-tests-tag }}
   COLLECTOR_IMAGE: quay.io/rhacs-eng/collector:${{ inputs.collector-tag }}
 
 jobs:

--- a/ansible/roles/run-test-target/tasks/test-collection-method.yml
+++ b/ansible/roles/run-test-target/tasks/test-collection-method.yml
@@ -23,7 +23,7 @@
 
 - set_fact:
     collector_image: "{{ lookup('env', 'COLLECTOR_IMAGE', default='quay.io/rhacs-eng/collector:' +  collector_tag_result.stdout) }}"
-    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/qa-multi-arch:collector-tests-' + collector_tag_result.stdout) }}"
+    integration_tests_image: "{{ lookup('env', 'TEST_IMAGE', default='quay.io/rhacs-eng/collector-tests:' + collector_tag_result.stdout) }}"
 
 - set_fact:
     run_args: -test.run {{ collector_test }} -test.timeout 60m -test.count=1

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -14,11 +14,11 @@ COLLECTOR_QA_TAG=$(shell cat container/QA_TAG | tr -d '\n')
 endif
 
 ifeq ($(COLLECTOR_TESTS_REPO),)
-COLLECTOR_TESTS_REPO=quay.io/rhacs-eng/qa-multi-arch
+COLLECTOR_TESTS_REPO=quay.io/rhacs-eng/collector-tests
 endif
 
 ifeq ($(COLLECTOR_TESTS_IMAGE),)
-COLLECTOR_TESTS_IMAGE=$(COLLECTOR_TESTS_REPO):collector-tests-$(COLLECTOR_TAG)
+COLLECTOR_TESTS_IMAGE=$(COLLECTOR_TESTS_REPO):$(COLLECTOR_TAG)
 endif
 
 SHELL=/bin/bash


### PR DESCRIPTION
## Description

Backport of #2150.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Test image is built and pushed to the new registry.
