### PR TITLE
Remove SSH access to builder container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ cmake-build-*/
 # Vim swap files
 *.swp
 
-# Development SSH Server keys
-.collector_dev_ssh_host_ed25519_key*
-
 # vscode configuration files
 .vscode/
 .devcontainer/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ include Makefile-constants.mk
 
 NPROCS ?= $(shell nproc)
 
-DEV_SSH_SERVER_KEY ?= $(CURDIR)/.collector_dev_ssh_host_ed25519_key
 BUILD_BUILDER_IMAGE ?= false
 
 export COLLECTOR_VERSION := $(COLLECTOR_TAG)
@@ -77,19 +76,13 @@ ci-benchmarks:
 .PHONY: ci-all-tests
 ci-all-tests: ci-benchmarks ci-integration-tests
 
-$(DEV_SSH_SERVER_KEY):
-ifeq (,$(wildcard $(DEV_SSH_SERVER_KEY)))
-	ssh-keygen -t ed25519 -N '' -f $(DEV_SSH_SERVER_KEY) < /dev/null
-endif
-
 .PHONY: start-builder
 start-builder: builder teardown-builder
-	docker run -d \
+	docker run -id \
 		--name $(COLLECTOR_BUILDER_NAME) \
 		--pull never \
 		--platform ${PLATFORM} \
 		-v $(CURDIR):$(CURDIR):Z \
-		$(if $(LOCAL_SSH_PORT),-p $(LOCAL_SSH_PORT):22 )\
 		-w $(CURDIR) \
 		--cap-add sys_ptrace \
 		quay.io/stackrox-io/collector-builder:$(COLLECTOR_BUILDER_TAG)

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -33,7 +33,6 @@ RUN dnf -y update \
         libtool \
         libuuid-devel \
         make \
-        openssh-server \
         openssl-devel \
         patchutils \
         passwd \
@@ -57,22 +56,5 @@ COPY third_party third_party
 RUN "builder/install/install-dependencies.sh" && if [ -z "${COLLECTOR_BUILDER_DEBUG}" ]; then rm -rf ${BUILD_DIR}; fi
 RUN echo -e '/usr/local/lib\n/usr/local/lib64' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
 
-# Set up ssh for remote development with IDE
-RUN ssh-keygen -A \
-   && ( \
-    echo 'LogLevel DEBUG2'; \
-    echo 'PermitRootLogin yes'; \
-    echo 'PasswordAuthentication yes'; \
-    echo 'HostKeyAlgorithms ssh-ed25519'; \
-    echo 'Subsystem sftp /usr/libexec/openssh/sftp-server'; \
-  ) > /etc/ssh/sshd_config \
-  && mkdir /run/sshd
-
-# Add remote development user
-RUN useradd -m remoteuser \
-  && yes c0llectah | passwd remoteuser || if [[ $? -eq 141 ]]; then true; else exit $?; fi
-
 # Create directory to copy collector source into builder container
 RUN mkdir /src && chmod a+rwx /src
-
-CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/docs/how-to-start.md
+++ b/docs/how-to-start.md
@@ -182,40 +182,6 @@ cmake.
 This is also an easy way to run collector under thread or address sanitizer, but
 you will need to deploy an image built with the `image-dev` make target.
 
-### Development with an IDE (CLion)
-
-#### Setup
-These instructions are for using the *JetBrains* C/C++ IDE **CLion**, but should be adaptable to any IDE that supports development over ssh/sftp.
-- If running CLion IDE for the first time:
-  - Download and install CLion (https://www.jetbrains.com/clion/download/)
-  - Create a project from the `collector/collector` directory using an existing CMakeLists file (`collector/collector/CMakeLists.txt`).
-- Create the collector builder container if not already running, or if the builder image has changed.
-  - `make start-dev`
-    - (Optional) Local builder images can used by setting the environment variable before execution using `BUILD_BUILDER_IMAGE=true make start-dev`.
-Or, builder images from a PR by with `COLLECTOR_BUILDER_TAG=<circle-build-id> make start-dev`.
-
-Instructions for Mac OS
-- In the **CLion->Preferences** window, add a new **Toolchain** entry in settings under **Build, Execution, Deployment** as a **Remote Host** type.
-- Then, click in the **Credentials** section and fill out the SSH credentials used in the builder Dockerfile.
-  - Host: `localhost`, Port: `2222`, User name: `remoteuser`, Password: `c0llectah`
-- Next, select **Deployment** under **Build, Execution, Deployment**, and then **Mappings**. Set **Deployment path** to `/tmp`.
-- Finally, add a CMake profile that uses the **Remote Host** toolchain and change **Build directory**/**Generation Path** to `cmake-build`.
-
-Instructions for Linux
-- In the **File->Settings->Build, Execution, Deployment->Toolchains** window, add a new **Toolchain** entry as a **Remote Host** type.
-- Then, click in the **Credentials** section and fill out the SSH credentials used in the builder Dockerfile.
-  - Host: `localhost`, Port: `2222`, User name: `remoteuser`, Password: `c0llectah`
-- In the **File->Setting->Build, Execution, Deployment->Deployment** window click on the **Mappings** tab. Set **Deployment path** to /tmp.
-- In the **File->Settings->Build, Execution, Deployment->CMake** window add a CMake profile that uses the **Remote Host** toolchain and change **Build directory**/**Generation Path** to `cmake-build`.
-
-#### Teardown
-- Run `make teardown-dev` to remove the builder container and associated ephemeral ssh keys from `$HOME/.ssh/known_hosts`
-- After restarting, you may need click **Resync with Remote Hosts** under the **Tools** menu in **CLion**.
-
-#### Compilation and Testing
-- To build the Falco wrapper libary and collector binary: select the *collector* configuration from the **Run...** menu and then **Build**.
-- To run unit tests, select the *runUnitTests* configuration and then select **Run**.
-
 ### Development with Visual Studio Code
 #### Setup for C++ using devcontainers
 Visual Studio Code can be used as a development environment by leveraging its devcontainers feature.


### PR DESCRIPTION
## Description

Z builds are currently failing when building the builder image with the following error:

```
Dockerfile:72
--------------------
  71 |     # Add remote development user
  72 | >>> RUN useradd -m remoteuser \
  73 | >>>   && yes c0llectah | passwd remoteuser || if [[ $? -eq 141 ]]; then true; else exit $?; fi
  74 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c useradd -m remoteuser   && yes c0llectah | passwd remoteuser || if [[ $? -eq 141 ]]; then true; else exit $?; fi" did not complete successfully: exit code: 1
gmake: *** [Makefile:27: builder] Error 1
```

In the past, SSH was used with CLion for development, but devcontainers are now properly supported by that IDE, so there is no point in keeping the SSH access method in the builder container.

The documentation section on developing with CLion has been removed since it is no longer supported. I have not documented how to use a devcontainer with that environment because I have no idea how that works and don't have access to CLion for testing either, contributions to add the section back in are welcomed.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

- [x] Z builder build succeeds in CI.
