### PR TITLE
ROX-35107: Add Konflux pipeline check for post-quantum crypto policy

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -580,7 +580,9 @@ spec:
           if grep -q "${EXPECTED_GROUP}" "${CONFIG_FILE}"; then
             echo "PASS: ${EXPECTED_GROUP} found in ${CONFIG_FILE}"
           else
+            echo "Contents of ${CONFIG_FILE}:"
             cat "${CONFIG_FILE}"
+            echo
             echo "FAIL: The image's OpenSSL is not configured to support ML-KEM."
             echo "FAIL: ${EXPECTED_GROUP} not found in ${CONFIG_FILE}"
             exit 1

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -555,34 +555,34 @@ spec:
       values: [ "false" ]
 
   - name: verify-crypto-policies
-    params:
-    - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     when:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
     taskSpec:
-      params:
-      - name: IMAGE_URL
-        type: string
-      - name: IMAGE_DIGEST
-        type: string
+      description: >-
+        Verify that OpenSSL in the built collector image is configured to support post-quantum
+        cryptography (more specifically, the ML-KEM algorithm group). Regressions can occur e.g.
+        if the crypto-policy setting is removed from the Dockerfile, or the base image is changed
+        to one that does not support post-quantum cryptography.
       steps:
       - name: check-pq-crypto-policy
-        image: $(params.IMAGE_URL)@$(params.IMAGE_DIGEST)
+        image: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
+        env:
+        - name: EXPECTED_GROUP
+          value: X25519MLKEM768
+        - name: CONFIG_FILE
+          value: /etc/crypto-policies/back-ends/opensslcnf.config
         script: |
           #!/bin/bash
           set -euo pipefail
           echo "Verifying post-quantum crypto policy configuration..."
-          if grep -q X25519MLKEM768 /etc/crypto-policies/back-ends/opensslcnf.config; then
-            echo "PASS: X25519MLKEM768 found in /etc/crypto-policies/back-ends/opensslcnf.config"
+          if grep -q "${EXPECTED_GROUP}" "${CONFIG_FILE}"; then
+            echo "PASS: ${EXPECTED_GROUP} found in ${CONFIG_FILE}"
           else
-            echo "FAIL: X25519MLKEM768 not found in /etc/crypto-policies/back-ends/opensslcnf.config"
-            echo "The post-quantum crypto policy (DEFAULT:PQ) may not be properly applied."
-            cat /etc/crypto-policies/back-ends/opensslcnf.config
+            cat "${CONFIG_FILE}"
+            echo "FAIL: The image's OpenSSL is not configured to support ML-KEM."
+            echo "FAIL: ${EXPECTED_GROUP} not found in ${CONFIG_FILE}"
             exit 1
           fi
 

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -560,19 +560,19 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values: [ "false" ]
     taskRef:
       params:
       - name: name
         value: verify-pq-crypto-policies
       - name: bundle
-        value: quay.io/rhacs-eng/konflux-tasks:pr-105@sha256:bbda5ad1b1ffdffb4918d0c12542c0d603060a1690338a6592b0eaa46cf2119b
+        value: quay.io/rhacs-eng/konflux-tasks:latest@sha256:4d05c7ad1bcf63015b6b67787e9f024466fd2c864b69f7939a1925e307afb9b0
       - name: kind
         value: task
       resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
 
   - name: push-dockerfile
     params:

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -554,39 +554,25 @@ spec:
       operator: in
       values: [ "false" ]
 
-  - name: verify-crypto-policies
+  - name: verify-pq-crypto-policies
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     when:
     - input: $(params.skip-checks)
       operator: in
       values: [ "false" ]
-    taskSpec:
-      description: >-
-        Verify that OpenSSL in the built collector image is configured to support post-quantum
-        cryptography (more specifically, the ML-KEM algorithm group). Regressions can occur e.g.
-        if the crypto-policy setting is removed from the Dockerfile, or the base image is changed
-        to one that does not support post-quantum cryptography.
-      steps:
-      - name: check-pq-crypto-policy
-        image: $(tasks.build-image-index.results.IMAGE_URL)@$(tasks.build-image-index.results.IMAGE_DIGEST)
-        env:
-        - name: EXPECTED_GROUP
-          value: X25519MLKEM768
-        - name: CONFIG_FILE
-          value: /etc/crypto-policies/back-ends/opensslcnf.config
-        script: |
-          #!/bin/bash
-          set -euo pipefail
-          echo "Verifying post-quantum crypto policy configuration..."
-          if grep -q "${EXPECTED_GROUP}" "${CONFIG_FILE}"; then
-            echo "PASS: ${EXPECTED_GROUP} found in ${CONFIG_FILE}"
-          else
-            echo "Contents of ${CONFIG_FILE}:"
-            cat "${CONFIG_FILE}"
-            echo
-            echo "FAIL: The image's OpenSSL is not configured to support ML-KEM."
-            echo "FAIL: ${EXPECTED_GROUP} not found in ${CONFIG_FILE}"
-            exit 1
-          fi
+    taskRef:
+      params:
+      - name: name
+        value: verify-pq-crypto-policies
+      - name: bundle
+        value: quay.io/rhacs-eng/konflux-tasks:pr-105@sha256:bbda5ad1b1ffdffb4918d0c12542c0d603060a1690338a6592b0eaa46cf2119b
+      - name: kind
+        value: task
+      resolver: bundles
 
   - name: push-dockerfile
     params:

--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -554,6 +554,38 @@ spec:
       operator: in
       values: [ "false" ]
 
+  - name: verify-crypto-policies
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: [ "false" ]
+    taskSpec:
+      params:
+      - name: IMAGE_URL
+        type: string
+      - name: IMAGE_DIGEST
+        type: string
+      steps:
+      - name: check-pq-crypto-policy
+        image: $(params.IMAGE_URL)@$(params.IMAGE_DIGEST)
+        script: |
+          #!/bin/bash
+          set -euo pipefail
+          echo "Verifying post-quantum crypto policy configuration..."
+          if grep -q X25519MLKEM768 /etc/crypto-policies/back-ends/opensslcnf.config; then
+            echo "PASS: X25519MLKEM768 found in /etc/crypto-policies/back-ends/opensslcnf.config"
+          else
+            echo "FAIL: X25519MLKEM768 not found in /etc/crypto-policies/back-ends/opensslcnf.config"
+            echo "The post-quantum crypto policy (DEFAULT:PQ) may not be properly applied."
+            cat /etc/crypto-policies/back-ends/opensslcnf.config
+            exit 1
+          fi
+
   - name: push-dockerfile
     params:
     - name: IMAGE


### PR DESCRIPTION
## Description

Verify that the built collector image has `X25519MLKEM768` in `/etc/crypto-policies/back-ends/opensslcnf.config`, guarding against regressions of the `DEFAULT:PQ` crypto-policy setting.

I added this check because:
- I added PQC support in https://github.com/stackrox/collector/pull/2977
- it was subsequently removed by mistake in https://github.com/stackrox/collector/pull/3021
- since we currently do not have E2E tests for PQC support, I only discovered this months later, via manual testing
- until we have E2E tests in place, I'd like to have a regression test that is ideally not located in the same place as the code that enables PQC (i.e. not in the Dockerfile), so it's harder to remove it by mistake

Update: Extracted the script into a task here: https://github.com/stackrox/konflux-tasks/pull/105

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [x] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.