### PR TITLE
ROX-29605: Fix clang&llvm installation in the builder / 3.21

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,8 +11,8 @@ RUN dnf -y update \
         binutils-devel \
         bison \
         ca-certificates \
-        clang-19.1.5 \
-        llvm-19.1.5 \
+        'clang-19.1.*' \
+        'llvm-19.1.*' \
         cmake \
         cracklib-dicts \
         diffutils \


### PR DESCRIPTION
## Description

The same as https://github.com/stackrox/collector/pull/2349 but targeting `release-3.21`.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Only CI.