### PR TITLE
ROX-32487 Add RHCOS 10 integration tests for OCP 4.22+

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -72,9 +72,9 @@ virtual_machines:
   rhcos:
     project: rhcos-cloud
     images:
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.19') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-10') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-9') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18') }}"
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.14') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12') }}"
     username: core
@@ -93,9 +93,9 @@ virtual_machines:
     arch: arm64
     machine_type: t2a-standard-2
     images:
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.19 aarch64.images.gcp.name') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-10') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-9') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
-      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16 aarch64.images.gcp.name') }}"
     username: core
     ignition:
       ignition:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -69,15 +69,22 @@ virtual_machines:
       - rhel-9-4-sap-ha
     container_engine: podman
 
+  # RHCOS lifecycle dates: https://access.redhat.com/support/policy/updates/openshift#dates
   rhcos:
     project: rhcos-cloud
     images:
+      # OCP 4.22 (RHEL 10.2 + 9.8), EUS until June 2029
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-10') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-9') }}"
+      # OCP 4.20 (RHEL 9.6), EUS until October 2028
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.20') }}"
+      # OCP 4.18 (RHEL 9.4), EUS until February 2028
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18') }}"
+      # OCP 4.16 (RHEL 9.4), EUS until June 2027
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16') }}"
+      # OCP 4.14 (RHEL 9.2), EUS until October 2026
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.14') }}"
+      # OCP 4.12 (RHEL 8.6), EUS until January 2027
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12') }}"
     username: core
     ignition:
@@ -95,10 +102,14 @@ virtual_machines:
     arch: arm64
     machine_type: t2a-standard-2
     images:
+      # OCP 4.22 (RHEL 10.2 + 9.8), EUS until June 2029
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-10') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-9') }}"
+      # OCP 4.20 (RHEL 9.6), EUS until October 2028
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.20 aarch64.images.gcp.name') }}"
+      # OCP 4.18 (RHEL 9.4), EUS until February 2028
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
+      # OCP 4.16 (RHEL 9.4), EUS until June 2027
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16 aarch64.images.gcp.name') }}"
     username: core
     ignition:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -74,7 +74,9 @@ virtual_machines:
     images:
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-10') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 x86_64.images.gcp.name rhel-9') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.20') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.14') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.12') }}"
     username: core
@@ -95,7 +97,9 @@ virtual_machines:
     images:
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-10') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.22 aarch64.images.gcp.name rhel-9') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.20 aarch64.images.gcp.name') }}"
       - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.18 aarch64.images.gcp.name') }}"
+      - "{{ lookup('ansible.builtin.pipe', 'scripts/fetch_ocp_rhcos_bootimage.sh 4.16 aarch64.images.gcp.name') }}"
     username: core
     ignition:
       ignition:

--- a/ansible/roles/create-all-vms/tasks/by-image.yml
+++ b/ansible/roles/create-all-vms/tasks/by-image.yml
@@ -3,9 +3,13 @@
 - include_vars: s390x.yml
 
 - set_fact:
-    vm_hashable_name: "{{ item.1 }}-{{ job_id }}"
-    vm_image_short: "{{ item.1 | truncate(16, True, '') }}"
+    vm_display_name: "{{ item.1.split('|')[0] }}"
+    vm_gcp_image: "{{ item.1.split('|')[-1] }}"
     arch: "{{ item.0.value.arch | default('amd64') }}"
+
+- set_fact:
+    vm_hashable_name: "{{ vm_display_name }}-{{ job_id }}"
+    vm_image_short: "{{ vm_display_name | truncate(16, True, '') }}"
 
 - set_fact:
     vm_hashed_name: "{{ vm_hashable_name | hash('md5') | truncate(8, True, '') }}"
@@ -37,9 +41,9 @@
     # still populate the family, since it is used as a label to differentiate
     # VMs
     vm_family: "{{ item.0.key }}"
-    vm_image: "{{ item.1 | truncate(63, True, '') }}"
+    vm_image: "{{ vm_gcp_image | truncate(63, True, '') }}"
     vm_platform: "{{ item.0.key }}"
-    vm_config: "{{ item.1 }}"
+    vm_config: "{{ vm_display_name }}"
     vm_collection_method: "{{ collection_method | default('any') | replace('-', '_') }}"
     vm_available_zones: "{{ gcp_available_zones }}"
     vm_ignition: "{{ item.0.value.ignition | default({}) }}"

--- a/ansible/roles/create-all-vms/tasks/by-image.yml
+++ b/ansible/roles/create-all-vms/tasks/by-image.yml
@@ -3,13 +3,9 @@
 - include_vars: s390x.yml
 
 - set_fact:
-    vm_display_name: "{{ item.1.split('|')[0] }}"
-    vm_gcp_image: "{{ item.1.split('|')[-1] }}"
+    vm_hashable_name: "{{ item.1 }}-{{ job_id }}"
+    vm_image_short: "{{ item.1 | truncate(16, True, '') }}"
     arch: "{{ item.0.value.arch | default('amd64') }}"
-
-- set_fact:
-    vm_hashable_name: "{{ vm_display_name }}-{{ job_id }}"
-    vm_image_short: "{{ vm_display_name | truncate(16, True, '') }}"
 
 - set_fact:
     vm_hashed_name: "{{ vm_hashable_name | hash('md5') | truncate(8, True, '') }}"
@@ -41,9 +37,9 @@
     # still populate the family, since it is used as a label to differentiate
     # VMs
     vm_family: "{{ item.0.key }}"
-    vm_image: "{{ vm_gcp_image | truncate(63, True, '') }}"
+    vm_image: "{{ item.1 | truncate(63, True, '') }}"
     vm_platform: "{{ item.0.key }}"
-    vm_config: "{{ vm_display_name }}"
+    vm_config: "{{ item.1 }}"
     vm_collection_method: "{{ collection_method | default('any') | replace('-', '_') }}"
     vm_available_zones: "{{ gcp_available_zones }}"
     vm_ignition: "{{ item.0.value.ignition | default({}) }}"

--- a/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
+++ b/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
@@ -31,4 +31,15 @@ if [ "$image_name" == "null" ]; then
     echo "Failed to parse JSON data or path does not exist"
     exit 1
 fi
-echo "$image_name"
+
+# When using the split format (rhel-variant specified), output both a display
+# name (with OCP version embedded) and the actual GCP image name, separated
+# by '|'. This allows VMs to be easily distinguishable by OCP version.
+# e.g., rhcos-422-10-2-20260217-0-gcp-x86-64|rhcos-10-2-20260217-0-gcp-x86-64
+if [ -n "$RHEL_VARIANT" ]; then
+    ocp_short="${OCP_VERSION//./}"
+    display_name="${image_name/rhcos-/rhcos-${ocp_short}-}"
+    echo "${display_name}|${image_name}"
+else
+    echo "$image_name"
+fi

--- a/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
+++ b/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
@@ -31,15 +31,4 @@ if [ "$image_name" == "null" ]; then
     echo "Failed to parse JSON data or path does not exist"
     exit 1
 fi
-
-# When using the split format (rhel-variant specified), output both a display
-# name (with OCP version embedded) and the actual GCP image name, separated
-# by '|'. This allows VMs to be easily distinguishable by OCP version.
-# e.g., rhcos-422-10-2-20260217-0-gcp-x86-64|rhcos-10-2-20260217-0-gcp-x86-64
-if [ -n "$RHEL_VARIANT" ]; then
-    ocp_short="${OCP_VERSION//./}"
-    display_name="${image_name/rhcos-/rhcos-${ocp_short}-}"
-    echo "${display_name}|${image_name}"
-else
-    echo "$image_name"
-fi
+echo "$image_name"

--- a/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
+++ b/ansible/scripts/fetch_ocp_rhcos_bootimage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-    echo "Usage: $0 <ocp-version> [<architectures.path>]"
+    echo "Usage: $0 <ocp-version> [<architectures.path>] [<rhel-variant>]"
     exit 1
 fi
 
@@ -10,7 +10,15 @@ OCP_VERSION=$1
 # Json path with architecture and image name, e.g., x86_64.images.gcp.name or s390x.artifacts.ibmcloud.release
 JSONPATH=${2:-"x86_64.images.gcp.name"}
 
-URL="https://raw.githubusercontent.com/openshift/installer/release-${OCP_VERSION}/data/data/coreos/rhcos.json"
+# Optional RHEL variant (e.g., rhel-9, rhel-10) for OCP 4.22+ which splits
+# RHCOS images into separate coreos-rhel-9.json and coreos-rhel-10.json files.
+RHEL_VARIANT=${3:-""}
+
+if [ -n "$RHEL_VARIANT" ]; then
+    URL="https://raw.githubusercontent.com/openshift/installer/release-${OCP_VERSION}/data/data/coreos/coreos-${RHEL_VARIANT}.json"
+else
+    URL="https://raw.githubusercontent.com/openshift/installer/release-${OCP_VERSION}/data/data/coreos/rhcos.json"
+fi
 
 json_data=$(curl --retry 5 --retry-delay 2 -sS "$URL")
 if [ -z "$json_data" ]; then


### PR DESCRIPTION
## Summary

- **Updated `fetch_ocp_rhcos_bootimage.sh`** to support an optional `rhel-variant` argument (e.g., `rhel-9`, `rhel-10`). OCP 4.22+ splits RHCOS boot images into `coreos-rhel-9.json` and `coreos-rhel-10.json` instead of the single `rhcos.json` used by earlier releases. The script remains backward compatible for older OCP versions.
- **Added RHCOS 10 and OCP 4.20 images** to the integration test matrix, covering all OCP releases with extended support:

### rhcos (x86_64)

| RHEL | OCP |
|------|-----|
| 10.2 | 4.22 |
| 9.6 | 4.22 |
| 9.6 | 4.20 |
| 9.4 | 4.18 |
| 9.4 | 4.16 |
| 9.2 | 4.14 |
| 8.6 | 4.12 |

### rhcos-arm64

| RHEL | OCP |
|------|-----|
| 10.2 | 4.22 |
| 9.6 | 4.22 |
| 9.6 | 4.20 |
| 9.4 | 4.18 |
| 9.4 | 4.16 |

## Test plan

- [x] Verified `fetch_ocp_rhcos_bootimage.sh` resolves all images correctly with both old and new URL formats
- [x] CI integration tests pass on RHCOS VMs (including new RHEL 10 images)
All rhcos jobs on CI pass for x86
All rhcos jobs on CI pass for fcarm64