### PR TITLE
ROX-33431: Bump prefetch-dependencies memory

### DIFF
--- a/.tekton/collector-build.yaml
+++ b/.tekton/collector-build.yaml
@@ -91,10 +91,10 @@ spec:
       # We saw prefetch-dependencies _step_ also OOMKill-ed, therefore bumping its memory compared to default.
       computeResources:
         limits:
-          memory: 6Gi
+          memory: 7Gi
         requests:
           cpu: "1"
-          memory: 6Gi
+          memory: 7Gi
   - pipelineTaskName: build-source-image
     stepSpecs:
     - name: use-trusted-artifact


### PR DESCRIPTION
## Description

Bumping memory to prevent the observed OOM kills.
The current 6G still leads to kills, e.g. in these pods:
- collector-on-push-8m74d-prefetch-dependencies-pod
- collector-on-push-jf5kh-prefetch-dependencies-pod
- collector-on-push-vfvfs-prefetch-dependencies-pod
- collector-on-push-vj9q5-prefetch-dependencies-pod

Since it's not too frequent, I hope giving it 1G more should be enough.

Related thread https://redhat-internal.slack.com/archives/C081BAM590Q/p1780296820165749

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Updated documentation accordingly~~

**Automated testing**

No change.

## Testing Performed

Just CI.