### PR TITLE
feat(ansible): Improve ansible create and destroy vms for ppc64le

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,8 +122,16 @@ jobs:
 
   ppc64le-integration-tests:
     uses: ./.github/workflows/integration-tests-vm-type.yml
+    strategy:
+      # ensure that if one part of the matrix fails, the
+      # rest will continue
+      fail-fast: false
+      matrix:
+        vm_type:
+          - rhel-ppc64le-9
+          - rhel-ppc64le-10
     with:
-      vm_type: rhel-ppc64le
+      vm_type: ${{ matrix.vm_type }}
       collector-tag: ${{ inputs.collector-tag }}
       collector-qa-tag: ${{ inputs.collector-qa-tag }}
       collector-tests-tag: ${{ inputs.collector-tests-tag }}

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -110,7 +110,8 @@ summarized below:
 | ------------- | -------------- |
 | rhel          | rhel-7 <br> rhel-8 |
 | rhel-s390x    | rhel-8-6-s390x |
-| rhel-ppc64le  | rhel-8.8-05102023 |
+| rhel-ppc64le-9 | rhel-96-04282025 |
+| rhel-ppc64le-10 | rhel-10-04252025 |
 | rhel-sap      | rhel-8-4-sap-ha <br> rhel-8-6-sap-ha |
 | cos           | cos-stable <br> cos-beta <br> cos-dev |
 | sles          | sles-12 <br> sles-15 |

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -53,16 +53,21 @@ virtual_machines:
     families:
       - rhel-8-6-s390x
 
-  # We have taken families name as "p" since there is a character limit for instance name
-  # in ibm cloud (56 chars max)
-  rhel-ppc64le:
+  rhel-ppc64le-9:
     project: rhel-ppc64le-cloud
     arch: ppc64le
     ssh_key_file: "~/.ssh/acs-ppc64le-rsa.prv"
+    container_engine: podman
     images:
       - rhel-96-04282025
-      - rhel-10-04252025
+
+  rhel-ppc64le-10:
+    project: rhel-ppc64le-cloud
+    arch: ppc64le
+    ssh_key_file: "~/.ssh/acs-ppc64le-rsa.prv"
     container_engine: podman
+    images:
+      - rhel-10-04252025
 
   rhel-sap:
     project: rhel-sap-cloud

--- a/ansible/group_vars/platform_rhel-ppc64le.yml
+++ b/ansible/group_vars/platform_rhel-ppc64le.yml
@@ -1,5 +1,0 @@
-
----
-ansible_ssh_common_args: -c aes128-ctr
-# This is a workaround for ppc64le vsi creation since there is an issue with ssh connection between ubuntu vm in azure and power vsi in IBM Cloud
-# Reference link https://askubuntu.com/questions/1229456/ssh-fails-with-connection-timed-out-in-vpn-and-hangs-here-expecting-ssh2-msg

--- a/ansible/group_vars/vm_arch_ppc64le.yml
+++ b/ansible/group_vars/vm_arch_ppc64le.yml
@@ -1,0 +1,2 @@
+---
+ansible_ssh_common_args: -c aes128-ctr

--- a/ansible/roles/create-all-vms/tasks/by-image.yml
+++ b/ansible/roles/create-all-vms/tasks/by-image.yml
@@ -12,11 +12,11 @@
 
 - set_fact:
     vm_full_name: "{{ gcp_instance_prefix }}-{{ vm_image_short }}-{{ vm_hashed_name }}"
-  when: item.0.key != 'rhel-ppc64le'
+  when: arch != 'ppc64le'
 
 - set_fact:
-    vm_full_name: "{{ gcp_instance_prefix }}-rhel-ppc64le-{{ vm_hashed_name }}"
-  when: item.0.key == 'rhel-ppc64le'
+    vm_full_name: "{{ gcp_instance_prefix }}-{{ item.0.key }}-{{ vm_hashed_name }}"
+  when: arch == 'ppc64le'
 
 - set_fact:
     ibm_env: "{{ s390x.env }}"

--- a/ansible/roles/create-vm/tasks/create-ppc64le-vm.yml
+++ b/ansible/roles/create-vm/tasks/create-ppc64le-vm.yml
@@ -1,40 +1,6 @@
 - name: Fetch the variables from var file
   include_vars:
     file: ppc64le.yml
-  collections:
-   - ibm.cloudcollection
-
-- name: Check for existing SSH Key
-  ibm.cloudcollection.ibm_pi_key_info:
-    pi_key_name: "{{ pi_name }}-ssh-key"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  failed_when:
-    - pi_ssh_key_existing_output.rc != 0
-    - '"does not exist" not in pi_ssh_key_existing_output.stderr'
-  register: pi_ssh_key_existing_output
-
-- set_fact:
-    ssh_key_exists: "{{ pi_ssh_key_existing_output.resource.id is defined }}"
-
-- name: Save existing SSH Key as fact
-  set_fact:
-    cacheable: True
-    pi_ssh_key: "{{ pi_ssh_key_existing_output.resource }}"
-  when: ssh_key_exists
-
-- name: Add new SSH Key
-  ibm.cloudcollection.ibm_pi_key:
-    pi_key_name: "{{ pi_name }}-ssh-key"
-    pi_ssh_key: "{{ ssh_public_key }}"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  register: pi_ssh_key_create_output
-  when: not ssh_key_exists
-
-- name: Save new SSH Key as fact
-  set_fact:
-    cacheable: True
-    pi_ssh_key: "{{ pi_ssh_key_create_output.resource }}"
-  when: not ssh_key_exists
 
 - name: Retrieve image list
   ibm.cloudcollection.ibm_pi_images_info:
@@ -47,115 +13,140 @@
                         items2dict(key_name='name',
                         value_name='id') }}"
 
-- name: Check for existing network
-  ibm.cloudcollection.ibm_pi_network_info:
-    pi_network_name: "{{ pi_name }}-network"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  failed_when:
-    - pi_network_existing_output.rc != 0
-    - '"could not be found" not in pi_network_existing_output.stderr'
-  register: pi_network_existing_output
+- name: Create and register POWER Virtual Server resources
+  block:
+    - name: Check for existing SSH Key
+      ibm.cloudcollection.ibm_pi_key_info:
+        pi_key_name: "{{ pi_name }}-ssh-key"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      failed_when:
+        - pi_ssh_key_existing_output.rc != 0
+        - '"does not exist" not in pi_ssh_key_existing_output.stderr'
+      register: pi_ssh_key_existing_output
 
-- set_fact:
-    network_exists: "{{ pi_network_existing_output.resource.id is defined }}"
+    - name: Save existing SSH Key as fact
+      set_fact:
+        pi_ssh_key: "{{ pi_ssh_key_existing_output.resource }}"
+      when: pi_ssh_key_existing_output.rc == 0
 
-- name: Save existing network as fact
-  set_fact:
-    cacheable: True
-    pi_network_id: "{{ pi_network_existing_output.resource.id }}"
-  when: network_exists
+    - name: Add new SSH Key
+      ibm.cloudcollection.ibm_pi_key:
+        pi_key_name: "{{ pi_name }}-ssh-key"
+        pi_ssh_key: "{{ ssh_public_key }}"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      register: pi_ssh_key_create_output
+      when: pi_ssh_key_existing_output.rc != 0
 
-- name: Add new network
-  ibm.cloudcollection.ibm_pi_network:
-    pi_network_name: "{{ pi_name }}-network"
-    pi_network_type: "pub-vlan"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  register: pi_network_create_output
-  when: not network_exists
+    - name: Save new SSH Key as fact
+      set_fact:
+        pi_ssh_key: "{{ pi_ssh_key_create_output.resource }}"
+      when: pi_ssh_key_existing_output.rc != 0
 
-- name: Save new network as fact
-  set_fact:
-    cacheable: True
-    pi_network_id: "{{ pi_network_create_output.resource.network_id }}"
-  when: not network_exists
+    - name: Check for existing network
+      ibm.cloudcollection.ibm_pi_network_info:
+        pi_network_name: "{{ pi_name }}-network"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      failed_when:
+        - pi_network_existing_output.rc != 0
+        - '"could not be found" not in pi_network_existing_output.stderr'
+      register: pi_network_existing_output
 
-- name: Check for existing Virtual Server Instance
-  ibm.cloudcollection.ibm_pi_instance_info:
-    pi_instance_name: "{{ pi_name }}"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  failed_when:
-    - pi_instance_existing_output.rc != 0
-    - '"does not exist" not in pi_instance_existing_output.stderr'
-  register: pi_instance_existing_output
+    - name: Save existing network as fact
+      set_fact:
+        pi_network_id: "{{ pi_network_existing_output.resource.id }}"
+      when: pi_network_existing_output.rc == 0
 
-- name: Save existing Power VSI fact
-  set_fact:
-    cacheable: True
-    pi_instance: "{{ pi_instance_existing_output.resource }}"
-  when: pi_instance_existing_output.rc == 0
+    - name: Add new network
+      ibm.cloudcollection.ibm_pi_network:
+        pi_network_name: "{{ pi_name }}-network"
+        pi_network_type: "pub-vlan"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      register: pi_network_create_output
+      when: pi_network_existing_output.rc != 0
 
-- name: Create a POWER Virtual Server Instance
-  ibm.cloudcollection.ibm_pi_instance:
-    state: available
-    pi_memory: "{{ memory }}"
-    pi_processors: "{{ processors }}"
-    pi_instance_name: "{{ pi_name }}"
-    pi_proc_type: "{{ proc_type }}"
-    pi_image_id: "{{ image_dict[vm_image] }}"
-    pi_volume_ids: []
-    pi_network:
-      - network_id: "{{ pi_network_id }}"
-    pi_key_pair_name: "{{ pi_ssh_key.pi_key_name }}"
-    pi_sys_type: "{{ sys_type }}"
-    pi_storage_type: "{{ storage_type }}"
-    pi_replication_policy: none
-    pi_replication_scheme: suffix
-    pi_replicants: "1"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-    id: "{{ pi_instance.resource.id | default(omit) }}"
-  register: pi_instance_create_output
-  when: pi_instance_existing_output.rc != 0
+    - name: Save new network as fact
+      set_fact:
+        pi_network_id: "{{ pi_network_create_output.resource.network_id }}"
+      when: pi_network_existing_output.rc != 0
 
-- name: Check for existing Virtual Server Instance
-  ibm.cloudcollection.ibm_pi_instance_info:
-    pi_instance_name: "{{ pi_name }}"
-    pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
-  register: pi_instance_new_output
-  when: pi_instance_create_output.resource is defined
+    - name: Check for existing Virtual Server Instance
+      ibm.cloudcollection.ibm_pi_instance_info:
+        pi_instance_name: "{{ pi_name }}"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      failed_when:
+        - pi_instance_existing_output.rc != 0
+        - '"does not exist" not in pi_instance_existing_output.stderr'
+      register: pi_instance_existing_output
 
-- name: Save new Power VSI fact
-  set_fact:
-    cacheable: True
-    pi_instance: "{{ pi_instance_new_output.resource }}"
-  when: pi_instance_new_output.resource is defined
+    - name: Save existing Power VSI fact
+      set_fact:
+        pi_instance: "{{ pi_instance_existing_output.resource }}"
+      when: pi_instance_existing_output.rc == 0
 
-- name: Print Public IP Address
-  debug:
-    var: pi_instance.networks[0].external_ip
+    - name: Create a POWER Virtual Server Instance
+      ibm.cloudcollection.ibm_pi_instance:
+        state: available
+        pi_memory: "{{ memory }}"
+        pi_processors: "{{ processors }}"
+        pi_instance_name: "{{ pi_name }}"
+        pi_proc_type: "{{ proc_type }}"
+        pi_image_id: "{{ image_dict[vm_image] }}"
+        pi_volume_ids: []
+        pi_network:
+          - network_id: "{{ pi_network_id }}"
+        pi_key_pair_name: "{{ pi_ssh_key.pi_key_name }}"
+        pi_sys_type: "{{ sys_type }}"
+        pi_storage_type: "{{ storage_type }}"
+        pi_replication_policy: none
+        pi_replication_scheme: suffix
+        pi_replicants: "1"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      register: pi_instance_create_output
+      when: pi_instance_existing_output.rc != 0
 
-- name: Add VSI to Ansible inventory
-  add_host:
-    name: "{{ pi_name }}"
-    ansible_host: "{{ pi_instance.networks[0].external_ip }}"
-    ansible_user: root
-    groups:
-      - job_id_{{ job_id }}
-      - platform_{{ test_platform }}
-      - vm_arch_ppc64le
-      - container_engine_{{ container_engine }}
-    ansible_ssh_extra_args: -o StrictHostKeyChecking=no
-    ansible_ssh_private_key_file: "{{ vm_ssh_key_file }}"
-    vm_config: "{{ vm_config }}"
-    vm_image_family: "{{ vm_family }}"
-    vm_collection_method: "{{ vm_collection_method }}"
-    vm_arch: "{{ vm_arch }}"
-    ibm_cloud_vm: true
+    - name: Check for existing Virtual Server Instance
+      ibm.cloudcollection.ibm_pi_instance_info:
+        pi_instance_name: "{{ pi_name }}"
+        pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
+      register: pi_instance_new_output
+      when: pi_instance_create_output.resource is defined
 
-- name: generate provisioner inventory file
-  template:
-    src: 'ibm-cloud-inventory.j2'
-    dest: "{{ ibm_output_inventory_file }}"
-    mode: '0644'
-  when:
-    - ibm_output_inventory_file != ""
-  delegate_to: localhost
+    - name: Save new Power VSI fact
+      set_fact:
+        pi_instance: "{{ pi_instance_new_output.resource }}"
+      when: pi_instance_new_output.resource is defined
+
+    - name: Print Public IP Address
+      debug:
+        var: pi_instance.networks[0].external_ip
+      when:
+        - pi_instance is defined
+        - pi_instance.networks | length > 0
+
+  always:
+    - name: Add VSI to Ansible inventory
+      add_host:
+        name: "{{ pi_name }}"
+        ansible_host: "{{ (pi_instance.networks[0].external_ip | default('')) if (pi_instance is defined and pi_instance.networks | length > 0) else '' }}"
+        ansible_user: root
+        groups:
+          - job_id_{{ job_id }}
+          - platform_{{ test_platform }}
+          - vm_arch_ppc64le
+          - container_engine_{{ container_engine }}
+        ansible_ssh_extra_args: -o StrictHostKeyChecking=no
+        ansible_ssh_private_key_file: "{{ vm_ssh_key_file }}"
+        vm_config: "{{ vm_config }}"
+        vm_image_family: "{{ vm_family }}"
+        vm_collection_method: "{{ vm_collection_method }}"
+        vm_arch: "{{ vm_arch }}"
+        ibm_cloud_vm: true
+
+    - name: generate provisioner inventory file
+      template:
+        src: 'ibm-cloud-inventory.j2'
+        dest: "{{ ibm_output_inventory_file }}"
+        mode: '0644'
+      when:
+        - ibm_output_inventory_file != ""
+      delegate_to: localhost

--- a/ansible/roles/destroy-vm/tasks/destroy-ppc64le-vm.yml
+++ b/ansible/roles/destroy-vm/tasks/destroy-ppc64le-vm.yml
@@ -70,6 +70,7 @@
     pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
     state: absent
     pi_key_name: "{{ hostname }}-ssh-key"
+    pi_ssh_key: "{{ pi_ssh_key_existing_info.resource.ssh_key }}"
     id: "{{ pi_ssh_key_existing_info.resource.id }}"
   retries: 10
   delay: 30

--- a/ansible/roles/destroy-vm/tasks/destroy-ppc64le-vm.yml
+++ b/ansible/roles/destroy-vm/tasks/destroy-ppc64le-vm.yml
@@ -1,6 +1,5 @@
 ---
 
-# Set fact that are required to destroy vsi instance
 - set_fact:
     hostname: "{{ inventory_hostname }}"
 
@@ -19,14 +18,7 @@
 - name: Save existing Power VSI fact
   delegate_to: localhost
   set_fact:
-    cacheable: True
     pi_instance: "{{ pi_instance_existing_output.resource }}"
-  when: pi_instance_existing_output.rc == 0
-
-- name: Save network details
-  delegate_to: localhost
-  set_fact:
-    public_subnet: "{{ pi_instance.networks|rejectattr('external_ip', 'equalto', '') | list | first }}"
   when: pi_instance_existing_output.rc == 0
 
 - name: Delete instance by id
@@ -39,7 +31,6 @@
   delay: 5
   register: delete_operation
   until: delete_operation is success
-  ignore_errors: true
   when: pi_instance_existing_output.rc == 0
 
 - name: Check for existing network
@@ -78,15 +69,14 @@
   ibm.cloudcollection.ibm_pi_key:
     pi_cloud_instance_id: "{{ pi_cloud_instance_id }}"
     state: absent
-    pi_ssh_key: "{{ pi_ssh_key_existing_info.resource }}"
     pi_key_name: "{{ hostname }}-ssh-key"
     id: "{{ pi_ssh_key_existing_info.resource.id }}"
   retries: 10
   delay: 30
   register: pi_ssh_key_delete
-  when: 
+  when:
     - pi_ssh_key_existing_info is success
-    - pi_ssh_key_existing_info.resource is defined
+    - pi_ssh_key_existing_info.resource.id is defined
 
 - name: Remove IBM inventory file (delete file)
   delegate_to: localhost

--- a/ansible/roles/provision-vm/tasks/redhat.yml
+++ b/ansible/roles/provision-vm/tasks/redhat.yml
@@ -70,5 +70,8 @@
     state: stopped
     enabled: false
   when: vm_arch == "ppc64le"
-  ignore_errors: true
+  register: cockpit_disable
+  failed_when:
+    - cockpit_disable is failed
+    - "'Could not find the requested service' not in (cockpit_disable.msg | default(''))"
 


### PR DESCRIPTION
This PR introduces the following improvements for the ppc64le ansible create and destroy tasks

## Description

- Split rhel-ppc64le into rhel-ppc64le-9 and rhel-ppc64le-10 so GitHub Actions can run RHEL 9.6 and RHEL 10 PowerVS tests in parallel (fail-fast: false).
- Move the PowerVS SSH cipher workaround to group_vars/vm_arch_ppc64le.yml so it still applies after the VM type split.
- Wrap PowerVS create in block/always so a failed create still lands in inventory and teardown can delete IBM resources.
- Stop caching PowerVS facts on localhost so instance/network/key IDs cannot leak across VMs.
- Replace cockpit ignore_errors with failed_when that only ignores a missing cockpit.socket unit.
- Make instance delete fail the destroy play if it cannot remove the VM, and delete SSH keys by id instead of passing the whole resource.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

Tested using CI.

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
