### PR TITLE
Drop unnecessary capabilities after BPF initialization

### DIFF
--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -120,6 +120,26 @@ void initialChecks() {
   }
 }
 
+void DropCapabilities() {
+  auto kv = HostInfo::Instance().GetKernelVersion();
+  bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
+
+  capng_clear(CAPNG_SELECT_CAPS);
+  capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE | CAPNG_PERMITTED, CAP_SYS_PTRACE, -1);
+
+  if (!has_discrete_bpf) {
+    capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE | CAPNG_PERMITTED, CAP_SYS_ADMIN, -1);
+    CLOG(INFO) << "Kernel " << kv.release << " lacks discrete CAP_BPF, keeping CAP_SYS_ADMIN";
+  }
+
+  if (capng_apply(CAPNG_SELECT_CAPS) < 0) {
+    CLOG(WARNING) << "Failed to drop capabilities";
+  } else {
+    CLOG(INFO) << "Dropped capabilities after BPF initialization, keeping CAP_SYS_PTRACE"
+               << (has_discrete_bpf ? "" : " and CAP_SYS_ADMIN");
+  }
+}
+
 void RunService(CollectorConfig& config) {
   auto& startup_diagnostics = StartupDiagnostics::GetInstance();
   CollectorService collector(config, &g_control, &g_signum);
@@ -133,6 +153,8 @@ void RunService(CollectorConfig& config) {
   gplNotice();
 
   startup_diagnostics.Log();
+
+  DropCapabilities();
 
   collector.RunForever();
 }

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -143,10 +143,10 @@ void RunService(CollectorConfig& config) {
   bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
 
   if (has_discrete_bpf) {
-    DropCapabilities({CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE});
+    DropCapabilities({CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE}, true);
     CLOG(INFO) << "Dropped capabilities, keeping CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE";
   } else {
-    DropCapabilities({CAP_SYS_ADMIN, CAP_SYS_PTRACE});
+    DropCapabilities({CAP_SYS_ADMIN, CAP_SYS_PTRACE}, true);
     CLOG(INFO) << "Kernel " << kv.release << " lacks discrete CAP_BPF, keeping CAP_SYS_ADMIN, CAP_SYS_PTRACE";
   }
 

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include "CollectorVersion.h"
 #include "Control.h"
 #include "Diagnostics.h"
+#include "DropCapabilities.h"
 #include "EventNames.h"
 #include "FileSystem.h"
 #include "GRPC.h"
@@ -120,36 +121,6 @@ void initialChecks() {
   }
 }
 
-void DropCapabilities() {
-  auto kv = HostInfo::Instance().GetKernelVersion();
-  bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
-
-  capng_clear(CAPNG_SELECT_CAPS);
-
-  auto caps = static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED);
-
-  // CAP_SYS_PTRACE: ongoing /proc/<pid>/ reads across namespaces
-  capng_updatev(CAPNG_ADD, caps, CAP_SYS_PTRACE, -1);
-
-  if (has_discrete_bpf) {
-    // CAP_BPF: runtime BPF map lookups (stats) and potential capture restart
-    // CAP_PERFMON: BPF program re-attachment on capture restart
-    capng_updatev(CAPNG_ADD, caps, CAP_BPF, -1);
-    capng_updatev(CAPNG_ADD, caps, CAP_PERFMON, -1);
-  } else {
-    // On kernels < 5.8, CAP_SYS_ADMIN covers BPF and perf operations
-    capng_updatev(CAPNG_ADD, caps, CAP_SYS_ADMIN, -1);
-  }
-
-  if (capng_apply(CAPNG_SELECT_CAPS) < 0) {
-    CLOG(WARNING) << "Failed to drop capabilities";
-  } else if (has_discrete_bpf) {
-    CLOG(INFO) << "Dropped capabilities, keeping CAP_SYS_PTRACE, CAP_BPF, CAP_PERFMON";
-  } else {
-    CLOG(INFO) << "Dropped capabilities, keeping CAP_SYS_PTRACE, CAP_SYS_ADMIN";
-  }
-}
-
 void RunService(CollectorConfig& config) {
   auto& startup_diagnostics = StartupDiagnostics::GetInstance();
   CollectorService collector(config, &g_control, &g_signum);
@@ -164,7 +135,20 @@ void RunService(CollectorConfig& config) {
 
   startup_diagnostics.Log();
 
-  DropCapabilities();
+  // Drop capabilities no longer needed after BPF initialization.
+  // The main thread keeps BPF + PERFMON (runtime map lookups, potential
+  // capture restart) and SYS_PTRACE (/proc reads). Individual worker
+  // threads drop further in their own entry points.
+  auto kv = HostInfo::Instance().GetKernelVersion();
+  bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
+
+  if (has_discrete_bpf) {
+    DropCapabilities({CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE});
+    CLOG(INFO) << "Dropped capabilities, keeping CAP_BPF, CAP_PERFMON, CAP_SYS_PTRACE";
+  } else {
+    DropCapabilities({CAP_SYS_ADMIN, CAP_SYS_PTRACE});
+    CLOG(INFO) << "Kernel " << kv.release << " lacks discrete CAP_BPF, keeping CAP_SYS_ADMIN, CAP_SYS_PTRACE";
+  }
 
   collector.RunForever();
 }

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -125,18 +125,28 @@ void DropCapabilities() {
   bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
 
   capng_clear(CAPNG_SELECT_CAPS);
-  capng_updatev(CAPNG_ADD, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_SYS_PTRACE, -1);
 
-  if (!has_discrete_bpf) {
-    capng_updatev(CAPNG_ADD, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_SYS_ADMIN, -1);
-    CLOG(INFO) << "Kernel " << kv.release << " lacks discrete CAP_BPF, keeping CAP_SYS_ADMIN";
+  auto caps = static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED);
+
+  // CAP_SYS_PTRACE: ongoing /proc/<pid>/ reads across namespaces
+  capng_updatev(CAPNG_ADD, caps, CAP_SYS_PTRACE, -1);
+
+  if (has_discrete_bpf) {
+    // CAP_BPF: runtime BPF map lookups (stats) and potential capture restart
+    // CAP_PERFMON: BPF program re-attachment on capture restart
+    capng_updatev(CAPNG_ADD, caps, CAP_BPF, -1);
+    capng_updatev(CAPNG_ADD, caps, CAP_PERFMON, -1);
+  } else {
+    // On kernels < 5.8, CAP_SYS_ADMIN covers BPF and perf operations
+    capng_updatev(CAPNG_ADD, caps, CAP_SYS_ADMIN, -1);
   }
 
   if (capng_apply(CAPNG_SELECT_CAPS) < 0) {
     CLOG(WARNING) << "Failed to drop capabilities";
+  } else if (has_discrete_bpf) {
+    CLOG(INFO) << "Dropped capabilities, keeping CAP_SYS_PTRACE, CAP_BPF, CAP_PERFMON";
   } else {
-    CLOG(INFO) << "Dropped capabilities after BPF initialization, keeping CAP_SYS_PTRACE"
-               << (has_discrete_bpf ? "" : " and CAP_SYS_ADMIN");
+    CLOG(INFO) << "Dropped capabilities, keeping CAP_SYS_PTRACE, CAP_SYS_ADMIN";
   }
 }
 

--- a/collector/collector.cpp
+++ b/collector/collector.cpp
@@ -125,10 +125,10 @@ void DropCapabilities() {
   bool has_discrete_bpf = (kv.kernel > 5) || (kv.kernel == 5 && kv.major >= 8);
 
   capng_clear(CAPNG_SELECT_CAPS);
-  capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE | CAPNG_PERMITTED, CAP_SYS_PTRACE, -1);
+  capng_updatev(CAPNG_ADD, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_SYS_PTRACE, -1);
 
   if (!has_discrete_bpf) {
-    capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE | CAPNG_PERMITTED, CAP_SYS_ADMIN, -1);
+    capng_updatev(CAPNG_ADD, static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED), CAP_SYS_ADMIN, -1);
     CLOG(INFO) << "Kernel " << kv.release << " lacks discrete CAP_BPF, keeping CAP_SYS_ADMIN";
   }
 

--- a/collector/lib/CollectorStatsExporter.cpp
+++ b/collector/lib/CollectorStatsExporter.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 
 #include "Containers.h"
+#include "DropCapabilities.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "Utility.h"
@@ -46,6 +47,8 @@ class CollectorTimerGauge {
 };
 
 void CollectorStatsExporter::run() {
+  collector::DropCapabilities({CAP_BPF});
+
   auto& collectorEventCounters = prometheus::BuildGauge()
                                      .Name("rox_collector_events")
                                      .Help("Collector events")

--- a/collector/lib/ConfigLoader.cpp
+++ b/collector/lib/ConfigLoader.cpp
@@ -6,6 +6,7 @@
 
 #include "internalapi/sensor/collector.pb.h"
 
+#include "DropCapabilities.h"
 #include "EnvVar.h"
 #include "Logging.h"
 
@@ -527,6 +528,7 @@ sensor::CollectorConfig ConfigLoader::NewRuntimeConfig() {
 }
 
 void ConfigLoader::WatchFile() {
+  DropCapabilities({});
   const auto& file = parser_.GetFile();
 
   if (!inotify_.IsValid()) {

--- a/collector/lib/DropCapabilities.h
+++ b/collector/lib/DropCapabilities.h
@@ -1,0 +1,32 @@
+#ifndef _DROP_CAPABILITIES_H_
+#define _DROP_CAPABILITIES_H_
+
+#include <initializer_list>
+
+extern "C" {
+#include <cap-ng.h>
+}
+
+#include "Logging.h"
+
+namespace collector {
+
+// Drop all Linux capabilities except those specified.
+// Clears the bounding set too, preventing regain via execve.
+// Logs the result but does not abort on failure.
+inline void DropCapabilities(std::initializer_list<unsigned int> keep) {
+  capng_clear(CAPNG_SELECT_ALL);
+
+  auto caps = static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED);
+  for (auto cap : keep) {
+    capng_update(CAPNG_ADD, caps, cap);
+  }
+
+  if (capng_apply(CAPNG_SELECT_ALL) != 0) {
+    CLOG(WARNING) << "Failed to drop capabilities";
+  }
+}
+
+}  // namespace collector
+
+#endif  // _DROP_CAPABILITIES_H_

--- a/collector/lib/DropCapabilities.h
+++ b/collector/lib/DropCapabilities.h
@@ -12,17 +12,20 @@ extern "C" {
 namespace collector {
 
 // Drop all Linux capabilities except those specified.
-// Clears the bounding set too, preventing regain via execve.
+// If clear_bounding is true, also clears the bounding set (requires
+// CAP_SETPCAP — use only on the first drop before other caps are lost).
 // Logs the result but does not abort on failure.
-inline void DropCapabilities(std::initializer_list<unsigned int> keep) {
-  capng_clear(CAPNG_SELECT_ALL);
+inline void DropCapabilities(std::initializer_list<unsigned int> keep,
+                             bool clear_bounding = false) {
+  auto scope = clear_bounding ? CAPNG_SELECT_ALL : CAPNG_SELECT_CAPS;
+  capng_clear(scope);
 
   auto caps = static_cast<capng_type_t>(CAPNG_EFFECTIVE | CAPNG_PERMITTED);
   for (auto cap : keep) {
     capng_update(CAPNG_ADD, caps, cap);
   }
 
-  if (capng_apply(CAPNG_SELECT_ALL) != 0) {
+  if (capng_apply(scope) != 0) {
     CLOG(WARNING) << "Failed to drop capabilities";
   }
 }

--- a/collector/lib/NetworkStatusNotifier.cpp
+++ b/collector/lib/NetworkStatusNotifier.cpp
@@ -3,6 +3,7 @@
 #include <google/protobuf/util/time_util.h>
 
 #include "CollectorStats.h"
+#include "DropCapabilities.h"
 #include "DuplexGRPC.h"
 #include "GRPCUtil.h"
 #include "Logging.h"
@@ -110,6 +111,7 @@ void NetworkStatusNotifier::ReceiveIPNetworks(const sensor::IPNetworkList& netwo
 }
 
 void NetworkStatusNotifier::Run() {
+  DropCapabilities({CAP_SYS_PTRACE});
   Profiler::RegisterCPUThread();
   auto next_attempt = std::chrono::system_clock::now();
 

--- a/collector/lib/SignalServiceClient.cpp
+++ b/collector/lib/SignalServiceClient.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 
+#include "DropCapabilities.h"
 #include "GRPCUtil.h"
 #include "Logging.h"
 #include "ProtoUtil.h"
@@ -43,6 +44,7 @@ bool SignalServiceClient::EstablishGRPCStreamSingle() {
 }
 
 void SignalServiceClient::EstablishGRPCStream() {
+  DropCapabilities({});
   while (EstablishGRPCStreamSingle());
   CLOG(INFO) << "Signal service client terminating.";
 }


### PR DESCRIPTION
## Summary

Self-harden collector by dropping unnecessary Linux capabilities after BPF initialization, regardless of how it is deployed. Even with `privileged: true`, the process capability set is minimized per-thread before entering the event loop.

Based on prior work by @erthalion in #1908.

### Per-thread capability model

| Thread | Entry point | Capabilities kept | Why |
|---|---|---|---|
| Main (event loop) | `RunService()` | BPF, PERFMON, SYS_PTRACE | BPF map ops, capture restart, /proc reads |
| Stats exporter | `CollectorStatsExporter::run()` | BPF | `bpf_map_lookup_elem()` for metrics |
| Network notifier | `NetworkStatusNotifier::Run()` | SYS_PTRACE | /proc reads for network state |
| Signal client | `SignalServiceClient::EstablishGRPCStream()` | none | gRPC streaming only |
| Config loader | `ConfigLoader::WatchFile()` | none | inotify + YAML parsing only |

On kernels < 5.8 (RHEL 8), the main thread keeps SYS_ADMIN + SYS_PTRACE instead of BPF + PERFMON + SYS_PTRACE.

### Implementation

- `DropCapabilities.h` — single utility: clears all caps + bounding set via `CAPNG_SELECT_ALL`, adds back only what is specified
- Called at each thread entry point with that thread's minimal set
- Uses libcap-ng which was already linked but never called
- Kernel version detection via `HostInfo::GetKernelVersion()` for RHEL 8 fallback
- Warns but does not abort if the drop fails (collector still works, just without hardening)

### What gets dropped (~38 of 41 capabilities)

NET_RAW, SYS_MODULE, DAC_OVERRIDE, CHOWN, FOWNER, KILL, SETUID, SETGID, NET_BIND_SERVICE, MKNOD, SYS_RAWIO, AUDIT_WRITE, SYS_RESOURCE, DAC_READ_SEARCH, NET_ADMIN, and all others not in the keep list above.

### Differences from #1908

- Drops *after* InitKernel() instead of at main() start — allows dropping SYS_RESOURCE
- Kernel-version-aware: discrete CAP_BPF on 5.8+, CAP_SYS_ADMIN fallback on older
- Does not keep CAP_DAC_READ_SEARCH (validated unnecessary via CI in #3447)
- Does not keep CAP_SYS_ADMIN on modern kernels (validated BPF + PERFMON suffice)

Companion to #3447 which reduces the deployment-side privileges.

## Test plan

- [ ] C++ compilation succeeds (builder container, all 4 architectures)
- [ ] Unit tests pass
- [ ] Integration tests pass — collector logs show capability drop messages
- [ ] Verify collector remains functional after drops (process events, network flows, /proc scraping, metrics)