### PR TITLE
Fetch VM families from GCP for testing

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -28,8 +28,7 @@ virtual_machines:
   rhel:
     project: rhel-cloud
     families:
-      - rhel-8
-      - rhel-9
+      "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_gcp_families.sh -a X86_64 -p rhel-cloud') }}"
     container_engine: podman
 
   rhel-arm64:
@@ -37,7 +36,7 @@ virtual_machines:
     arch: arm64
     machine_type: t2a-standard-2
     families:
-      - rhel-9-arm64
+      "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_gcp_families.sh -a ARM64 -p rhel-cloud') }}"
     container_engine: podman
 
   rhel-s390x:
@@ -59,12 +58,7 @@ virtual_machines:
   rhel-sap:
     project: rhel-sap-cloud
     families:
-      - rhel-8-6-sap-ha
-      - rhel-8-8-sap-ha
-      - rhel-8-10-sap-ha
-      - rhel-9-0-sap-ha
-      - rhel-9-2-sap-ha
-      - rhel-9-4-sap-ha
+      "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_gcp_families.sh -a X86_64 -p rhel-sap-cloud') }}"
     container_engine: podman
 
   rhcos:
@@ -141,16 +135,14 @@ virtual_machines:
   ubuntu-os:
     project: ubuntu-os-cloud
     families:
-      - ubuntu-2204-lts
-      - ubuntu-2404-lts-amd64
+      "{{ lookup('ansible.builtin.pipe', \"scripts/fetch_gcp_families.sh -f '^ubuntu-\\d+-lts(-amd64)?$'\") }}"
 
   ubuntu-arm:
     project: ubuntu-os-cloud
     arch: arm64
     machine_type: t2a-standard-2
     families:
-      - ubuntu-2204-lts-arm64
-      - ubuntu-2404-lts-arm64
+      "{{ lookup('ansible.builtin.pipe', \"scripts/fetch_gcp_families.sh -f '^ubuntu-\\d+-lts-arm64$'\") }}"
 
   ubuntu-os-pro:
     project: ubuntu-os-pro-cloud

--- a/ansible/scripts/fetch_gcp_families.sh
+++ b/ansible/scripts/fetch_gcp_families.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function usage() {
+    echo "$0 [OPTIONS]"
+    echo ""
+    echo "[OPTIONS]"
+    echo " -a, --arch"
+    echo "    Architecture wanted for the listed images"
+    echo " -p, --project"
+    echo "    Project the image is hosted in"
+    echo " -f, --family"
+    echo "    Regular expression for the image family to be listed"
+}
+
+TEMP=$(getopt -o 'ha:p:f:' -l 'help,arch,project,family' -n "$0" -- "$@")
+
+# shellcheck disable=SC2181
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+eval set -- "$TEMP"
+unset TEMP
+
+arch=""
+family=""
+project=""
+filter=""
+using_regex=0
+using_aip=0
+
+while true; do
+    case "${1:-}" in
+        '-h' | '--help')
+            usage
+            exit 0
+            ;;
+
+        '-a' | '--arch')
+            arch="architecture=$2"
+            using_aip=1
+            shift 2
+            ;;
+
+        '-p' | '--project')
+            project="selfLink=/$2/"
+            using_aip=1
+            shift 2
+            ;;
+
+        '-f' | '--family')
+            family="family ~ \"$2\""
+            using_regex=1
+            shift 2
+            ;;
+
+        '--')
+            shift
+            break
+            ;;
+    esac
+done
+
+if ((using_regex != 0 && using_aip != 0)); then
+    echo >&2 "Mixing regex and AIP-160 is not supported in gcloud filters"
+    echo >&2 "see: https://cloud.google.com/compute/docs/reference/rest/v1/images/list"
+    exit 1
+elif ((using_regex != 0)); then
+    filter="$family"
+elif ((using_aip != 0)); then
+    if [[ -n "$project" ]]; then
+        filter="$project"
+        if [[ -n "$arch" ]]; then
+            filter="$filter AND $arch"
+        fi
+    elif [[ -n "$arch" ]]; then
+        filter="$arch"
+    fi
+fi
+
+gcloud compute images list \
+    --format='json(family)' \
+    --filter="$filter" \
+    --limit 10 | jq -cM '[ .[].family ]'


### PR DESCRIPTION

## Description

Few times over the last couple of years we have found ourselves having to update the list of VMs we use for testing manually when a family is added or removed from GCP. This is an annoying process that also turns our CI red until we get it done when an image is removed.

With this change, the list of VM images to be used for RHEL and Ubuntu will be directly retrieved from GCP with a script.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
