### PR TITLE
ROX-33133: Re-enable post-quantum crypto-policies for Collector

### DIFF
--- a/collector/container/konflux.Dockerfile
+++ b/collector/container/konflux.Dockerfile
@@ -138,6 +138,8 @@ COPY --from=builder ${CMAKE_BUILD_DIR}/collector/self-checks /usr/local/bin/
 
 COPY LICENSE /licenses/LICENSE
 
+RUN update-crypto-policies --set DEFAULT:PQ
+
 EXPOSE 8080 9090
 
 ENTRYPOINT ["collector"]


### PR DESCRIPTION
## Description

Back-port of https://github.com/stackrox/collector/pull/3448 to the `release-3.25` branch. Required for https://github.com/stackrox/collector/pull/3434 to actually have an effect.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

See https://github.com/stackrox/collector/pull/3448
