### PR TITLE
ROX-30928: Disable garden-linux integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
           - rhel-sap
           # TODO(ROX-30765): re-enable once provisioning is fixed
           # - sles
-          - garden-linux
+          # - garden-linux
     with:
       vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ inputs.collector-tag }}


### PR DESCRIPTION
## Description

Disable garden-linux:
- the kernel bumper is broken and difficult to fix (for more than a month)
- process-listening-on-ports tests are failing for a reason specific to garden-linux

Let's simply disable the tests.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly
