### PR TITLE
Always rebuild builder and test container on PRs to release branches

### DIFF
--- a/.github/workflows/collector-builder.yml
+++ b/.github/workflows/collector-builder.yml
@@ -51,7 +51,8 @@ jobs:
             github.ref_type == 'tag' || startsWith(github.ref_name, 'release-')
           )) ||
           contains(github.event.pull_request.labels.*.name, 'build-builder-image') ||
-          github.event_name == 'schedule'
+          github.event_name == 'schedule' ||
+          (github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-'))
         run: |
           COLLECTOR_BUILDER_TAG="${DEFAULT_BUILDER_TAG}"
           if [[ "${{ github.event_name }}" == 'pull_request' || \

--- a/.github/workflows/integration-test-containers.yml
+++ b/.github/workflows/integration-test-containers.yml
@@ -56,11 +56,13 @@ jobs:
     needs:
       - should-build-test-image
     if: |
-      (
+      ((
         github.event_name != 'pull_request' ||
         needs.should-build-test-image.outputs.build-image == 'true' ||
         contains(github.event.pull_request.labels.*.name, 'rebuild-test-container')
-      ) &&
+      ) || (
+        github.event_name == 'pull_request' && startsWith(github.base_ref, 'release-')
+      )) &&
       !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests')
 
     outputs:


### PR DESCRIPTION
## Description

By nature, the release branches can drift from the master branch, this includes differences to the dependencies installed to the builder image and the tests the collector binary is run against.

Because the builder and integration tests images both take a pretty long time to build, we originally settled on only rebuilding these when it was absolutely necessary and added a couple PR labels to have them rebuilt on demand. Since we now have Power and Z runners for faster builds and the integration tests are being built in a faster manner too, we should just rebuild these on PRs targeting the release branch to reduce any potential confusion on colleagues that may not be aware of this intricate configuration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
