### PR TITLE
fix(mintmaker): always recreate ACS konflux-tasks update PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,6 +50,8 @@
         "matchPackageNames": [
           "/^quay.io/rhacs-eng/konflux-tasks/",
         ],
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch",
       },
     ],
   },


### PR DESCRIPTION

## Description

Recently found some PRs that should've updated the custom konflux tasks from stackrox that were not being set to auto-merge, it has been suggested by the MintMaker team that adding the fields in this PR will help with the issue.

More context at: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1782727458789889

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Run the configuration through `renovate-config-validator`

```
 INFO: Validating .github/renovate.json5
ERROR: Found errors in configuration
       "file": ".github/renovate.json5",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: rpmVulnerabilityAutomerge"
         },
         {
           "topic": "Configuration Error",
           "message": "The following managers configured in enabledManagers are not supported: \"rpm-lockfile\""
         }
       ]
```

