### PR TITLE
Skip flaky fedora test

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -531,6 +531,9 @@ func TestUdpNetworkFlow(t *testing.T) {
 	if strings.Contains(config.VMInfo().Config, "rhel-8-4-sap") {
 		t.Skip("Skipping test on RHEL 8.4 SAP due to a verifier issue")
 	}
+	if strings.Contains(config.VMInfo().Config, "fedora-coreos-stable") {
+		t.Skip("Skipping due to ROX-27673")
+	}
 	suite.Run(t, new(suites.UdpNetworkFlow))
 }
 


### PR DESCRIPTION

## Description

The TestUdpNetworkFlow test on Fedora has been flaky for the last couple of months and making our CI red. We will skip this test until ROX-27673 is addressed.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Check the CI logs to ensure the test is properly skipped.
