### PR TITLE
ROX-33567: Use vpc_inventory to retrieve IBM VMs

### DIFF
--- a/ansible/ci/inventory_IBM-Z.vpc.yml
+++ b/ansible/ci/inventory_IBM-Z.vpc.yml
@@ -1,0 +1,17 @@
+---
+plugin: ibm.cloudcollection.vpc_inventory
+regions:
+  - us-east
+#ibmcloud_api_key: "{{ lookup('env', 'IBM_CLOUD_S390X_API_KEY') }}"
+ansible_host_type: name
+fail_on_duplicate: false
+compose:
+  ibm_cloud_vm: "true"
+  vm_arch: "tags | select('match', '^vm_arch:') | map('split', ':') | map('last') | first"
+  vm_config: "tags | select('match', '^vm_config:') | map('split', ':') | map('last') | first"
+  vm_image_family: "tags | select('match', '^vm_image_family:') | map('split', ':') | map('last') | first"
+filters:
+  resource_group: 1a33a6a9bd6e498f8115e9b1064bfa97
+keyed_groups:
+  - key: "tags | select('match', '^job_id:') | map('split', ':') | map('last') | first"
+    prefix: job_id

--- a/ansible/dev/inventory_IBM-Z.vpc.yml
+++ b/ansible/dev/inventory_IBM-Z.vpc.yml
@@ -1,0 +1,1 @@
+../ci/inventory_IBM-Z.vpc.yml

--- a/ansible/roles/create-vm/tasks/create-s390x-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-s390x-vm.yml
@@ -28,6 +28,11 @@
         zone: "{{ s390x.zone }}"
         boot_volume:
           - size: "{{ s390x.disk_size }}"
+        tags:
+          - "job_id:{{ job_id }}"
+          - "vm_config:{{ vm_config }}"
+          - "vm_image_family:{{ vm_family }}"
+          - "vm_arch:{{ vm_arch }}"
       register: vsi
 
     - name: Check for existing Floating IP
@@ -51,33 +56,3 @@
       debug:
         msg: "{{ vsi_name }} IP Address: {{ fip.resource.address }}"
 
-  always:
-    # regardless of success/failure of VM creation we want to add an entry
-    # to the inventory. VM creation can fail but a VM can be created (in a failed
-    # state) but without a record of it in the inventory we can leak VM instances
-    # in IBM cloud. Empty defaults in some variables here are to account for this.
-    - name: Add VSI to Ansible inventory
-      add_host:
-        name: "{{ vsi_name }}"
-        ansible_user: root
-        ansible_host: "{{ fip.resource.address | default('') }}"
-        groups:
-          - job_id_{{ job_id }}
-          - platform_{{ test_platform }}
-          - vm_arch_s390x
-        ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
-        ansible_ssh_private_key_file: "{{ vm_ssh_key_file }}"
-        vm_config: "{{ vm_config }}"
-        vm_image_family: "{{ vm_family }}"
-        vm_collection_method: "{{ vm_collection_method }}"
-        vm_arch: "{{ vm_arch }}"
-        ibm_cloud_vm: true
-
-    - name: generate provisioner inventory file
-      template:
-        src: 'ibm-cloud-inventory.j2'
-        dest: "{{ ibm_output_inventory_file }}"
-        mode: '0644'
-      when:
-        - ibm_output_inventory_file != ""
-      delegate_to: localhost


### PR DESCRIPTION
## Description

The IBM cloudcollection provides an [inventory plugin](https://galaxy.ansible.com/ui/repo/published/ibm/cloudcollection/content/inventory/vpc_inventory/). We used to create an inventory yaml file for the VMs we create in the IBM cloud, and this seems to have led to VM leaks. By using the inventory, we hope to address those leak issues (and also to simplify housekeeping).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why you did not do so. (Valid reasons include "CI is sufficient" or "No testable changes")
In addition to reviewing your code, reviewers **must** also review your testing instructions, and make sure they are sufficient.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
