### PR TITLE
chore(KONFLUX-6210): fix name label and set cpe label

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -127,4 +127,5 @@ ENTRYPOINT ["collector"]
 LABEL \
     com.redhat.component="rhacs-collector-container" \
     io.k8s.display-name="collector" \
-    name="rhacs-collector-rhel8"
+    name="advanced-cluster-security/rhacs-collector-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.8::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also:

* https://github.com/stackrox/stackrox/pull/16735
* https://github.com/release-engineering/rhtap-ec-policy/pull/149
