### PR TITLE
ROX-36447: Enable both clair-scan and roxctl-scan- #3867

### DIFF
--- a/.tekton/collector-component-pipeline.yaml
+++ b/.tekton/collector-component-pipeline.yaml
@@ -388,6 +388,26 @@ spec:
       values: [ "false" ]
 
   - name: roxctl-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: roxctl-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:97e2b2cdca9110fdc8a93ba585a1a1a743f989f2fd85f4073f6e5ea9ad2ce828
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
+  - name: clair-scan
     matrix:
       params:
       - name: image-platform
@@ -401,9 +421,9 @@ spec:
     taskRef:
       params:
       - name: name
-        value: roxctl-scan
+        value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:97e2b2cdca9110fdc8a93ba585a1a1a743f989f2fd85f4073f6e5ea9ad2ce828
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.4@sha256:219964897ac4d5a9473ec297a1b39ae078a34b76b45d04c4672bd569cc295c29
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Replace clair-scan task with roxctl-scan to provide better security coverage as per Konflux Integration Service Team migration plan.

Changes:

Updated task name from clair-scan to roxctl-scan
Updated bundle reference to task-roxctl-scan:0.1
Removed matrix configuration as roxctl-scan handles multi-arch natively
