### PR TITLE
ROX-34722: Switch to periodic konflux retest

### DIFF
--- a/.github/workflows/konflux-auto-retest.yml
+++ b/.github/workflows/konflux-auto-retest.yml
@@ -1,17 +1,18 @@
-name: Retest Konflux Builds
+name: Periodic Retest Failed Konflux Builds
 
 on:
-  check_run:
-    types: [completed]
-  pull_request:
-    types: [synchronize]
+  schedule:
+    - cron: '5,15,25,35,45,55 * * * *'
+  workflow_dispatch:
 
 jobs:
-  retest-failed-builds:
-    uses: stackrox/actions/.github/workflows/retest-konflux-builds.yml@v1
+  retest:
+    uses: stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@f4660e8 # ratchet:stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@v1
     permissions:
       pull-requests: write
       issues: write
+      checks: read
+      contents: read
     with:
       max_retries: 3
-      check_name_suffix: '-on-push'
+      retest_command: '/konflux-retest'

--- a/.github/workflows/konflux-auto-retest.yml
+++ b/.github/workflows/konflux-auto-retest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   retest:
-    uses: stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@f4660e8 # ratchet:stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@v1
+    uses: stackrox/actions/.github/workflows/periodic-retest-konflux-builds.yml@v1
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Description

Updates the Konflux retest process to run periodically, with the goal of optimizing GitHub Actions invocations.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

If any of these don't apply, please comment below.

## Testing Performed

test: https://github.com/stackrox/test-konflux-repo/pull/5