### PR TITLE
[backport 3.23] fix: don't fail integration test jobs on artifact upload errors (#3296)

### DIFF
--- a/.github/workflows/integration-tests-vm-type.yml
+++ b/.github/workflows/integration-tests-vm-type.yml
@@ -140,6 +140,10 @@ jobs:
 
       - name: Store artifacts
         if: always()
+        # Don't fail the job on upload errors (e.g. ECONNRESET) —
+        # these are debug logs, not consumed by downstream jobs.
+        # Test failures still fail the job via the Run Tests step.
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.vm_type }}-logs


### PR DESCRIPTION
Backport of #3296 