### PR TITLE
Fix ibmcloud s390x securities group cleanup

### DIFF
--- a/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
+++ b/ansible/roles/destroy-vm/tasks/destroy-s390x-vm.yml
@@ -53,11 +53,16 @@
   delegate_to: localhost
   ibm.cloudcollection.ibm_is_security_group:
     state: absent
+    id: "{{ sg.resource.id }}"
     name: "{{ inventory_hostname }}-sg"
     vpc: "{{ s390x.vpc_id }}"
+    resource_group: "{{ s390x.vsi_resource_group_id }}"
   register: sg_delete
+  retries: 6
+  delay: 20
+  until: sg_delete is success
   failed_when:
-    - sg_delete.rc | default(0) != 0
+    - sg_delete.rc != 0
     - '"Target not found" not in (sg_delete.stderr | default(""))'
     - '"Target not found" not in (sg_delete.msg | default(""))'
     - '"not_found" not in (sg_delete.stderr | default(""))'


### PR DESCRIPTION
## Description
Updates the security group deletion, now has several retries. IBMcloud would not delete the SG until the attached resources were deleted first. The retries and timeout allow for time for the releases to be removed before deleting the sg
## Checklist
- [x] Investigated and inspected CI test results
- [ ] Updated documentation accordingly

**Automated testing**
  - [ ] Added unit tests
  - [ ] Added integration tests
  - [ ] Added regression tests

## Testing Performed
Testing done with CI, and the manually checked ibmcloud  and security groups were cleaned up properly

For more details, ref the [Confluence page](https://stack-rox.atlassian.net/wiki/spaces/StackRox/pages/855998488/Proposal+Explicitly+List+Testing+Steps+on+PRs) about this section.
