### PR TITLE
Use docker cache mount on builder image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -5,6 +5,8 @@ ARG COLLECTOR_BUILDER_DEBUG
 
 USER root
 
+ENV OUTPUT_DIR=/tmp/output
+
 RUN dnf -y update \
     && dnf -y install --nobest \
         autoconf \
@@ -53,8 +55,9 @@ WORKDIR ${BUILD_DIR}
 COPY install builder/install
 COPY third_party third_party
 
-RUN "builder/install/install-dependencies.sh" && if [ -z "${COLLECTOR_BUILDER_DEBUG}" ]; then rm -rf ${BUILD_DIR}; fi
-RUN echo -e '/usr/local/lib\n/usr/local/lib64' > /etc/ld.so.conf.d/usrlocallib.conf && ldconfig
+RUN --mount=type=cache,target=${OUTPUT_DIR} \
+    "builder/install/install-dependencies.sh" \
+    && if [ -z "${COLLECTOR_BUILDER_DEBUG}" ]; then rm -rf ${BUILD_DIR}; fi
 
 # Create directory to copy collector source into builder container
 RUN mkdir /src && chmod a+rwx /src

--- a/builder/install/05-abseil.sh
+++ b/builder/install/05-abseil.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/abseil-cpp
 
 cp LICENSE "${LICENSE_DIR}/Abseil-${ABSEIL_VERSION}"
 
-mkdir cmake-build
-cd cmake-build
-cmake .. \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
+cmake_wrap "abseil-cpp" "${OUTPUT_DIR}" \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=17 \
     -DABSL_PROPAGATE_CXX_STD=ON
-
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/10-protobuf.sh
+++ b/builder/install/10-protobuf.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/protobuf
 cp LICENSE "${LICENSE_DIR}/protobuf-${PROTOBUF_VERSION}"
 
-mkdir -p cmake-build && cd cmake-build
-cmake -S ../ \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
+cmake_wrap "protobuf" "${OUTPUT_DIR}" \
     -DBUILD_SHARED_LIBS=OFF \
     -Dprotobuf_BUILD_TESTS=OFF \
     -Dprotobuf_ABSL_PROVIDER=package
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/10-yaml-cpp.sh
+++ b/builder/install/10-yaml-cpp.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/yaml-cpp
 cp LICENSE "${LICENSE_DIR}/yaml-cpp-${YAMLCPP_VERSION}"
 
-cmake -B build/ \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+cmake_wrap "yaml-cpp" "${OUTPUT_DIR}" \
     -DYAML_CPP_BUILD_CONTRIB=OFF \
     -DYAML_CPP_BUILD_TOOLS=OFF \
     -DYAML_BUILD_SHARED_LIBS=OFF \
     -DYAML_CPP_INSTALL=ON
-cmake --build build --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/20-googletest.sh
+++ b/builder/install/20-googletest.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/googletest
 cp LICENSE "${LICENSE_DIR}/googletest-${GOOGLETEST_REVISION}"
-mkdir cmake-build
-cd cmake-build
-cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DCMAKE_INSTALL_PREFIX=/usr/local ..
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+
+cmake_wrap "googletest" "${OUTPUT_DIR}"

--- a/builder/install/30-cares.sh
+++ b/builder/install/30-cares.sh
@@ -1,23 +1,20 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
-if [ -n "${WITH_RHEL_RPMS}" ]; then
+if [ -n "${WITH_RHEL_RPMS:-}" ]; then
     # Already installed as an RPM, nothing more to do.
     exit 0
 fi
 
+source builder/install/cmake.sh
+
 cd third_party/c-ares
 cp LICENSE.md "${LICENSE_DIR}/c-ares-${CARES_VERSION}"
 
-mkdir cmake-build
-cd cmake-build
-cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+cmake_wrap "c-ares" "${OUTPUT_DIR}" \
     -DCARES_INSTALL=ON \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
     -DCARES_SHARED=OFF \
     -DCARES_STATIC=ON \
     -DCARES_STATIC_PIC=ON \
-    -DCARES_BUILD_TOOLS=OFF \
-    ..
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+    -DCARES_BUILD_TOOLS=OFF

--- a/builder/install/35-re2.sh
+++ b/builder/install/35-re2.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/re2
 
 cp LICENSE "${LICENSE_DIR}/re2-${RE2_VERSION}"
 
-mkdir cmake-build && cd cmake-build
-cmake .. \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
+cmake_wrap "re2" "${OUTPUT_DIR}" \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DBUILD_SHARED_LIBS=OFF
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/40-civetweb.sh
+++ b/builder/install/40-civetweb.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/civetweb
 
 cp LICENSE.md "${LICENSE_DIR}/CivetWeb-${CIVETWEB_VERSION}"
 
-mkdir cmake-build
-cd cmake-build
-cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
+cmake_wrap "civetweb" "${OUTPUT_DIR}" \
     -DCIVETWEB_ENABLE_CXX=ON \
     -DBUILD_SHARED_LIBS:BOOL=NO \
     -DCIVETWEB_BUILD_TESTING=NO \
     -DCIVETWEB_ENABLE_IPV6=NO \
-    -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=NO \
-    ..
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+    -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=NO

--- a/builder/install/40-grpc.sh
+++ b/builder/install/40-grpc.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 export CXXFLAGS="-Wno-error=class-memaccess -Wno-ignored-qualifiers -Wno-stringop-truncation -Wno-cast-function-type -Wno-attributes"
 
 cd third_party/grpc
 
 cp NOTICE.txt "${LICENSE_DIR}/grpc-${GRPC_REVISION}"
-mkdir -p cmake/build
-cd cmake/build
-cmake \
+
+cmake_wrap "grpc" "${OUTPUT_DIR}" \
     -DgRPC_PROTOBUF_PROVIDER=package \
     -DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG \
     -DgRPC_ZLIB_PROVIDER=package \
@@ -23,12 +24,6 @@ cmake \
     -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
     -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
     -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DgRPC_DOWNLOAD_ARCHIVES=OFF \
     -DgRPC_INSTALL=ON \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DCMAKE_CXX_STANDARD=17 \
-    ../..
-
-make ${NPROCS:+-j ${NPROCS}}
-make install
+    -DCMAKE_CXX_STANDARD=17

--- a/builder/install/50-prometheus.sh
+++ b/builder/install/50-prometheus.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/prometheus-cpp
 
 cat LICENSE > "${LICENSE_DIR}/prometheus-${PROMETHEUS_CPP_REVISION}"
 
-mkdir cmake-build
-cd cmake-build
-cmake -DENABLE_TESTING=OFF -DUSE_THIRDPARTY_LIBRARIES=NO -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" ../
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+cmake_wrap "prometheus" "${OUTPUT_DIR}" \
+    -DENABLE_TESTING=OFF \
+    -DUSE_THIRDPARTY_LIBRARIES=NO

--- a/builder/install/60-jsoncpp.sh
+++ b/builder/install/60-jsoncpp.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
+
+source builder/install/cmake.sh
 
 cd third_party/jsoncpp
 
 cp LICENSE "${LICENSE_DIR}/jsoncpp-${JSONCPP_REVISION}"
 
-mkdir cmake-build
-cd cmake-build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+cmake_wrap "jsoncpp" "${OUTPUT_DIR}" \
     -DCMAKE_CXX_FLAGS=-fPIC \
     -DJSONCPP_WITH_TESTS=OFF \
     -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF \
     -DBUILD_SHARED_LIBS=OFF \
-    -DBUILD_OBJECT_LIBS=OFF \
-    ..
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+    -DBUILD_OBJECT_LIBS=OFF

--- a/builder/install/60-tbb.sh
+++ b/builder/install/60-tbb.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
-if [ -n "${WITH_RHEL_RPMS}" ]; then
+if [ -n "${WITH_RHEL_RPMS:-}" ]; then
     # Already installed as an RPM, nothing more to do.
     exit 0
 fi
 
+source builder/install/cmake.sh
+
 cd third_party/tbb
 cp LICENSE.txt "${LICENSE_DIR}/tbb-${TBB_VERSION}"
-cmake -B cmake-build -S . \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_INSTALL_PREFIX=/usr/local \
+
+cmake_wrap "tbb" "${OUTPUT_DIR}" \
     -DBUILD_SHARED_LIBS=OFF \
     -DTBB_TEST=OFF \
     -DTBBMALLOC_BUILD=OFF
-cmake --build cmake-build --target install ${NPROCS:+-j ${NPROCS}}

--- a/builder/install/70-valijson.sh
+++ b/builder/install/70-valijson.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
+source builder/install/cmake.sh
 cd third_party/valijson
 cp LICENSE "${LICENSE_DIR}/valijson-${VALIJSON_VERSION}"
 
-mkdir cmake-build && cd cmake-build
-cmake \
+cmake_wrap "valijson" "${OUTPUT_DIR}" \
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
-    -Dvalijson_BUILD_TESTS=OFF \
-    ..
-cmake --build . --target install ${NPROCS:+-j ${NPROCS}}
+    -Dvalijson_BUILD_TESTS=OFF

--- a/builder/install/80-libbpf.sh
+++ b/builder/install/80-libbpf.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 cd third_party/libbpf
 
 cp LICENSE "${LICENSE_DIR}/libbpf-${LIBBPF_VERSION}"
 
-mkdir src/build
-make BUILD_STATIC_ONLY=y OBJDIR=build "LDFLAGS=-Wl,-Bstatic" "CFLAGS=-fPIC ${EXTRA_CFLAGS_DEBUG}" \
+LIBBPF_OUTPUT="${OUTPUT_DIR}/libbpf"
+mkdir -p "${LIBBPF_OUTPUT}"
+
+make BUILD_STATIC_ONLY=y OBJDIR="${LIBBPF_OUTPUT}" "LDFLAGS=-Wl,-Bstatic" "CFLAGS=-fPIC ${EXTRA_CFLAGS_DEBUG:-}" \
      ${NPROCS:+-j ${NPROCS}} -C src install install_uapi_headers

--- a/builder/install/cmake.sh
+++ b/builder/install/cmake.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+function cmake_wrap() {
+    set -x
+    PKG_NAME="$1"
+    shift
+    OUTPUT_DIR="$1/${PKG_NAME}"
+    shift
+
+    mkdir -p "${OUTPUT_DIR}"
+    cmake -S . -B "${OUTPUT_DIR}" \
+        -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        "$@"
+    cmake --build "${OUTPUT_DIR}" --target install ${NPROCS:+-j ${NPROCS}}
+}

--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -45,6 +45,8 @@ ARG USE_VALGRIND=false
 ARG ADDRESS_SANITIZER=false
 ARG TRACE_SINSP_EVENTS=false
 
+ENV OUTPUT_DIR=/tmp/output
+
 WORKDIR ${BUILD_DIR}
 
 RUN mkdir kernel-modules \


### PR DESCRIPTION
## Description

This should only have an effect on development, on CI the cache will not exist and the builds will always happen from scratch.

A small cmake wrapper function has been created to abstract the common logic of configuring, compiling and installing on all modules.

In the past we have tried to use `ccache` in a similar way, but that ended up being quite convoluted, this approach is a lot more straightforward IMO.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Output of `time make builder` from scratch and after making a change to one of the install scripts:
```
BUILD_BUILDER_IMAGE=true make builder  5.82s user 1.23s system 0% cpu 17:28.09 total
BUILD_BUILDER_IMAGE=true make builder  5.35s user 0.91s system 4% cpu 2:06.03 total
```
