### PR TITLE
ROX-27673: disable UDP recvmmsg tests on 'fedora-coreos'

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -564,7 +564,8 @@ func TestUdpNetworkFlow(t *testing.T) {
 	if strings.Contains(config.VMInfo().Config, "rhel-8-4-sap") {
 		t.Skip("Skipping test on RHEL 8.4 SAP due to a verifier issue")
 	}
-	if strings.Contains(config.VMInfo().Config, "fedora-coreos-stable") {
+	// Matches both 'fedora-coreos' and 'fedora-coreos-stable'
+	if strings.Contains(config.VMInfo().Config, "fedora-coreos") {
 		t.Skip("Skipping due to ROX-27673")
 	}
 	suite.Run(t, new(suites.UdpNetworkFlow))


### PR DESCRIPTION
## Description

This test is flaky on fedora-coreos, similarly to fedora-coreos-stable. Disable it until we fix the issue.

Failure log example : https://github.com/stackrox/collector/actions/runs/17635837825/job/50117088388

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests