### PR TITLE
ROX-30215: allow release managers to review Renovate bot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,10 @@ RELEASED_VERSIONS.unsupported   @stackrox/collector-team
 # The RHTAP maintainers for ACS review all changes related to the Konflux pipelines, such as new
 # pipelines, parameter changes or automated task updates as well as Dockerfile updates.
 # rhacs-bot auto-approves MintMaker PRs for automated task and security updates.
-**/konflux.*Dockerfile  @stackrox/rhtap-maintainers @rhacs-bot
-/.tekton/               @stackrox/rhtap-maintainers @rhacs-bot
-rpms.*                  @stackrox/rhtap-maintainers @rhacs-bot
+# Unsuccessful auto-merges need to be fixed and approved by release managers.
+**/konflux.*Dockerfile  @stackrox/rhtap-maintainers @stackrox/release-mgmt @rhacs-bot
+/.tekton/               @stackrox/rhtap-maintainers @stackrox/release-mgmt @rhacs-bot
+rpms.*                  @stackrox/rhtap-maintainers @stackrox/release-mgmt @rhacs-bot
+
+# RHTAP maintainers review Renovate configuration.
 .github/renovate.json5  @stackrox/rhtap-maintainers


### PR DESCRIPTION
## Description

From this discussion: https://spaces.redhat.com/spaces/StackRox/pages/661160921/How+to+handle+MintMaker+updates+during+the+release+process?focusedCommentId=664404840#comment-664404840

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

None, but I got "This CODEOWNERS file is valid." message (see `Files changed` tab)