### PR TITLE
fix: provide container plugin path to memcheck tests

### DIFF
--- a/collector/test/CMakeLists.txt
+++ b/collector/test/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(test_file ${TEST_SRC_FILES})
         endif()
 
         add_test(NAME memcheck_${test_name} COMMAND valgrind -q --leak-check=full --trace-children=yes $<TARGET_FILE:${test_name}>)
+        set_property(TEST memcheck_${test_name} APPEND PROPERTY ENVIRONMENT "ROX_COLLECTOR_CONTAINER_PLUGIN_PATH=${CMAKE_BINARY_DIR}/collector/collector-container-plugin.so")
     endif()
 endforeach()
 


### PR DESCRIPTION
## Description

Set `ROX_COLLECTOR_CONTAINER_PLUGIN_PATH` for the separately registered `memcheck_` CTest entries, just as it is set for the normal unit tests.

Targets `collector-container-plugin` (#3939); this is a sibling of #3940, not dependent on the validator changes. One-line test configuration fix, no production changes.

## Failure

Both existing Valgrind unit-test jobs fail `SystemInspectorServiceTest.FilterEvent` before loading the plugin:

```text
Expected: (plugin_path) != (nullptr), actual: NULL vs (nullptr)
```

CTest's environment property is attached to the normal test, not automatically inherited by the separately registered `memcheck_SystemInspectorServiceTest`.

Failing jobs: [AMD64](https://github.com/stackrox/collector/actions/runs/34291974066/job/102280835314), [ARM64](https://github.com/stackrox/collector/actions/runs/34291974066/job/102280835154). Both report 32/33 tests passing; the sole failed entry is `memcheck_SystemInspectorServiceTest`. This addresses the missing-environment assertion, not the separate library diagnostics in Valgrind output.

## Validation

- Fresh Linux ARM64 builder configuration with `-DUSE_VALGRIND=ON -DCMAKE_BUILD_TYPE=Debug` succeeds.
- `ctest --show-only=json-v1` confirms identical plugin-path environment values for normal and memcheck SystemInspectorServiceTest entries.
- `git diff --check` passes.
- Full test execution has not been rerun locally; CI will validate execution.

`skip-integration-tests` skips the broad VM/Kubernetes matrix for this test-configuration-only fix; existing unit-test jobs remain enabled.
