### PR TITLE
chore: enable platform automerge for Renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,7 @@
     "automergeSchedule": [
       "at any time"
     ],
+    "platformAutomerge": true
   }],
   "labels": ["auto-approve"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,7 +83,7 @@
     "automergeSchedule": [
       "at any time"
     ],
-    "platformAutomerge": true
+    "platformAutomerge": true,
   }],
   "labels": ["auto-approve"],
 }


### PR DESCRIPTION
## Description

After https://github.com/stackrox/collector/pull/2197, we're seeing the first Renovate PRs being auto-approved: https://github.com/stackrox/collector/pull/2213

However, they don't auto-merge yet. Our [agreement](https://docs.google.com/document/d/1YiIA9cqZzBIqBr54_b9NViUGvTSou0rdjF5oh5Ag_sI/edit?tab=t.0#bookmark=id.ru7qfcc9qfp4) was to enable platformAutomerge, this is what this PR now does.
I allowed the auto-merge to be enabled in this repository.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Ran local Renovate validation.