### PR TITLE
Update RHEL SAP VMs for tests

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -59,8 +59,12 @@ virtual_machines:
   rhel-sap:
     project: rhel-sap-cloud
     families:
-      - rhel-8-4-sap-ha
       - rhel-8-6-sap-ha
+      - rhel-8-8-sap-ha
+      - rhel-8-10-sap-ha
+      - rhel-9-0-sap-ha
+      - rhel-9-2-sap-ha
+      - rhel-9-4-sap-ha
     # RHEL SAP 8.4 seems to have an older version of podman that
     # fails with our integration tests, so we stick with docker
     # for now.

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -65,10 +65,7 @@ virtual_machines:
       - rhel-9-0-sap-ha
       - rhel-9-2-sap-ha
       - rhel-9-4-sap-ha
-    # RHEL SAP 8.4 seems to have an older version of podman that
-    # fails with our integration tests, so we stick with docker
-    # for now.
-    container_engine: docker
+    container_engine: podman
 
   rhcos:
     project: rhcos-cloud


### PR DESCRIPTION
## Description

RHEL SAP 8.4 was removed from GCP, so we are using this opportunity to update the list of VMs used for testing.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
