### PR TITLE
backport(release-3.20): Renovate bot auto-merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,10 @@
 RELEASED_VERSIONS               @stackrox/collector-team
 RELEASED_VERSIONS.unsupported   @stackrox/collector-team
 
-# The RHTAP maintainers for ACS review all changes related to the Konflux (f.k.a. RHTAP) pipelines, such as new
+# The RHTAP maintainers for ACS review all changes related to the Konflux pipelines, such as new
 # pipelines, parameter changes or automated task updates as well as Dockerfile updates.
-**/konflux.*Dockerfile  @stackrox/rhtap-maintainers
-/.tekton/               @stackrox/rhtap-maintainers
-rpms.*                  @stackrox/rhtap-maintainers
+# rhacs-bot auto-approves MintMaker PRs for automated task and security updates.
+**/konflux.*Dockerfile  @stackrox/rhtap-maintainers @rhacs-bot
+/.tekton/               @stackrox/rhtap-maintainers @rhacs-bot
+rpms.*                  @stackrox/rhtap-maintainers @rhacs-bot
+.github/renovate.json5  @stackrox/rhtap-maintainers

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,4 +71,18 @@
     "dockerfile",
     "rpm",
   ],
+  "packageRules": [{
+    "matchPackageNames": ["/.*/"],
+    "groupName": "All updates",
+    "automerge": true,
+    // A known issue is that some non-Konflux CI jobs in currently fail, which may prevent successful auto-merging with a "branch" auto-merge setting.
+    // Therefore, we use PR merge type and have automation approve PRs.
+    "automergeType": "pr",
+    "automergeStrategy": "squash",
+    // Tell Renovate that it can automerge branches at any time of the day.
+    "automergeSchedule": [
+      "at any time"
+    ],
+  }],
+  "labels": ["auto-approve"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,5 +84,5 @@
       "at any time"
     ],
   }],
-  "labels": ["auto-approve"],
+  "labels": ["auto-approve", "build-builder-image","rebuild-test-container"],
 }

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,20 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+    types:
+    - labeled
+
+jobs:
+  auto-approve:
+    name: Auto-approve Konflux updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'red-hat-konflux[bot]' && github.event.label.name == 'auto-approve'
+    steps:
+    - env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        gh pr review ${{ github.event.pull_request.number }} \
+          --approve --body "Auto-approved by automation." \
+          --repo "${{ github.repository }}"


### PR DESCRIPTION
## Description

Backporting the changes to the Renovate config, auto-approve workflow and CODEOWNERS.
This will enable auto-merges of Renovate updates to the release branch.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested in `master` branch, example https://github.com/stackrox/collector/pull/2223
