### PR TITLE
Downgrade network status notifier messages to trace

### DIFF
--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -228,7 +228,7 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
   ExternalIPsConfig prevEnableExternalIPs = config_.GetExternalIPsConf();
 
   while (writer->Sleep(next_scrape)) {
-    CLOG(DEBUG) << "Starting network status notification";
+    CLOG(TRACE) << "Starting network status notification";
     next_scrape = std::chrono::system_clock::now() + std::chrono::seconds(config_.ScrapeInterval());
 
     if (!UpdateAllConnsAndEndpoints()) {
@@ -275,7 +275,7 @@ void NetworkStatusNotifier::RunSingle(IDuplexClientWriter<sensor::NetworkConnect
     }
 
     if (!msg) {
-      CLOG(DEBUG) << "No update to report";
+      CLOG(TRACE) << "No update to report";
       continue;
     }
 


### PR DESCRIPTION
## Description

Currently two log messages are at debug level, which makes this level useless, since information in it is covered by an avalanche of repeating network status notifier messages. Downgrade to trace.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run Collector manually with the new level.