### PR TITLE
ROX-29508: Hot reload TLS certificates

### DIFF
--- a/collector/lib/GRPC.cpp
+++ b/collector/lib/GRPC.cpp
@@ -18,9 +18,8 @@ std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromConfig(const TlsConf
       60);
 
   grpc::experimental::TlsChannelCredentialsOptions options;
-  options.set_certificate_provider(provider);
-  options.watch_root_certs();
-  options.watch_identity_key_cert_pairs();
+  options.set_root_certificate_provider(provider);
+  options.set_identity_certificate_provider(provider);
 
   return grpc::experimental::TlsCredentials(options);
 }

--- a/collector/lib/GRPC.cpp
+++ b/collector/lib/GRPC.cpp
@@ -1,34 +1,28 @@
 #include "GRPC.h"
 
-#include <fstream>
-#include <sstream>
 #include <string>
 
 #include <grpcpp/create_channel.h>
+#include <grpcpp/security/tls_certificate_provider.h>
+#include <grpcpp/security/tls_credentials_options.h>
 
 #include "optionparser.h"
 
 namespace collector {
 
-namespace {
-
-std::string ReadFileContents(const std::string& filename) {
-  std::stringstream buffer;
-  std::ifstream ifs(filename);
-  buffer << ifs.rdbuf();
-  return buffer.str();
-}
-
-}  // namespace
-
 std::shared_ptr<grpc::ChannelCredentials> TLSCredentialsFromConfig(const TlsConfig& config) {
-  grpc::SslCredentialsOptions sslOptions;
+  auto provider = std::make_shared<grpc::experimental::FileWatcherCertificateProvider>(
+      config.GetClientKey(),
+      config.GetClientCert(),
+      config.GetCa(),
+      60);
 
-  sslOptions.pem_root_certs = ReadFileContents(config.GetCa());
-  sslOptions.pem_private_key = ReadFileContents(config.GetClientKey());
-  sslOptions.pem_cert_chain = ReadFileContents(config.GetClientCert());
+  grpc::experimental::TlsChannelCredentialsOptions options;
+  options.set_certificate_provider(provider);
+  options.watch_root_certs();
+  options.watch_identity_key_cert_pairs();
 
-  return grpc::SslCredentials(sslOptions);
+  return grpc::experimental::TlsCredentials(options);
 }
 
 std::shared_ptr<grpc::Channel> CreateChannel(const std::string& server_address, const std::string& hostname_override, const std::shared_ptr<grpc::ChannelCredentials>& creds) {


### PR DESCRIPTION
## Description

Replace `grpc::SslCredentials` with `grpc::experimental::FileWatcherCertificateProvider` so that the collector re-reads its client cert and key from disk when the files change, rather than caching them for the lifetime of the process.

`FileWatcherCertificateProvider` reads the PEM files at startup (synchronously, before the first connection) and then checks for changes every 60 seconds. When cert files are rotated on disk, the next TLS handshake automatically uses the new credentials.

Alternatives considered: A more invasive approach would be to pass a channel factory into `SignalServiceClient` and `NetworkConnectionInfoServiceComm` so that each reconnect loop recreates the `grpc::Channel` with freshly-read certs. This avoids the background file-watching thread but requires changes across ~8 files and reworks how the channel is shared.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Deployed StackRox on an OpenShift cluster via the operator. Scaled down the operator and sensor, then deployed a mock sensor pod (Python TLS server on port 8443 with mTLS, handling HTTP/2 frames) that logs client certificate details (subject CN, serial, validity) on each connection.

1. Baseline (old image 3.24.0-83-gcb7ff40e2b): Collector connected and presented its original cert (CN=COLLECTOR_SERVICE: ..., serial AE17E23080E076CC).
2. Rotated certs with old image: Generated a new cert signed by the same CA (CN=VBOLOGA-COLLECTOR-ROTATED) and updated `tls-cert-collector` secret. After waiting for kubelet propagation, collector still presented the original cert, confirming no hot reload in the old code.
3. Switched to PR image (3.24.0-110-g1fed990080): Collector restarted and picked up the rotated cert (CN=VBOLOGA-COLLECTOR-ROTATED, serial 3C124B...386F) as expected.
4. Restored original certs with PR image: Updated `tls-cert-collector` back to the original cert. Without restarting collector, it switched to presenting the original cert again (CN=COLLECTOR_SERVICE: ..., serial AE17E23080E076CC), proving `FileWatcherCertificateProvider` detected the on-disk change and reloaded
  certs automatically.