### PR TITLE
fix: add rhacs-bot to CODEOWNERS for auto-approve targets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,10 @@
 RELEASED_VERSIONS               @stackrox/collector-team
 RELEASED_VERSIONS.unsupported   @stackrox/collector-team
 
-# The RHTAP maintainers for ACS review all changes related to the Konflux (f.k.a. RHTAP) pipelines, such as new
+# The RHTAP maintainers for ACS review all changes related to the Konflux pipelines, such as new
 # pipelines, parameter changes or automated task updates as well as Dockerfile updates.
-**/konflux.*Dockerfile  @stackrox/rhtap-maintainers
-/.tekton/               @stackrox/rhtap-maintainers
-rpms.*                  @stackrox/rhtap-maintainers
+# rhacs-bot auto-approves MintMaker PRs for automated task and security updates.
+**/konflux.*Dockerfile  @stackrox/rhtap-maintainers @rhacs-bot
+/.tekton/               @stackrox/rhtap-maintainers @rhacs-bot
+rpms.*                  @stackrox/rhtap-maintainers @rhacs-bot
 .github/renovate.json5  @stackrox/rhtap-maintainers


### PR DESCRIPTION
## Description

Per title.
Triggered by 

<img width="470" alt="Screenshot 2025-07-08 at 08 17 33" src="https://github.com/user-attachments/assets/71f4a64d-05e4-43f8-98e8-c13c18ddfc44" />

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

No testing possible. 
