### PR TITLE
Use go cross-compilation to speed up test builds on CI

### DIFF
--- a/ansible/ci-build-tests.yml
+++ b/ansible/ci-build-tests.yml
@@ -6,15 +6,12 @@
 
   tasks:
     - set_fact:
-        platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-      when: build_multi_arch
-
-    - set_fact:
-        platforms: "linux/amd64,linux/arm64"
-      when: not build_multi_arch
-
-    - set_fact:
         collector_root: "{{ lookup('env', 'GITHUB_WORKSPACE') }}"
+
+    - name: Build test binaries
+      community.general.make:
+        chdir: "{{ collector_root }}/integration-tests"
+        target: build-all
 
     - name: Login to quay.io
       community.docker.docker_login:
@@ -45,4 +42,3 @@
         registry_url: quay.io
         state: absent
       when: true
-

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,35 +1,14 @@
-ARG TEST_ROOT="/tests"
-
-FROM golang:1.23 as builder
-
-ARG TEST_ROOT
-
-ENV GOCACHE=/root/.cache/go-build
-
-RUN mkdir -p "$TEST_ROOT"
-WORKDIR "$TEST_ROOT"
-
-# Cache dependencies
-COPY go.* "$TEST_ROOT"
-RUN go mod download
-
-COPY suites "$TEST_ROOT/suites/"
-COPY pkg "$TEST_ROOT/pkg/"
-COPY integration_test.go "$TEST_ROOT"
-COPY benchmark_test.go "$TEST_ROOT"
-COPY k8s_test.go "$TEST_ROOT"
-
-RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go test -tags bench,k8s -c -o collector-tests
-
 FROM alpine:3.18
 
-ARG TEST_ROOT
+ARG TEST_ROOT="/tests"
 
-RUN apk add docker
-
-COPY --from=builder $TEST_ROOT/collector-tests $TEST_ROOT/collector-tests
-COPY images.yml "$TEST_ROOT"
+RUN apk add docker && \
+    mkdir -p $TEST_ROOT
 
 WORKDIR "$TEST_ROOT"
 
-ENTRYPOINT ["./collector-tests"]
+COPY bin/$TARGETARCH/collector-tests /usr/local/bin
+
+COPY images.yml .
+
+ENTRYPOINT ["collector-tests"]

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -21,6 +21,8 @@ ifeq ($(COLLECTOR_TESTS_IMAGE),)
 COLLECTOR_TESTS_IMAGE=$(COLLECTOR_TESTS_REPO):$(COLLECTOR_TAG)
 endif
 
+GOARCH ?= $(shell go env GOARCH)
+
 SHELL=/bin/bash
 
 # Environment variable COLLECTOR_IMAGE is used by integration-tests
@@ -59,11 +61,18 @@ $(foreach element,$(ALL_TESTS),$(eval $(call make-test-target-dockerized,$(eleme
 
 .PHONY: build
 build:
-	mkdir -p bin
-	go test -tags bench,k8s -c -o bin/collector-tests
+	mkdir -p bin/$(GOARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go test -tags bench,k8s -c -o bin/$(GOARCH)/collector-tests
+
+.PHONY: build-all
+build-all:
+	GOARCH=amd64 make build
+	GOARCH=arm64 make build
+	GOARCH=s390x make build
+	GOARCH=ppc64le make build
 
 .PHONY: build-image
-build-image:
+build-image: build-all
 	docker build --platform $(PLATFORM) -t $(COLLECTOR_TESTS_IMAGE) \
 		--build-arg QA_TAG=$(shell cat container/QA_TAG) \
 		$(CURDIR)


### PR DESCRIPTION
## Description

After adding Arm runners on GHA, we made it so the Arm test image is always built. Unfortunately, because we use QEMU to build the images, the build has gotten quite slow.

In order to speed up the build, this change makes it so we cross-compile the binaries for all our supported platforms locally and the image build simply copies the binaries into the final image.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Run tests for all architectures.