### PR TITLE
build: Speed up `arm64` Konflux builds

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -399,7 +399,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: PLATFORM
-      value: linux/arm64
+      value: linux-cxlarge/arm64
     taskRef:
       params:
       - name: name

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -399,7 +399,7 @@ spec:
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: PLATFORM
-      value: linux-cxlarge/arm64
+      value: linux-c2xlarge/arm64
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
## Description

Looking at these earlier runs ([one](https://github.com/stackrox/collector/runs/49375296007), [two](https://github.com/stackrox/collector/runs/49487466713), [three](https://github.com/stackrox/collector/runs/49470441288)), buildah* tasks for `arm64` take one hour whereas other arches complete in 20-35 minutes. Thus `arm64` is solely responsible for slowing down the overall pipeline.

Similar to <https://github.com/stackrox/stackrox/pull/16654>, I apply here bigger instance type for arm64 to speed it up.

* `linux-cxlarge/arm64` ->
  * 39m55s https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/collector-on-push-bhtn4
* `linux-c2xlarge/arm64` ->
  * 27m12s https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/collector-on-push-8xbst

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

CI is green, ARM buildah task runs aren't much slower than for other arches.