### PR TITLE
Add ibmcloud SecurityGroup dynamically for s390x CI vms

### DIFF
--- a/ansible/roles/create-vm/tasks/create-s390x-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-s390x-vm.yml
@@ -2,6 +2,16 @@
   include_vars:
     file: s390x.yml
 
+- name: Get Ansible public IP
+  uri:
+    url: https://api.ipify.org?format=json
+    return_content: yes
+  register: ipify_response
+
+- name: Set Ansible host IP fact
+  set_fact:
+    ansible_host_ip: "{{ (ipify_response.content | from_json).ip }}"
+
 - name: Create s390x VM
   block:
     - name: Check for existing VSI
@@ -11,6 +21,28 @@
         - vsi.rc != 0
         - '"No Instance found" not in vsi.stderr'
       register: vsi
+
+    - name: Create Security Group for VSI
+      ibm.cloudcollection.ibm_is_security_group:
+        name: "{{ vsi_name }}-sg"
+        vpc: "{{ s390x.vpc_id }}"
+        resource_group: "{{ s390x.vsi_resource_group_id }}"
+      register: vsi_sg
+
+    - name: Add Inbound SSH Rule for Ansible Host
+      ibm.cloudcollection.ibm_is_security_group_rule:
+        group: "{{ vsi_sg.resource.id }}"
+        direction: inbound
+        remote: "{{ ansible_host_ip }}/32"
+        tcp:
+          port_min: 22
+          port_max: 22
+
+    - name: Add Outbound Rule (Allow All)
+      ibm.cloudcollection.ibm_is_security_group_rule:
+        group: "{{ vsi_sg.resource.id }}"
+        direction: outbound
+        remote: "0.0.0.0/0"
 
     - name: Configure VSI
       ibm.cloudcollection.ibm_is_instance:
@@ -25,6 +57,8 @@
           - "{{ s390x.ssh_key_id }}"
         primary_network_interface:
           - subnet: "{{ s390x.subnet_id }}"
+            security_groups:
+              - "{{ vsi_sg.resource.id }}"
         zone: "{{ s390x.zone }}"
         boot_volume:
           - size: "{{ s390x.disk_size }}"

--- a/ansible/roles/create-vm/tasks/create-s390x-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-s390x-vm.yml
@@ -35,8 +35,8 @@
         direction: inbound
         remote: "{{ ansible_host_ip }}/32"
         tcp:
-          port_min: 22
-          port_max: 22
+          - port_min: 22
+            port_max: 22
 
     - name: Add Outbound Rule (Allow All)
       ibm.cloudcollection.ibm_is_security_group_rule:

--- a/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
+++ b/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
@@ -38,6 +38,15 @@
     zone: "{{ fip.resource.zone }}"
   when: fip.resource.id is defined
 
+- name: Check for existing Security Group
+  delegate_to: localhost
+  ibm.cloudcollection.ibm_is_security_group_info:
+    name: "{{ inventory_hostname }}-sg"
+  failed_when:
+    - sg.rc != 0
+    - '"No Security Group found" not in sg.stderr'
+  register: sg
+
 - name: Delete Security Group
   delegate_to: localhost
   ibm.cloudcollection.ibm_is_security_group:

--- a/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
+++ b/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
@@ -38,6 +38,13 @@
     zone: "{{ fip.resource.zone }}"
   when: fip.resource.id is defined
 
+- name: Delete Security Group
+  delegate_to: localhost
+  ibm.cloudcollection.ibm_is_security_group:
+    state: absent
+    id: "{{ sg.resource.id }}"
+  when: sg.resource.id is defined
+
 - name: Remove IBM inventory file (delete file)
   delegate_to: localhost
   file:


### PR DESCRIPTION
## Description
Current IBMcloud for s390x VM's security group was removed by IBMcloud security for allowing ssh access from anywhere. This change creates a security group for the Ansible host IP dynamically 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.
Update to CI 
## Testing Performed
CI is able to create and SSH into s390x VMs

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
