### PR TITLE
ROX-33568: retry logic to container spawn in integration-tests

### DIFF
--- a/integration-tests/pkg/executor/executor_docker_api.go
+++ b/integration-tests/pkg/executor/executor_docker_api.go
@@ -158,10 +158,13 @@ func (d *dockerAPIExecutor) StartContainer(startConfig config.ContainerStartConf
 	}
 
 	_, err = RetryWithTimeout(func() (output string, err error) {
-		if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-			return "", errors.Wrapf(err, "start %s", startConfig.Name)
-		}
+		return NoOutput, d.client.ContainerStart(ctx, resp.ID, container.StartOptions{})
+	}, fmt.Errorf("Container %s could not be started", startConfig.Name))
+	if err != nil {
+		return "", err
+	}
 
+	_, err = RetryWithTimeout(func() (output string, err error) {
 		inspect, err := d.client.ContainerInspect(ctx, resp.ID)
 
 		if err != nil {

--- a/integration-tests/pkg/executor/executor_docker_api.go
+++ b/integration-tests/pkg/executor/executor_docker_api.go
@@ -156,15 +156,6 @@ func (d *dockerAPIExecutor) StartContainer(startConfig config.ContainerStartConf
 	if err != nil {
 		return "", errors.Wrapf(err, "create %s", startConfig.Name)
 	}
-
-	waitResp, waitErr := d.client.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
-	select {
-	case <-waitResp:
-		break
-	case err := <-waitErr:
-		return "", errors.Wrapf(err, "wait %s", startConfig.Name)
-	}
-
 	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
 		return "", errors.Wrapf(err, "start %s", startConfig.Name)
 	}

--- a/integration-tests/pkg/executor/executor_docker_api.go
+++ b/integration-tests/pkg/executor/executor_docker_api.go
@@ -156,11 +156,12 @@ func (d *dockerAPIExecutor) StartContainer(startConfig config.ContainerStartConf
 	if err != nil {
 		return "", errors.Wrapf(err, "create %s", startConfig.Name)
 	}
-	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		return "", errors.Wrapf(err, "start %s", startConfig.Name)
-	}
 
 	_, err = RetryWithTimeout(func() (output string, err error) {
+		if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+			return "", errors.Wrapf(err, "start %s", startConfig.Name)
+		}
+
 		inspect, err := d.client.ContainerInspect(ctx, resp.ID)
 
 		if err != nil {


### PR DESCRIPTION
## Description

There are sporadic failures when starting containers during integration tests.

```
2026/01/23 07:32:41 INFO: start external-connection with quay.io/rhacs-eng/qa-multi-arch:alpine-curl-2.0.5 (dcd32a1451f7)
    base.go:74: 
        	Error Trace:	/home/runner/work/collector/collector/integration-tests/suites/base.go:74
        	            				/home/runner/work/collector/collector/integration-tests/suites/runtime_config_file.go:115
        	            				/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:192
        	Error:      	Received unexpected error:
        	            	Error response from daemon: runc: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: unable to freeze: OCI runtime error
        	            	start collector
        	            	github.com/stackrox/collector/integration-tests/pkg/executor.(*dockerAPIExecutor).StartContainer
        	            		/home/runner/work/collector/collector/integration-tests/pkg/executor/executor_docker_api.go:159
        	            	github.com/stackrox/collector/integration-tests/pkg/collector.(*DockerCollectorManager).launchCollector
        	            		/home/runner/work/collector/collector/integration-tests/pkg/collector/collector_docker.go:149
        	            	github.com/stackrox/collector/integration-tests/pkg/collector.(*DockerCollectorManager).Launch
        	            		/home/runner/work/collector/collector/integration-tests/pkg/collector/collector_docker.go:81
        	            	github.com/stackrox/collector/integration-tests/suites.(*IntegrationTestSuiteBase).StartCollector
        	            		/home/runner/work/collector/collector/integration-tests/suites/base.go:74
        	            	github.com/stackrox/collector/integration-tests/suites.(*RuntimeConfigFileTestSuite).SetupTest
        	            		/home/runner/work/collector/collector/integration-tests/suites/runtime_config_file.go:115
        	            	github.com/stretchr/testify/suite.Run.func1
        	            		/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:192
        	            	testing.tRunner
        	            		/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.linux-amd64/src/testing/testing.go:1690
        	            	runtime.goexit
        	            		/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.linux-amd64/src/runtime/asm_amd64.s:1700
        	Test:       	TestRuntimeConfigFile/TestRuntimeConfigFileDisable
```

A previous fix attempt as been made by waiting on the status of the freshly created container, but the failure can still be observed. https://github.com/stackrox/collector/pull/2818

We revert the previous change and implement a brute retry of the Start operation.
