### PR TITLE
build: Fix clang&llvm installation in the builder / 3.20

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,8 +11,8 @@ RUN dnf -y update \
         binutils-devel \
         bison \
         ca-certificates \
-        clang-19.1.5 \
-        llvm-19.1.5 \
+        'clang-19.1.*' \
+        'llvm-19.1.*' \
         cmake \
         cracklib-dicts \
         diffutils \


### PR DESCRIPTION
## Description

To unblock https://github.com/stackrox/collector/pull/2346 and others.

See https://redhat-internal.slack.com/archives/CFMQ5C2TT/p1755181397587059

Wildcards work according to docs <https://dnf.readthedocs.io/en/latest/command_ref.html#specifying-packages>. I verified `dnf install 'clang-19.1.*'` manually and CentOS happily suggests to install `19.1.7-1.el9` with a bunch of deps.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
No change.

## Testing Performed

CI should tell.
