### PR TITLE
chore: Bump Konflux image expiration to 52 weeks

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -27,7 +27,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    value: '13w'
+    value: '52w'
   - name: output-image-repo
     value: quay.io/rhacs-eng/release-collector
   - name: path-context


### PR DESCRIPTION
## Description

Similar to: https://github.com/stackrox/scanner/pull/3147
Related thread: https://redhat-internal.slack.com/archives/CELUQKESC/p1777919339423939

If Konflux-built images expire, they are gone and this can be a problem when COLLECTOR_VERSION is not updated for too long. Bumping the image expiration should make that less probable.

I'm open to bargain on the duration (to make it lower)!

It looks like GHA-built images aren't set to expire at all. At least, I wasn't able to find the `quay.expires-after` label.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**
No change.

## Testing Performed

None. Should just work.