### PR TITLE
ROX-30898, ROX-30899: Konflux backports / 4.8

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,9 @@
 {
-  // This configures Konflux Renovate bot, the thing that keeps our pipelines use up-to-date tasks.
+  // This configures Konflux Renovate bot a.k.a. MintMaker, the thing that keeps our pipelines use up-to-date tasks.
 
   // After making changes to this file, you can validate it by running something like this in the root of the repo:
   // $ docker run --rm -it --entrypoint=renovate-config-validator -v "$(pwd)":/mnt -w /mnt renovate/renovate --strict
-  // Note: ignore errors about the config for `rpm`. This is to be addressed with https://issues.redhat.com/browse/CWFHEALTH-4117
+  // Note: ignore errors about the config for `rpm-lockfile`. This is to be addressed with https://issues.redhat.com/browse/CWFHEALTH-4117
   // There are more validation options, see https://docs.renovatebot.com/config-validation/
 
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -59,9 +59,10 @@
       ],
     },
   },
-  "rpm": {
+  "rpm-lockfile": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
+      // Note that MintMaker will create security updates outside of schedule.
       "after 3am and before 7am",
     ],
   },
@@ -69,7 +70,7 @@
     // Restrict Renovate focus on Konflux things since we rely on GitHub's dependabot for everything else.
     "tekton",
     "dockerfile",
-    "rpm",
+    "rpm-lockfile",
   ],
   "packageRules": [{
     "matchPackageNames": ["/.*/"],

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -138,9 +138,9 @@ spec:
   - name: init
     params:
     - name: image-url
-        # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
-        # As a workaround, we still provide a unique tag that's based on a revision to this task to comply with its
-      # expected input. We later actually add this tag on a built image with build-image-index-extra task.
+      # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
+      # As a workaround, we still provide a unique tag that's based on a revision in order for this task to comply with
+      # its expected input. We later actually add this tag on a built image with the apply-index-image-tag task.
       value: $(params.output-image-repo):konflux-$(params.revision)
     - name: rebuild
       value: $(params.rebuild)
@@ -440,31 +440,23 @@ spec:
       operator: in
       values: [ "true" ]
 
-  - name: build-image-index-extra
-    matrix:
-      params:
-      - name: IMAGE
-        value:
-        - $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-latest
-        - $(params.output-image-repo):$(tasks.determine-image-tag.results.IMAGE_TAG)-slim
-        - $(params.output-image-repo):konflux-$(params.revision)
+  - name: apply-index-image-tag
     params:
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: IMAGES
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
       value:
-      - $(tasks.build-container-amd64.results.IMAGE_REF)
-      - $(tasks.build-container-s390x.results.IMAGE_REF)
-      - $(tasks.build-container-ppc64le.results.IMAGE_REF)
-      - $(tasks.build-container-arm64.results.IMAGE_REF)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(tasks.determine-image-expiration.results.IMAGE_EXPIRES_AFTER)
+      - $(tasks.determine-image-tag.results.IMAGE_TAG)-latest
+      - $(tasks.determine-image-tag.results.IMAGE_TAG)-slim
+      - konflux-$(params.revision)
     taskRef:
       params:
       - name: name
-        value: build-image-index
+        value: apply-tags
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:ba7fbed5c4862968c1a77d6b90d5bdd497925ab1de41b859c027dd5c3069cd3e
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:f44be1bf0262471f2f503f5e19da5f0628dcaf968c86272a2ad6b4871e708448
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -2,7 +2,9 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: collector-component-pipeline
+
 spec:
+
   finally:
   - name: slack-notification
     params:
@@ -24,6 +26,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: show-sbom
     params:
     - name: IMAGE_URL
@@ -37,6 +40,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: post-metric-end
     params:
     - name: AGGREGATE_TASKS_STATUS
@@ -50,6 +54,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   params:
   - description: Source Repository URL
     name: git-url
@@ -107,6 +112,7 @@ spec:
     description: This sets the expiration time for intermediate OCI artifacts produced and used during builds after which they can be garbage collected.
     name: oci-artifact-expires-after
     type: string
+
   results:
   - description: ""
     name: IMAGE_URL
@@ -120,11 +126,15 @@ spec:
   - description: ""
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
+
   workspaces:
   - name: git-auth
+
   tasks:
+
   - name: post-metric-start
     taskRef: *post-bigquery-metrics-ref
+
   - name: init
     params:
     - name: image-url
@@ -143,6 +153,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: clone-repository
     params:
     - name: url
@@ -175,6 +186,7 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+
   - name: determine-image-expiration
     params:
     - name: DEFAULT_IMAGE_EXPIRES_AFTER
@@ -190,6 +202,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: determine-image-tag
     params:
     - name: TAG_SUFFIX
@@ -205,6 +218,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+
   - name: prefetch-dependencies
     params:
     - name: input
@@ -232,6 +246,7 @@ spec:
     workspaces:
     - name: git-basic-auth
       workspace: git-auth
+
   - name: build-container-amd64
     params:
     - name: IMAGE
@@ -270,6 +285,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+
   - name: build-container-s390x
     params:
     - name: IMAGE
@@ -311,6 +327,7 @@ spec:
       operator: in
       values: [ "true" ]
     timeout: 1h30m0s
+
   - name: build-container-ppc64le
     params:
     - name: IMAGE
@@ -352,6 +369,7 @@ spec:
       operator: in
       values: [ "true" ]
     timeout: 1h30m0s
+
   - name: build-container-arm64
     params:
     - name: IMAGE
@@ -393,6 +411,7 @@ spec:
       operator: in
       values: [ "true" ]
     timeout: 1h30m0s
+
   - name: build-image-index
     params:
     - name: IMAGE
@@ -420,6 +439,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+
   - name: build-image-index-extra
     matrix:
       params:
@@ -452,6 +472,7 @@ spec:
     - input: $(tasks.init.results.build)
       operator: in
       values: [ "true" ]
+
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -478,6 +499,7 @@ spec:
     - input: $(params.build-source-image)
       operator: in
       values: [ "true" ]
+
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -497,6 +519,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: clair-scan
     params:
     - name: image-digest
@@ -516,6 +539,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
@@ -533,6 +557,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -556,6 +581,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -579,6 +605,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT
@@ -602,6 +629,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: clamav-scan
     params:
     - name: image-digest
@@ -621,6 +649,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: rpms-signature-scan
     params:
     - name: image-digest
@@ -640,6 +669,7 @@ spec:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
+
   - name: push-dockerfile
     params:
     - name: IMAGE

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -11,10 +11,10 @@ spec:
     - name: key-name
       value: 'acs-konflux-notifications'
     when:
-        # Run when any task has Failed
+    # Run when any task has Failed
     - input: $(tasks.status)
       operator: in
-      values: ["Failed"]
+      values: [ "Failed" ]
     taskRef:
       params:
       - name: name
@@ -128,9 +128,9 @@ spec:
   - name: init
     params:
     - name: image-url
-          # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
-          # As a workaround, we still provide a unique tag that's based on a revision to this task to comply with its
-          # expected input. We later actually add this tag on a built image with build-image-index-extra task.
+        # We can't provide a StackRox-style tag because it is not known at this time (requires cloning source, etc.)
+        # As a workaround, we still provide a unique tag that's based on a revision to this task to comply with its
+      # expected input. We later actually add this tag on a built image with build-image-index-extra task.
       value: $(params.output-image-repo):konflux-$(params.revision)
     - name: rebuild
       value: $(params.rebuild)
@@ -171,7 +171,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -217,7 +217,7 @@ spec:
       value: $(params.oci-artifact-expires-after)
     - name: ACTIVATION_KEY
       value: subscription-manager-activation-key-prod
-        # Required for the RPM prefetching support.
+      # Required for the RPM prefetching support.
     - name: dev-package-managers
       value: "true"
     taskRef:
@@ -269,7 +269,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
   - name: build-container-s390x
     params:
     - name: IMAGE
@@ -309,7 +309,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
     timeout: 1h30m0s
   - name: build-container-ppc64le
     params:
@@ -350,7 +350,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
     timeout: 1h30m0s
   - name: build-container-arm64
     params:
@@ -391,7 +391,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
     timeout: 1h30m0s
   - name: build-image-index
     params:
@@ -419,7 +419,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
   - name: build-image-index-extra
     matrix:
       params:
@@ -451,7 +451,7 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
@@ -474,10 +474,10 @@ spec:
     when:
     - input: $(tasks.init.results.build)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
     - input: $(params.build-source-image)
       operator: in
-      values: ["true"]
+      values: [ "true" ]
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
@@ -496,7 +496,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: clair-scan
     params:
     - name: image-digest
@@ -515,7 +515,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
@@ -532,7 +532,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: sast-shell-check
     params:
     - name: image-digest
@@ -555,7 +555,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: sast-unicode-check
     params:
     - name: image-digest
@@ -578,7 +578,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: sast-snyk-check
     params:
     - name: SOURCE_ARTIFACT
@@ -601,7 +601,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: clamav-scan
     params:
     - name: image-digest
@@ -620,7 +620,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: rpms-signature-scan
     params:
     - name: image-digest
@@ -639,7 +639,7 @@ spec:
     when:
     - input: $(params.skip-checks)
       operator: in
-      values: ["false"]
+      values: [ "false" ]
   - name: push-dockerfile
     params:
     - name: IMAGE


### PR DESCRIPTION
## Description

Note: unlike https://github.com/stackrox/collector/pull/2489 and https://github.com/stackrox/collector/pull/2490, this change is more manual:
- `collector-component-pipeline.yaml` was badly formatted after migration tool.
- Its original `build-image-index-extra` assigned `-latest` and `-slim` tags besides the "Konflux-style" tag. Therefore, a simple cherry-pick did not work, I applied the change manually while keeping those additional tags.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Only CI.