### PR TITLE
Stop triggering konflux builds on marking PR as ready for review

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" || (
+      (event == "pull_request" && body.action != "ready_for_review") || (
         event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")
       )
   labels:


### PR DESCRIPTION

## Description

With our current CEL expression, transitioning a PR from draft to ready will re-trigger a konflux build. This wouldn't be such a big deal, except those builds take about 30 minutes and block us from merging PRs, so a draft PR with a list of green CI checks and the required approvals will still need at least 30 minutes before being merged. This is worsened by the fact that konflux builds are currently flaky and can require multiple runs before getting a successful one.

With this change, this transition should no longer trigger a build.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Transition the PR from draft to ready and check the konflux build is not re-triggered.
