### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,5 +85,5 @@
     ],
     "platformAutomerge": true,
   }],
-  "labels": ["auto-approve"],
+  "labels": ["auto-approve", "build-builder-image", "rebuild-test-container"],
 }


### PR DESCRIPTION
## Description

I had added the additional labels to always rebuild the builder image and test container on the release branches, but that had no effect - PRs were opened without them and I had to add them manually: https://github.com/stackrox/collector/pull/2236.

So, it seems like Renovate is taking the configuration from master branch and applying it to all branches 🤷 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

No testing required.