### PR TITLE
ROX-29604: Fix clang&llvm installation in the builder / 3.22

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf -y update \
         binutils-devel \
         bison \
         ca-certificates \
-        clang-19.1.5 \
-        llvm-19.1.5 \
+        'clang-19.1.*' \
+        'llvm-19.1.*' \
         cmake \
         cracklib-dicts \
         diffutils \


### PR DESCRIPTION
## Description

The same as https://github.com/stackrox/collector/pull/2349 but targeting `release-3.22`.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Only checking th CI.