### PR TITLE
ROX-33133: Re-enable post-quantum crypto-policies for Collector

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -138,6 +138,8 @@ COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
 
 COPY LICENSE /licenses/LICENSE
 
+RUN update-crypto-policies --set DEFAULT:PQ
+
 EXPOSE 8080 9090
 
 ENTRYPOINT ["collector"]


### PR DESCRIPTION
## Description

https://github.com/stackrox/collector/pull/2977 enabled post-quantum crypto policies in the Collector image.

Unfortunately https://github.com/stackrox/collector/pull/3021 removed that change. This PR re-enables the PQC policies.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Deployed a Konflux build with the fix to a cluster and verified that all Sensor accepted TLS connections report  `X25519MLKEM768`. Previously, collector-to-sensor connections showed plain `X25519`.