### PR TITLE
Retry querying rhcos version

### DIFF
--- a/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
+++ b/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
@@ -12,7 +12,7 @@ JSONPATH=${2:-"x86_64.images.gcp.name"}
 
 URL="https://raw.githubusercontent.com/openshift/installer/release-${OCP_VERSION}/data/data/coreos/rhcos.json"
 
-json_data=$(curl -s "$URL")
+json_data=$(curl --retry 5 --retry-delay 2 -sS "$URL")
 if [ -z "$json_data" ]; then
     echo "Failed to fetch JSON data from URL: $URL"
     exit 1


### PR DESCRIPTION
## Description

Recently we have seen some errors in CI where retrieving the rhcos images fails. This patch makes it so `curl` retries 5 times to get the version before failing in an attempt to mitigate this sort of error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is enough.
