### PR TITLE
Set appropriate name and cpe labels for konflux image

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -127,4 +127,6 @@ ENTRYPOINT ["collector"]
 LABEL \
     com.redhat.component="rhacs-collector-container" \
     io.k8s.display-name="collector" \
-    name="rhacs-collector-rhel8"
+    name="advanced-cluster-security/rhacs-collector-rhel8" \
+    cpe="cpe:/a:redhat:advanced_cluster_security:4.9::el8"
+


### PR DESCRIPTION
## Description

We plan to automate this in https://issues.redhat.com/browse/ROX-31181

