### PR TITLE
chore: Exclude `konflux.Dockerfile` from Dependabot's updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,7 @@ updates:
       interval: "weekly"
   - package-ecosystem: 'docker'
     directory: collector/container/
+    exclude-paths: [ '**/konflux*.Dockerfile' ]
     schedule:
       interval: "weekly"
   - package-ecosystem: 'docker'


### PR DESCRIPTION
## Description

The same change as in https://github.com/stackrox/stackrox/pull/19802 with the only difference that I've not seen Dependabot's PRs in this repo yet.

## Checklist
- ~~[ ] Investigated and inspected CI test results~~
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

None. GitHub will validate `dependabot.yaml`. Whether the change works is yet to be seen.